### PR TITLE
Set default dashboard to open Widget Editor on first launch

### DIFF
--- a/apps/aquamesh/src/state/store.ts
+++ b/apps/aquamesh/src/state/store.ts
@@ -11,7 +11,35 @@ export interface StateDashboard {
 export interface DashboardLayout {
   type?: string;
   id?: string;
+  name?: string;
+  component?: string;
+  active?: boolean;
+  weight?: number;
   children?: DashboardLayout[];
+}
+
+const DEFAULT_EDITOR_DASHBOARD: StateDashboard = {
+  id: 'default-dashboard',
+  name: 'Dashboard',
+  layout: {
+    type: 'row',
+    id: '#default-dashboard-layout',
+    children: [
+      {
+        type: 'tabset',
+        id: '#default-dashboard-tabset',
+        active: true,
+        children: [
+          {
+            type: 'tab',
+            id: '#default-widget-editor-tab',
+            name: 'Widget Editor',
+            component: 'WidgetEditor',
+          },
+        ],
+      },
+    ],
+  },
 }
 
 interface StoreState {
@@ -27,7 +55,7 @@ export const useStore = create<StoreState>()(
   persist(
     (set, get) => ({
       selectedDashboard: 0,
-      openDashboards: [],
+      openDashboards: [DEFAULT_EDITOR_DASHBOARD],
       setDashboards: (element) => set({ openDashboards: element }),
       setSelectedDashboard: (index) => set({ selectedDashboard: index }),
       changeWidgetData: (data) => {


### PR DESCRIPTION
### Motivation

- Ensure first-time users (when `aquamesh-storage` is missing) start with a usable workspace by opening the Widget Editor automatically.
- Match the expected initial `aquamesh-storage` shape so the UI shows a dashboard tabset containing the `WidgetEditor` component by default.

### Description

- Extended the `DashboardLayout` type to include `name`, `component`, `active`, and `weight` fields to represent tab/tabset nodes used by the layout system in `apps/aquamesh/src/state/store.ts`.
- Added a `DEFAULT_EDITOR_DASHBOARD` constant that defines a dashboard with a `row` layout containing an active `tabset` and a `Widget Editor` tab with `component: 'WidgetEditor'` in `apps/aquamesh/src/state/store.ts`.
- Initialized the persisted store's `openDashboards` with `DEFAULT_EDITOR_DASHBOARD` so `useStore` now creates one open dashboard (`selectedDashboard: 0`) when no `aquamesh-storage` exists.

### Testing

- Attempted unit tests with `npm --prefix apps/aquamesh run test:unit`, which failed in this environment due to a missing optional native dependency (`@rollup/rollup-linux-x64-gnu`).
- Attempted to launch the dev server with `npm --prefix apps/aquamesh run start -- --port 4173`, which was blocked by an interactive prompt to install `webpack-cli` in this environment and could not be completed non-interactively.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fbc5aaccc832b97298ac642f46bdd)