### PR TITLE
Make widget editor copy friendlier for non-programmers

### DIFF
--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
@@ -374,8 +374,8 @@ const ComponentPalette = ({
             }}
           >
             {isPhone
-              ? 'Tap + to add a block'
-              : 'Drag blocks onto the widget canvas'}
+              ? 'Tap + to add an item'
+              : 'Drag items into your widget'}
           </Typography>
           <Typography
             variant="caption"
@@ -386,10 +386,10 @@ const ComponentPalette = ({
             }}
           >
             {!showTooltips
-              ? 'Enable tooltips in settings for descriptions'
+              ? 'Turn on helpful tips in settings for short explanations'
               : isPhone
-                ? 'Long press blocks for descriptions'
-                : 'Hover over blocks for descriptions'}
+                ? 'Long press items for short explanations'
+                : 'Hover over items for short explanations'}
           </Typography>
         </Box>
       )}

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
@@ -55,8 +55,8 @@ const PALETTE_GROUPS = [
   'Chart Components',
 ]
 const PALETTE_GROUP_LABELS: Record<string, string> = {
-  'UI Components': 'Inputs and Controls',
-  'Layout Containers': 'Layout Containers',
+  'UI Components': 'Content and Controls',
+  'Layout Containers': 'Layout Helpers',
   'Chart Components': 'Charts',
 }
 

--- a/apps/aquamesh/src/components/WidgetEditor/components/dialogs/ComponentSearchDialog.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/dialogs/ComponentSearchDialog.tsx
@@ -208,7 +208,7 @@ const ComponentSearchDialog: React.FC<ComponentSearchDialogProps> = ({
         <TextField
           autoFocus
           fullWidth
-          placeholder="Search components by type or properties..."
+          placeholder="Search building blocks by name or what they do..."
           value={searchTerm}
           onChange={handleSearchChange}
           margin="normal"

--- a/apps/aquamesh/src/components/WidgetEditor/components/dialogs/SettingsDialog.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/dialogs/SettingsDialog.tsx
@@ -232,7 +232,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                   <InfoOutlinedIcon sx={{ mr: 1.5, color: 'primary.main' }} />
                   <Typography fontWeight="medium" color="text.primary">
-                    Show Component Tooltips
+                    Show Helpful Tips
                   </Typography>
                   <Box sx={{ flexGrow: 1 }} />
                   <Switch
@@ -246,7 +246,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
                   color="text.secondary"
                   sx={{ ml: 5, mb: 1 }}
                 >
-                  Display helpful tooltips when hovering over components in the
+                  Show short explanations when hovering over building blocks in the
                   palette.
                 </Typography>
               </Box>
@@ -563,21 +563,21 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
               <Grid item xs={12} md={6}>
                 <ShortcutCard
                   icon={<EditIcon />}
-                  title="Toggle edit/preview mode"
+                  title="Switch between edit and preview views"
                   shortcut="Ctrl + E"
                   color="#ff9800"
                 />
 
                 <ShortcutCard
                   icon={<FolderOpenIcon />}
-                  title="Open/Close Library"
+                  title="Open or close saved widgets"
                   shortcut="Ctrl + O"
                   color="#9c27b0"
                 />
 
                 <ShortcutCard
                   icon={<SettingsIcon />}
-                  title="Open/Close Settings"
+                  title="Open or close settings"
                   shortcut="Ctrl + ,"
                   color="#2196f3"
                 />

--- a/apps/aquamesh/src/components/WidgetEditor/components/dialogs/TemplateSelectionDialog.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/dialogs/TemplateSelectionDialog.tsx
@@ -427,7 +427,7 @@ const TemplateSelectionDialog: React.FC<TemplateSelectionDialogProps> = ({
               value={templateDescription}
               onChange={(e) => setTemplateDescription(e.target.value)}
               sx={{ mb: 3 }}
-              placeholder="Describe what this template is for or how it should be used (e.g., 'A dashboard layout with three metric panels and a chart')"
+              placeholder="Describe what this template is for or how it should be used (e.g., 'A support queue overview with tickets, status, and a chart')"
               InputProps={{
                 sx: {
                   borderRadius: 1.5,
@@ -649,9 +649,9 @@ const TemplateSelectionDialog: React.FC<TemplateSelectionDialogProps> = ({
                               : sortOption === 'name_desc'
                                 ? 'Name (Z-A)'
                                 : sortOption === 'components_asc'
-                                  ? 'Components (Low-High)'
+                                  ? 'Fewest Items'
                                   : sortOption === 'components_desc'
-                                    ? 'Components (High-Low)'
+                                    ? 'Most Items'
                                     : '')}
                     </Button>
                   </Tooltip>
@@ -787,7 +787,7 @@ const TemplateSelectionDialog: React.FC<TemplateSelectionDialogProps> = ({
                     : 'inherit',
               }}
             >
-              <ListItemText>Components (High-Low)</ListItemText>
+              <ListItemText>Most Items</ListItemText>
             </MenuItem>
             <MenuItem
               onClick={() => handleSortOptionChange('components_asc')}
@@ -799,7 +799,7 @@ const TemplateSelectionDialog: React.FC<TemplateSelectionDialogProps> = ({
                     : 'inherit',
               }}
             >
-              <ListItemText>Components (Low-High)</ListItemText>
+              <ListItemText>Fewest Items</ListItemText>
             </MenuItem>
           </Menu>
 
@@ -1092,7 +1092,7 @@ const TemplateSelectionDialog: React.FC<TemplateSelectionDialogProps> = ({
                           )
                         })}
                         <Chip
-                          label={`${template.components?.length || 0} components`}
+                          label={`${template.components?.length || 0} items`}
                           size="small"
                           color="primary"
                           sx={{

--- a/apps/aquamesh/src/components/WidgetEditor/components/dialogs/WidgetLibrary.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/dialogs/WidgetLibrary.tsx
@@ -280,7 +280,7 @@ const WidgetManagementModal: React.FC<WidgetManagementModalProps> = ({
             <Grid item xs={12} md={6}>
               <TextField
                 fullWidth
-                placeholder="Search saved widgets by name..."
+                placeholder="Search saved widgets by name or purpose..."
                 value={searchTerm}
                 onChange={handleSearchChange}
                 variant="outlined"
@@ -333,13 +333,13 @@ const WidgetManagementModal: React.FC<WidgetManagementModalProps> = ({
                 disabled={isLoading}
               >
                 <InputLabel id="sort-by-label" sx={{ color: 'text.secondary' }}>
-                  Sort By
+                  Sort Widgets
                 </InputLabel>
                 <Select
                   labelId="sort-by-label"
                   value={sortBy}
                   onChange={handleSortChange}
-                  label="Sort By"
+                  label="Sort Widgets"
                   startAdornment={
                     <InputAdornment position="start">
                       <SortIcon sx={{ color: 'text.secondary' }} />
@@ -361,10 +361,10 @@ const WidgetManagementModal: React.FC<WidgetManagementModalProps> = ({
                 >
                   <MenuItem value="nameAsc">Name (A-Z)</MenuItem>
                   <MenuItem value="nameDesc">Name (Z-A)</MenuItem>
-                  <MenuItem value="dateNewest">Date (Newest First)</MenuItem>
-                  <MenuItem value="dateOldest">Date (Oldest First)</MenuItem>
-                  <MenuItem value="mostComponents">Most Blocks</MenuItem>
-                  <MenuItem value="fewestComponents">Fewest Blocks</MenuItem>
+                  <MenuItem value="dateNewest">Newest First</MenuItem>
+                  <MenuItem value="dateOldest">Oldest First</MenuItem>
+                  <MenuItem value="mostComponents">Most Items</MenuItem>
+                  <MenuItem value="fewestComponents">Fewest Items</MenuItem>
                 </Select>
               </FormControl>
             </Grid>

--- a/apps/aquamesh/src/components/WidgetEditor/components/dialogs/WidgetMetadataDialog.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/dialogs/WidgetMetadataDialog.tsx
@@ -117,7 +117,7 @@ const WidgetMetadataDialog: React.FC<WidgetMetadataDialogProps> = ({
       }}
     >
       <DialogTitle>
-        <Typography variant="h6">Widget Properties</Typography>
+        <Typography variant="h6">Widget Details</Typography>
       </DialogTitle>
       
       <DialogContent dividers>
@@ -131,7 +131,7 @@ const WidgetMetadataDialog: React.FC<WidgetMetadataDialogProps> = ({
             required
             variant="outlined"
             error={!formData.name}
-            helperText={!formData.name ? 'Name is required' : ''}
+            helperText={!formData.name ? 'Please add a widget name' : ''}
           />
           
           {/* Widget Category */}
@@ -175,7 +175,7 @@ const WidgetMetadataDialog: React.FC<WidgetMetadataDialogProps> = ({
                 variant="outlined"
                 label="Tags"
                 placeholder="Add tags..."
-                helperText="Press Enter to add a new tag"
+                helperText="Press Enter after each keyword"
               />
             )}
             onKeyDown={(e) => {
@@ -204,7 +204,7 @@ const WidgetMetadataDialog: React.FC<WidgetMetadataDialogProps> = ({
             multiline
             rows={3}
             variant="outlined"
-            placeholder="Enter a description for this widget..."
+            placeholder="Explain what this widget helps someone do..."
           />
           
           {/* Other metadata */}

--- a/apps/aquamesh/src/components/WidgetEditor/components/dialogs/WidgetVersioningDialog.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/dialogs/WidgetVersioningDialog.tsx
@@ -365,7 +365,7 @@ const WidgetVersioningDialog: React.FC<WidgetVersioningDialogProps> = ({
                               )}
                               <Chip
                                 size="small"
-                                label={`${version.components.length} components`}
+                                label={`${version.components.length} items`}
                                 variant="outlined"
                                 sx={{ height: 20, fontSize: '0.7rem', borderColor: alpha(theme.palette.divider, 0.6), color: 'text.secondary' }}
                               />
@@ -407,7 +407,7 @@ const WidgetVersioningDialog: React.FC<WidgetVersioningDialogProps> = ({
                         <Typography variant={isPhone ? 'h6' : 'h5'} fontWeight="bold" color="#00C49A" sx={{ fontSize: isPhone ? '1rem' : undefined }}>
                           Version {selectedVersion.version}
                           {selectedVersion.isCurrent && (
-                            <Chip size="small" label="Current Version" color="primary" variant="filled" sx={{ ml: 1.5, fontWeight: 'bold', fontSize: '0.75rem' }}/>
+                            <Chip size="small" label="Current Saved Version" color="primary" variant="filled" sx={{ ml: 1.5, fontWeight: 'bold', fontSize: '0.75rem' }}/>
                           )}
                         </Typography>
                         <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
@@ -518,7 +518,7 @@ const WidgetVersioningDialog: React.FC<WidgetVersioningDialogProps> = ({
                               {widget.components.length}
                             </Typography>
                             <Typography variant="caption" color="text.secondary">
-                              Current Version
+                              Current Saved Version
                             </Typography>
                           </Box>
                         </Box>

--- a/apps/aquamesh/src/components/WidgetEditor/components/editors/ButtonEditor.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/editors/ButtonEditor.tsx
@@ -291,7 +291,7 @@ const ButtonEditor: React.FC<ComponentEditorProps<ButtonProps>> = ({ props, onCh
                   fontSize: isMobile ? '0.65rem' : undefined
                 }}
               >
-                Click Action:
+                What Happens When Clicked:
               </Typography>
               {props.clickAction === 'toast' && (
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
@@ -309,7 +309,7 @@ const ButtonEditor: React.FC<ComponentEditorProps<ButtonProps>> = ({ props, onCh
               {props.clickAction === 'openUrl' && props.url && (
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                   <Typography variant="caption" sx={{ fontSize: isMobile ? '0.65rem' : undefined }}>
-                    Open URL: {props.url}
+                    Open Link: {props.url}
                   </Typography>
                   <OpenInNewIcon sx={{ fontSize: isMobile ? '0.65rem' : '0.75rem', color: 'text.secondary' }} />
                 </Box>
@@ -407,7 +407,7 @@ const ButtonEditor: React.FC<ComponentEditorProps<ButtonProps>> = ({ props, onCh
           <Grid item xs={12}>
             <TextField
               fullWidth
-              label="Button Text"
+              label="Button Label"
               onFocus={(e) => { e.target.select() }}
               value={props.text || ''}
               onChange={(e) => handleChange('text', e.target.value)}
@@ -440,12 +440,12 @@ const ButtonEditor: React.FC<ComponentEditorProps<ButtonProps>> = ({ props, onCh
           
           <Grid item xs={12} sm={isMobile ? 12 : 6}>
             <FormControl fullWidth margin="dense" size={isMobile ? "small" : "medium"} variant="outlined">
-              <InputLabel id="button-variant-label" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Variant</InputLabel>
+              <InputLabel id="button-variant-label" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Button Style</InputLabel>
               <Select
                 labelId="button-variant-label"
                 value={props.variant || 'contained'}
                 onChange={(e) => handleChange('variant', e.target.value)}
-                label="Variant"
+                label="Button Style"
                 sx={{
                   '& .MuiOutlinedInput-notchedOutline': {
                     borderColor: 'rgba(0, 0, 0, 0.23)',
@@ -466,8 +466,8 @@ const ButtonEditor: React.FC<ComponentEditorProps<ButtonProps>> = ({ props, onCh
                   },
                 }}
               >
-                <MenuItem value="contained" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Contained</MenuItem>
-                <MenuItem value="outlined" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Outlined</MenuItem>
+                <MenuItem value="contained" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Filled</MenuItem>
+                <MenuItem value="outlined" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Outline</MenuItem>
                 <MenuItem value="text" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Text</MenuItem>
               </Select>
             </FormControl>
@@ -662,7 +662,7 @@ const ButtonEditor: React.FC<ComponentEditorProps<ButtonProps>> = ({ props, onCh
                     onChange={(e) => handleChange('showStartIcon', e.target.checked)}
                   />
                 }
-                label="Show Start Icon"
+                label="Show Icon Before Text"
                 sx={{ color: '#191919' }}
               />
               </Box>
@@ -677,7 +677,7 @@ const ButtonEditor: React.FC<ComponentEditorProps<ButtonProps>> = ({ props, onCh
                     onChange={(e) => handleChange('showEndIcon', e.target.checked)}
                   />
                 }
-                label="Show End Icon"
+                label="Show Icon After Text"
                 sx={{ color: '#191919' }}
               />
             </Box>
@@ -718,12 +718,12 @@ const ButtonEditor: React.FC<ComponentEditorProps<ButtonProps>> = ({ props, onCh
         <Grid container spacing={2}>
           <Grid item xs={12}>
             <FormControl fullWidth margin="dense" size="small" variant="outlined">
-              <InputLabel id="click-action-label">Click Action</InputLabel>
+              <InputLabel id="click-action-label">What Happens When Clicked</InputLabel>
               <Select
                 labelId="click-action-label"
                 value={props.clickAction || 'none'}
                 onChange={(e) => handleChange('clickAction', e.target.value)}
-                label="Click Action"
+                label="What Happens When Clicked"
                 sx={{
                   '& .MuiOutlinedInput-notchedOutline': {
                     borderColor: 'rgba(0, 0, 0, 0.23)',
@@ -742,8 +742,8 @@ const ButtonEditor: React.FC<ComponentEditorProps<ButtonProps>> = ({ props, onCh
                   },
                 }}
               >
-                <MenuItem value="toast">Show Toast</MenuItem>
-                <MenuItem value="openUrl">Open URL</MenuItem>
+                <MenuItem value="toast">Show Message</MenuItem>
+                <MenuItem value="openUrl">Open Link</MenuItem>
                 <MenuItem value="none">None</MenuItem>
               </Select>
             </FormControl>
@@ -754,13 +754,13 @@ const ButtonEditor: React.FC<ComponentEditorProps<ButtonProps>> = ({ props, onCh
               <Grid item xs={12}>
                 <TextField
                   fullWidth
-                  label="Toast Message"
+                  label="Message to Show"
                   value={props.toastMessage || ''}
                   onChange={(e) => handleChange('toastMessage', e.target.value)}
                   variant="outlined"
                   margin="dense"
                   size={isMobile ? "small" : "medium"}
-                  placeholder="Button clicked successfully!"
+                  placeholder="Action completed successfully!"
                   sx={{
                     '& .MuiOutlinedInput-root': {
                       '& fieldset': {
@@ -786,12 +786,12 @@ const ButtonEditor: React.FC<ComponentEditorProps<ButtonProps>> = ({ props, onCh
               </Grid>
               <Grid item xs={12}>
                 <FormControl fullWidth margin="dense" size={isMobile ? "small" : "medium"} variant="outlined">
-                  <InputLabel id="toast-severity-label" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Toast Severity</InputLabel>
+                  <InputLabel id="toast-severity-label" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Message Type</InputLabel>
                   <Select
                     labelId="toast-severity-label"
                     value={props.toastSeverity || 'info'}
                     onChange={(e) => handleChange('toastSeverity', e.target.value)}
-                    label="Toast Severity"
+                    label="Message Type"
                     sx={{
                       '& .MuiOutlinedInput-notchedOutline': {
                         borderColor: 'rgba(0, 0, 0, 0.23)',
@@ -826,7 +826,7 @@ const ButtonEditor: React.FC<ComponentEditorProps<ButtonProps>> = ({ props, onCh
             <Grid item xs={12}>
               <TextField
                 fullWidth
-                label="URL"
+                label="Link to Open"
                 value={props.url || ''}
                 onChange={(e) => handleChange('url', e.target.value)}
                 variant="outlined"

--- a/apps/aquamesh/src/components/WidgetEditor/components/editors/FieldSetEditor.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/editors/FieldSetEditor.tsx
@@ -242,17 +242,17 @@ const FieldSetEditor: React.FC<FieldSetEditorProps> = ({ props, onChange }) => {
                 fontSize: isMobile ? '0.65rem' : undefined 
               }}
             >
-              <span>Style: {borderStyle}</span>
+              <span>Outline: {borderStyle}</span>
               {Boolean(padding) && (
                 <>
                   <span>•</span>
-                  <span>Padding: {padding}</span>
+                  <span>Inside space: {padding}</span>
                 </>
               )}
               {Boolean(collapsed) && (
                 <>
                   <span>•</span>
-                  <span>Initially Collapsed</span>
+                  <span>Starts closed</span>
                 </>
               )}
             </Typography>
@@ -279,8 +279,8 @@ const FieldSetEditor: React.FC<FieldSetEditorProps> = ({ props, onChange }) => {
               onChange={(e) => handleChange('legend', e.target.value)}
               label={
                 <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                  Legend
-                  <Tooltip title="Text label that appears at the top of the fieldset">
+                  Group Title
+                  <Tooltip title="Heading shown at the top of this group.">
                     <InfoOutlinedIcon fontSize={isMobile ? "small" : "medium"} sx={{ ml: 0.5 }} />
                   </Tooltip>
                 </Box>
@@ -298,14 +298,14 @@ const FieldSetEditor: React.FC<FieldSetEditorProps> = ({ props, onChange }) => {
           
           <Grid item xs={12}>
             <FormControl fullWidth size={isMobile ? "small" : "medium"}>
-              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Icon Position</InputLabel>
+              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Icon Side</InputLabel>
               <Select
                 value={iconPosition}
                 onChange={(e) => {
                   setIconPosition(e.target.value)
                   handleChange('iconPosition', e.target.value)
                 }}
-                label="Icon Position"
+                label="Icon Side"
                 sx={{
                   '& .MuiSelect-select': { 
                     fontSize: isMobile ? '0.875rem' : undefined 
@@ -332,7 +332,7 @@ const FieldSetEditor: React.FC<FieldSetEditorProps> = ({ props, onChange }) => {
               }
               label={
                 <Typography sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>
-                  Initially Collapsed
+                  Starts closed
                 </Typography>
               }
             />
@@ -352,7 +352,7 @@ const FieldSetEditor: React.FC<FieldSetEditorProps> = ({ props, onChange }) => {
               }
               label={
                 <Typography sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>
-                  Use Animation
+                  Animate Open and Close
                 </Typography>
               }
             />
@@ -365,14 +365,14 @@ const FieldSetEditor: React.FC<FieldSetEditorProps> = ({ props, onChange }) => {
         <Grid container spacing={isMobile ? 1 : 2}>
           <Grid item xs={12} sm={6}>
             <FormControl fullWidth size={isMobile ? "small" : "medium"}>
-              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Border Style</InputLabel>
+              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Outline Style</InputLabel>
               <Select
                 value={borderStyle}
                 onChange={(e) => {
                   setBorderStyle(e.target.value)
                   handleChange('borderStyle', e.target.value)
                 }}
-                label="Border Style"
+                label="Outline Style"
                 sx={{
                   '& .MuiSelect-select': { 
                     fontSize: isMobile ? '0.875rem' : undefined 
@@ -393,7 +393,7 @@ const FieldSetEditor: React.FC<FieldSetEditorProps> = ({ props, onChange }) => {
               gutterBottom
               sx={{ fontSize: isMobile ? '0.875rem' : undefined }}
             >
-              Border Radius
+              Corner Roundness
             </Typography>
             <Slider
               value={borderRadius}
@@ -426,7 +426,7 @@ const FieldSetEditor: React.FC<FieldSetEditorProps> = ({ props, onChange }) => {
               gutterBottom
               sx={{ fontSize: isMobile ? '0.875rem' : undefined }}
             >
-              Padding
+              Space Around the Inside
             </Typography>
             <Slider
               value={padding}

--- a/apps/aquamesh/src/components/WidgetEditor/components/editors/FlexBoxEditor.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/editors/FlexBoxEditor.tsx
@@ -125,9 +125,9 @@ const FlexBoxEditor: React.FC<FlexBoxEditorProps> = ({ props, onChange }) => {
       case 'flex-start': justifyText = 'Start'; break;
       case 'flex-end': justifyText = 'End'; break;
       case 'center': justifyText = 'Center'; break;
-      case 'space-between': justifyText = 'Space Between'; break;
-      case 'space-around': justifyText = 'Space Around'; break;
-      case 'space-evenly': justifyText = 'Space Evenly'; break;
+      case 'space-between': justifyText = 'Spread Apart'; break;
+      case 'space-around': justifyText = 'Space Around Each'; break;
+      case 'space-evenly': justifyText = 'Evenly Spaced'; break;
       default: justifyText = justifyContent;
     }
     
@@ -193,28 +193,28 @@ const FlexBoxEditor: React.FC<FlexBoxEditorProps> = ({ props, onChange }) => {
             >
               <Chip 
                 size="small" 
-                label={`Direction: ${direction}`} 
+                label={`Order: ${direction}`}
                 color="primary" 
                 variant="outlined" 
                 sx={{ fontSize: isMobile ? '0.65rem' : undefined }}
               />
               <Chip 
                 size="small" 
-                label={`Justify: ${justifyText}`} 
+                label={`Across: ${justifyText}`}
                 color="secondary" 
                 variant="outlined" 
                 sx={{ fontSize: isMobile ? '0.65rem' : undefined }}
               />
               <Chip 
                 size="small" 
-                label={`Align: ${alignText}`} 
+                label={`Up/down: ${alignText}`}
                 color="info" 
                 variant="outlined" 
                 sx={{ fontSize: isMobile ? '0.65rem' : undefined }}
               />
               <Chip 
                 size="small" 
-                label={`Wrap: ${flexWrap}`} 
+                label={`New lines: ${flexWrap}`}
                 color="default" 
                 variant="outlined" 
                 sx={{ fontSize: isMobile ? '0.65rem' : undefined }}
@@ -231,9 +231,9 @@ const FlexBoxEditor: React.FC<FlexBoxEditorProps> = ({ props, onChange }) => {
                 fontSize: isMobile ? '0.65rem' : undefined 
               }}
             >
-              <span>Gap: {spacing}</span>
+              <span>Space between items: {spacing}</span>
               <span>•</span>
-              <span>Padding: {padding}</span>
+              <span>Inside space: {padding}</span>
               {Boolean(props.scrollable) && (
                 <>
                   <span>•</span>
@@ -250,7 +250,7 @@ const FlexBoxEditor: React.FC<FlexBoxEditorProps> = ({ props, onChange }) => {
         value={tabValue}
         onChange={handleTabChange}
         tabs={[
-          { label: 'Basic Settings', id: 'flexbox-basic', icon: <SettingsIcon fontSize={isMobile ? "small" : "medium"} /> },
+          { label: 'Basic Setup', id: 'flexbox-basic', icon: <SettingsIcon fontSize={isMobile ? "small" : "medium"} /> },
           { label: 'Styling', id: 'label-styling', icon: <FormatColorTextIcon fontSize={isMobile ? "small" : "medium"} /> }
         ]}
       />
@@ -258,14 +258,14 @@ const FlexBoxEditor: React.FC<FlexBoxEditorProps> = ({ props, onChange }) => {
       {/* Layout Tab */}
       <TabPanelShared value={tabValue} index={0}>
         <Grid container spacing={isMobile ? 1 : 2}>
-          {/* Flex Direction */}
+          {/* Item Direction */}
           <Grid item xs={12}>
             <Typography 
               variant={isMobile ? "body2" : "subtitle2"} 
               gutterBottom
               sx={{ fontSize: isMobile ? '0.875rem' : undefined }}
             >
-              Flex Direction
+              Item Direction
             </Typography>
             <Grid container spacing={isMobile ? 0.5 : 1}>
               <Grid item xs={3}>
@@ -330,7 +330,7 @@ const FlexBoxEditor: React.FC<FlexBoxEditorProps> = ({ props, onChange }) => {
                 >
                   <ArrowBackIcon fontSize={isMobile ? "small" : "medium"} />
                   <Typography variant="caption" sx={{ fontSize: isMobile ? '0.65rem' : undefined }}>
-                    Row Rev
+                    Reverse Row
                   </Typography>
                 </Button>
               </Grid>
@@ -352,7 +352,7 @@ const FlexBoxEditor: React.FC<FlexBoxEditorProps> = ({ props, onChange }) => {
                 >
                   <ArrowUpwardIcon fontSize={isMobile ? "small" : "medium"} />
                   <Typography variant="caption" sx={{ fontSize: isMobile ? '0.65rem' : undefined }}>
-                    Col Rev
+                    Reverse Column
                   </Typography>
                 </Button>
               </Grid>
@@ -362,10 +362,10 @@ const FlexBoxEditor: React.FC<FlexBoxEditorProps> = ({ props, onChange }) => {
           {/* Justification */}
           <Grid item xs={12} sm={6}>
             <FormControl fullWidth sx={{ mt: isMobile ? 1 : 2 }} size={isMobile ? "small" : "medium"}>
-              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Justify Content</InputLabel>
+              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Horizontal Position</InputLabel>
               <Select
                 value={justifyContent}
-                label="Justify Content"
+                label="Horizontal Position"
                 onChange={(e) => {
                   setJustifyContent(e.target.value)
                   handleChange('justifyContent', e.target.value)
@@ -377,9 +377,9 @@ const FlexBoxEditor: React.FC<FlexBoxEditorProps> = ({ props, onChange }) => {
                 <MenuItem value="flex-start" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Start</MenuItem>
                 <MenuItem value="center" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Center</MenuItem>
                 <MenuItem value="flex-end" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>End</MenuItem>
-                <MenuItem value="space-between" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Space Between</MenuItem>
-                <MenuItem value="space-around" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Space Around</MenuItem>
-                <MenuItem value="space-evenly" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Space Evenly</MenuItem>
+                <MenuItem value="space-between" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Spread Apart</MenuItem>
+                <MenuItem value="space-around" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Space Around Each</MenuItem>
+                <MenuItem value="space-evenly" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Evenly Spaced</MenuItem>
               </Select>
             </FormControl>
           </Grid>
@@ -387,10 +387,10 @@ const FlexBoxEditor: React.FC<FlexBoxEditorProps> = ({ props, onChange }) => {
           {/* Alignment */}
           <Grid item xs={12} sm={6}>
             <FormControl fullWidth sx={{ mt: isMobile ? 1 : 2 }} size={isMobile ? "small" : "medium"}>
-              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Align Items</InputLabel>
+              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Vertical Position</InputLabel>
               <Select
                 value={alignItems}
-                label="Align Items"
+                label="Vertical Position"
                 onChange={(e) => {
                   setAlignItems(e.target.value)
                   handleChange('alignItems', e.target.value)
@@ -411,10 +411,10 @@ const FlexBoxEditor: React.FC<FlexBoxEditorProps> = ({ props, onChange }) => {
           {/* Wrapping */}
           <Grid item xs={12} sm={6}>
             <FormControl fullWidth size={isMobile ? "small" : "medium"}>
-              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Flex Wrap</InputLabel>
+              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Move Items to New Lines</InputLabel>
               <Select
                 value={flexWrap}
-                label="Flex Wrap"
+                label="Move Items to New Lines"
                 onChange={(e) => {
                   setFlexWrap(e.target.value)
                   handleChange('wrap', e.target.value)
@@ -423,9 +423,9 @@ const FlexBoxEditor: React.FC<FlexBoxEditorProps> = ({ props, onChange }) => {
                   '& .MuiSelect-select': { fontSize: isMobile ? '0.875rem' : undefined }
                 }}
               >
-                <MenuItem value="nowrap" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>No Wrap</MenuItem>
+                <MenuItem value="nowrap" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Keep on One Line</MenuItem>
                 <MenuItem value="wrap" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Wrap</MenuItem>
-                <MenuItem value="wrap-reverse" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Wrap Reverse</MenuItem>
+                <MenuItem value="wrap-reverse" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>New Lines in Reverse Order</MenuItem>
               </Select>
             </FormControl>
           </Grid> 
@@ -442,7 +442,7 @@ const FlexBoxEditor: React.FC<FlexBoxEditorProps> = ({ props, onChange }) => {
             gutterBottom
             sx={{ fontSize: isMobile ? '0.875rem' : undefined }}
           >
-            Item Spacing (Gap)
+            Space Between Items
           </Typography>
           <Slider
             value={spacing}
@@ -473,7 +473,7 @@ const FlexBoxEditor: React.FC<FlexBoxEditorProps> = ({ props, onChange }) => {
               gutterBottom
               sx={{ fontSize: isMobile ? '0.875rem' : undefined }}
             >
-              Container Padding
+              Space Around the Inside
             </Typography>
             <Slider
               value={padding}

--- a/apps/aquamesh/src/components/WidgetEditor/components/editors/GridBoxEditor.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/editors/GridBoxEditor.tsx
@@ -126,7 +126,7 @@ const GridBoxEditor: React.FC<GridBoxEditorProps> = ({ props, onChange }) => {
               {cellPadding > 0 && (
                 <>
                   <span>•</span>
-                  <span>Cell Padding: {cellPadding}</span>
+                  <span>Inside space: {cellPadding}</span>
                 </>
               )}
             </Typography>
@@ -138,7 +138,7 @@ const GridBoxEditor: React.FC<GridBoxEditorProps> = ({ props, onChange }) => {
         <Grid item xs={12} sm={6}>
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <TextField
-              label="Columns"
+              label="Number of Columns"
               type="number"
               fullWidth
               size={isMobile ? "small" : "medium"}
@@ -161,7 +161,7 @@ const GridBoxEditor: React.FC<GridBoxEditorProps> = ({ props, onChange }) => {
                 }
               }}
             />
-            <Tooltip title="Enter a value between 1 and 12">
+            <Tooltip title="Choose how many columns to show, from 1 to 12.">
               <InfoOutlinedIcon 
                 fontSize={isMobile ? "small" : "medium"} 
                 sx={{ ml: 0.5, mb: isMobile ? 2 : 3.5 }} 
@@ -176,9 +176,9 @@ const GridBoxEditor: React.FC<GridBoxEditorProps> = ({ props, onChange }) => {
               gutterBottom
               sx={{ fontSize: isMobile ? '0.875rem' : undefined }}
             >
-              Cell Padding
+              Space Inside Each Box
             </Typography>
-            <Tooltip title="Padding adds space inside each cell, around the content">
+            <Tooltip title="Adds breathing room around the content inside each box.">
               <InfoOutlinedIcon 
                 fontSize={isMobile ? "small" : "medium"} 
                 sx={{ ml: 1 }} 

--- a/apps/aquamesh/src/components/WidgetEditor/components/editors/LabelEditor.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/editors/LabelEditor.tsx
@@ -239,7 +239,7 @@ const LabelEditor: React.FC<LabelEditorProps> = ({ props, onChange }) => {
         <Grid container spacing={isMobile ? 1 : 2}>
           <Grid item xs={12}>
             <TextField
-              label="Label Text"
+              label="Text to Show"
               fullWidth
               onFocus={(e) => { e.target.select() }}
               value={(props.text as string) || ''}
@@ -268,7 +268,7 @@ const LabelEditor: React.FC<LabelEditorProps> = ({ props, onChange }) => {
               customColor={customColor}
               onColorChange={handleColorChange}
               onToggleCustomColor={handleCustomColorToggle}
-              label="Use Custom Color"
+              label="Choose Text Color"
             />
           </Grid>
           
@@ -286,7 +286,7 @@ const LabelEditor: React.FC<LabelEditorProps> = ({ props, onChange }) => {
                   <Typography sx={{ fontSize: isMobile ? '0.75rem' : undefined }}>
                     No Text Wrapping
                   </Typography>
-                  <TooltipStyled title="When enabled, text will not wrap to a new line and will be truncated with an ellipsis if it exceeds available space.">
+                  <TooltipStyled title="Keeps the text on one line and shortens it with “…” if it gets too long.">
                     <InfoOutlinedIcon fontSize={isMobile ? "small" : "medium"} sx={{ ml: 0.5 }} />
                   </TooltipStyled>
                 </Box>
@@ -307,10 +307,10 @@ const LabelEditor: React.FC<LabelEditorProps> = ({ props, onChange }) => {
         <Grid container spacing={isMobile ? 1 : 2}>
           <Grid item xs={12}>
             <FormControl fullWidth size={isMobile ? "small" : "medium"}>
-              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Text Variant</InputLabel>
+              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Text Style</InputLabel>
               <Select
                 value={variant}
-                label="Text Variant"
+                label="Text Style"
                 onChange={(e) => {
                   setVariant(e.target.value)
                   handleChange('variant', e.target.value)
@@ -327,10 +327,10 @@ const LabelEditor: React.FC<LabelEditorProps> = ({ props, onChange }) => {
                 <MenuItem value="h4" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Heading 4</MenuItem>
                 <MenuItem value="h5" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Heading 5</MenuItem>
                 <MenuItem value="h6" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Heading 6</MenuItem>
-                <MenuItem value="subtitle1" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Subtitle 1</MenuItem>
-                <MenuItem value="subtitle2" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Subtitle 2</MenuItem>
-                <MenuItem value="body1" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Body 1</MenuItem>
-                <MenuItem value="body2" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Body 2</MenuItem>
+                <MenuItem value="subtitle1" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Large Subtitle</MenuItem>
+                <MenuItem value="subtitle2" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Small Subtitle</MenuItem>
+                <MenuItem value="body1" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Normal Text</MenuItem>
+                <MenuItem value="body2" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Small Text</MenuItem>
               </Select>
             </FormControl>
           </Grid>

--- a/apps/aquamesh/src/components/WidgetEditor/components/editors/SwitchEditor.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/editors/SwitchEditor.tsx
@@ -326,7 +326,7 @@ const SwitchEditor: React.FC<SwitchEditorProps> = ({ props, onChange }) => {
         <Grid container spacing={isMobile ? 1 : 2}>
           <Grid item xs={12}>
             <TextField
-              label="Label Text"
+              label="Switch Label"
               fullWidth
               onFocus={(e) => { e.target.select() }}
               value={(props.label as string) || ''}
@@ -386,10 +386,10 @@ const SwitchEditor: React.FC<SwitchEditorProps> = ({ props, onChange }) => {
 
           <Grid item xs={12} sm={isMobile ? 12 : 6}>
             <FormControl fullWidth size={isMobile ? "small" : "medium"}>
-              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Label Placement</InputLabel>
+              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Label Position</InputLabel>
               <Select
                 value={labelPlacement}
-                label="Label Placement"
+                label="Label Position"
                 onChange={(e) => {
                   setLabelPlacement(e.target.value)
                   handleChange('labelPlacement', e.target.value)
@@ -400,8 +400,8 @@ const SwitchEditor: React.FC<SwitchEditorProps> = ({ props, onChange }) => {
                   }
                 }}
               >
-                <MenuItem value="end" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>End (Right)</MenuItem>
-                <MenuItem value="start" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Start (Left)</MenuItem>
+                <MenuItem value="end" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Right Side</MenuItem>
+                <MenuItem value="start" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Left Side</MenuItem>
                 <MenuItem value="top" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Top</MenuItem>
                 <MenuItem value="bottom" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Bottom</MenuItem>
               </Select>
@@ -447,9 +447,9 @@ const SwitchEditor: React.FC<SwitchEditorProps> = ({ props, onChange }) => {
               label={
                 <Box sx={{ display: 'flex', alignItems: 'center' }}>
                   <Typography sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>
-                    Use Custom Track Color
+                    Use Custom Switch Track Color
                   </Typography>
-                  <Tooltip title="Toggle custom track color for the switch">
+                  <Tooltip title="Choose a custom color for the switch track.">
                     <InfoOutlinedIcon fontSize={isMobile ? "small" : "medium"} sx={{ ml: 0.5 }} />
                   </Tooltip>
                 </Box>
@@ -464,7 +464,7 @@ const SwitchEditor: React.FC<SwitchEditorProps> = ({ props, onChange }) => {
           {useCustomColor && (
             <Grid item xs={12}>
               <TextField
-                label="Track Color"
+                label="Switch Track Color"
                 fullWidth
                 value={customTrackColor}
                 onChange={(e) => {
@@ -497,7 +497,7 @@ const SwitchEditor: React.FC<SwitchEditorProps> = ({ props, onChange }) => {
               customColor={customLabelColor}
               onToggleCustomColor={handleLabelColorToggle}
               onColorChange={handleLabelColorChange}
-              label="Use Custom Label Color"
+              label="Choose Label Color"
             />
           </Grid>
         </Grid>
@@ -535,11 +535,11 @@ const SwitchEditor: React.FC<SwitchEditorProps> = ({ props, onChange }) => {
             <>
               <Grid item xs={12}>
                 <TextField
-                  label="On Message"
+                  label="Message When On"
                   fullWidth
                   value={(props.onMessage as string) || 'Switch turned ON'}
                   onChange={(e) => handleChange('onMessage', e.target.value)}
-                  placeholder="Message when turned ON"
+                  placeholder="Message to show when switched on"
                   size={isMobile ? "small" : "medium"}
                   InputLabelProps={{
                     style: { fontSize: isMobile ? '0.875rem' : undefined }
@@ -552,11 +552,11 @@ const SwitchEditor: React.FC<SwitchEditorProps> = ({ props, onChange }) => {
               
               <Grid item xs={12}>
                 <TextField
-                  label="Off Message"
+                  label="Message When Off"
                   fullWidth
                   value={(props.offMessage as string) || 'Switch turned OFF'}
                   onChange={(e) => handleChange('offMessage', e.target.value)}
-                  placeholder="Message when turned OFF"
+                  placeholder="Message to show when switched off"
                   size={isMobile ? "small" : "medium"}
                   InputLabelProps={{
                     style: { fontSize: isMobile ? '0.875rem' : undefined }
@@ -569,10 +569,10 @@ const SwitchEditor: React.FC<SwitchEditorProps> = ({ props, onChange }) => {
               
               <Grid item xs={12}>
                 <FormControl fullWidth size={isMobile ? "small" : "medium"}>
-                  <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Toast Severity</InputLabel>
+                  <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Message Type</InputLabel>
                   <Select
                     value={(props.toastSeverity as string) || 'info'}
-                    label="Toast Severity"
+                    label="Message Type"
                     onChange={(e) => handleChange('toastSeverity', e.target.value)}
                     sx={{
                       '.MuiSelect-select': {

--- a/apps/aquamesh/src/components/WidgetEditor/components/editors/TextFieldEditor.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/editors/TextFieldEditor.tsx
@@ -84,14 +84,14 @@ const TextFieldEditor: React.FC<TextFieldEditorProps> = ({ props, onChange }) =>
           p: isMobile ? 1 : 2
         }}>
           <TextField
-            label={props.label as string || 'Label'}
-            placeholder={props.placeholder as string || 'Placeholder'}
+            label={props.label as string || 'Field Label'}
+            placeholder={props.placeholder as string || 'Example answer'}
             defaultValue={props.defaultValue as string || ''}
             variant={(props.variant as 'outlined' | 'filled' | 'standard') || 'outlined'}
             size={(props.size as 'small' | 'medium') || 'medium'}
             required={Boolean(props.required)}
             error={Boolean(props.error)}
-            helperText={props.error ? (props.errorText as string || 'Error text') : (props.helperText as string || '')}
+            helperText={props.error ? (props.errorText as string || 'Problem message') : (props.helperText as string || '')}
             fullWidth
             disabled={Boolean(props.disabled)}
             type={props.type as string || 'text'}
@@ -220,7 +220,7 @@ const TextFieldEditor: React.FC<TextFieldEditorProps> = ({ props, onChange }) =>
         <Grid container spacing={isMobile ? 1 : 2}>
           <Grid item xs={12}>
             <TextField
-              label="Field Label"
+              label="Question or Field Name"
               fullWidth
               size={isMobile ? "small" : "medium"}
               onFocus={(e) => { e.target.select() }}
@@ -239,7 +239,7 @@ const TextFieldEditor: React.FC<TextFieldEditorProps> = ({ props, onChange }) =>
           
           <Grid item xs={12} sm={6}>
             <TextField
-              label="Placeholder Text"
+              label="Example Text"
               fullWidth
               size={isMobile ? "small" : "medium"}
               onFocus={(e) => { e.target.select() }}
@@ -258,7 +258,7 @@ const TextFieldEditor: React.FC<TextFieldEditorProps> = ({ props, onChange }) =>
           
           <Grid item xs={12} sm={6}>
             <TextField
-              label="Default Value"
+              label="Pre-filled Answer"
               fullWidth
               size={isMobile ? "small" : "medium"}
               onFocus={(e) => { e.target.select() }}
@@ -277,10 +277,10 @@ const TextFieldEditor: React.FC<TextFieldEditorProps> = ({ props, onChange }) =>
           
           <Grid item xs={12} sm={6}>
             <FormControl fullWidth size={isMobile ? "small" : "medium"}>
-              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Input Type</InputLabel>
+              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Expected Answer Type</InputLabel>
               <Select
                 value={type}
-                label="Input Type"
+                label="Expected Answer Type"
                 onChange={(e) => {
                   setType(e.target.value)
                   handleChange('type', e.target.value)
@@ -306,10 +306,10 @@ const TextFieldEditor: React.FC<TextFieldEditorProps> = ({ props, onChange }) =>
         <Grid container spacing={isMobile ? 1 : 2}>
           <Grid item xs={12} sm={6}>
             <FormControl fullWidth size={isMobile ? "small" : "medium"}>
-              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Variant</InputLabel>
+              <InputLabel sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Display Style</InputLabel>
               <Select
                 value={variant}
-                label="Variant"
+                label="Display Style"
                 onChange={(e) => {
                   setVariant(e.target.value)
                   handleChange('variant', e.target.value)
@@ -318,9 +318,9 @@ const TextFieldEditor: React.FC<TextFieldEditorProps> = ({ props, onChange }) =>
                   '& .MuiSelect-select': { fontSize: isMobile ? '0.875rem' : undefined }
                 }}
               >
-                <MenuItem value="outlined" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Outlined</MenuItem>
-                <MenuItem value="filled" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Filled</MenuItem>
-                <MenuItem value="standard" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Standard</MenuItem>
+                <MenuItem value="outlined" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Box Outline</MenuItem>
+                <MenuItem value="filled" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Filled Background</MenuItem>
+                <MenuItem value="standard" sx={{ fontSize: isMobile ? '0.875rem' : undefined }}>Simple Line</MenuItem>
               </Select>
             </FormControl>
           </Grid>
@@ -412,7 +412,7 @@ const TextFieldEditor: React.FC<TextFieldEditorProps> = ({ props, onChange }) =>
               <Grid item xs={12} sm={6}>
                 {Boolean(props.error) && (
                   <TextField
-                    label="Error Text"
+                    label="Problem Message"
                     fullWidth
                     value={(props.errorText as string) || ''}
                     onChange={(e) => handleChange('errorText', e.target.value)}
@@ -467,7 +467,7 @@ const TextFieldEditor: React.FC<TextFieldEditorProps> = ({ props, onChange }) =>
             
             {hasStartAdornment && (
               <TextField
-                label="Start Adornment Text"
+                label="Text Before the Answer"
                 fullWidth
                 value={(props.startAdornmentText as string) || '$'}
                 onChange={(e) => handleChange('startAdornmentText', e.target.value)}
@@ -509,7 +509,7 @@ const TextFieldEditor: React.FC<TextFieldEditorProps> = ({ props, onChange }) =>
             
             {hasEndAdornment && (
               <TextField
-                label="End Adornment Text"
+                label="Text After the Answer"
                 fullWidth
                 value={(props.endAdornmentText as string) || 'kg'}
                 onChange={(e) => handleChange('endAdornmentText', e.target.value)}

--- a/apps/aquamesh/src/components/WidgetEditor/constants/componentTypes.ts
+++ b/apps/aquamesh/src/components/WidgetEditor/constants/componentTypes.ts
@@ -8,40 +8,40 @@ import GridViewIcon from '@mui/icons-material/GridView'
 import PieChartIcon from '@mui/icons-material/PieChart'
 import { ComponentType } from '../types/types'
 
-// Types of components that can be added to the widget
+// Building blocks that can be added to a widget.
 export const COMPONENT_TYPES: ComponentType[] = [
-  // UI Components
+  // Content and Controls
   {
     type: 'Label',
-    label: 'Text Label',
-    defaultProps: { text: 'Label Text' },
-    category: 'UI Components',
+    label: 'Display Text',
+    defaultProps: { text: 'Display Text' },
+    category: 'Content and Controls',
     icon: TextFieldsIcon,
-    tooltip: 'Adds a static text label to display information'
+    tooltip: 'Shows a short piece of text, such as a title, status, or note.'
   },
   {
     type: 'TextField',
-    label: 'Text Field',
-    defaultProps: { label: 'Text Field', placeholder: 'Enter text...', defaultValue: '' },
-    category: 'UI Components',
+    label: 'Answer Box',
+    defaultProps: { label: 'Answer Box', placeholder: 'Enter text...', defaultValue: '' },
+    category: 'Content and Controls',
     icon: InputIcon,
-    tooltip: 'Adds an input field for user text entry'
+    tooltip: 'Lets someone type a value, note, or answer into the widget.'
   },
   {
     type: 'Button',
     label: 'Button',
-    defaultProps: { text: 'Button', variant: 'contained', showToast: true, toastMessage: 'Button clicked!', toastSeverity: 'info' },
-    category: 'UI Components',
+    defaultProps: { text: 'Button', variant: 'contained', showToast: true, toastMessage: 'Action completed!', toastSeverity: 'info' },
+    category: 'Content and Controls',
     icon: SmartButtonIcon,
-    tooltip: 'Adds a clickable button that can trigger actions like showing notifications'
+    tooltip: 'Adds a button for actions like confirming a step, opening a link, or showing a message.'
   },
   {
     type: 'SwitchEnable',
     label: 'Switch',
     defaultProps: { label: 'Switch', defaultChecked: false },
-    category: 'UI Components',
+    category: 'Content and Controls',
     icon: ToggleOnIcon,
-    tooltip: 'Adds an on/off toggle switch for boolean settings'
+    tooltip: 'Adds a simple on/off choice, such as Enabled, Open, or Needs review.'
   },
   {
     type: 'Chart',
@@ -68,23 +68,23 @@ export const COMPONENT_TYPES: ComponentType[] = [
         ]
       }`
     },
-    category: 'UI Components',
+    category: 'Content and Controls',
     icon: PieChartIcon,
-    tooltip: 'Adds a pie chart visualization with JSON data'
+    tooltip: 'Shows a pie chart for simple breakdowns, such as ticket types or incident causes.'
   },
   
-  // Layout Containers
+  // Layout Helpers
   {
     type: 'FieldSet',
-    label: 'Field Set',
-    defaultProps: { legend: 'Field Set', collapsed: false },
-    category: 'Layout Containers',
+    label: 'Grouped Section',
+    defaultProps: { legend: 'Grouped Section', collapsed: false },
+    category: 'Layout Helpers',
     icon: ViewQuiltIcon,
-    tooltip: 'Creates a collapsible container that can be toggled open/closed to organize related components'
+    tooltip: 'Groups related items under one heading. It can be opened or collapsed.'
   },
   {
     type: 'FlexBox',
-    label: 'Flex Container',
+    label: 'Row or Column Group',
     defaultProps: { 
       direction: 'row', 
       justifyContent: 'flex-start', 
@@ -92,21 +92,21 @@ export const COMPONENT_TYPES: ComponentType[] = [
       spacing: 0,
       wrap: 'wrap'
     },
-    category: 'Layout Containers',
+    category: 'Layout Helpers',
     icon: FlexibleIcon,
-    tooltip: 'Creates a flexible layout container using CSS Flexbox for responsive positioning of components'
+    tooltip: 'Places items next to each other or stacks them, with simple spacing controls.'
   },
   {
     type: 'GridBox',
-    label: 'Grid Container',
+    label: 'Grid Group',
     defaultProps: { 
       columns: 2, 
       rows: 1,
       spacing: 2
     },
-    category: 'Layout Containers',
+    category: 'Layout Helpers',
     icon: GridViewIcon,
-    tooltip: 'Creates a grid layout container for organizing components in rows and columns'
+    tooltip: 'Arranges items into clear columns, like cards on a dashboard.'
   },
 ]
 

--- a/apps/aquamesh/src/components/WidgetEditor/constants/componentTypes.ts
+++ b/apps/aquamesh/src/components/WidgetEditor/constants/componentTypes.ts
@@ -84,7 +84,7 @@ export const COMPONENT_TYPES: ComponentType[] = [
   },
   {
     type: 'FlexBox',
-    label: 'Row or Column Group',
+    label: 'Flexible Group',
     defaultProps: { 
       direction: 'row', 
       justifyContent: 'flex-start', 

--- a/apps/aquamesh/src/components/WidgetEditor/constants/componentTypes.ts
+++ b/apps/aquamesh/src/components/WidgetEditor/constants/componentTypes.ts
@@ -10,12 +10,12 @@ import { ComponentType } from '../types/types'
 
 // Building blocks that can be added to a widget.
 export const COMPONENT_TYPES: ComponentType[] = [
-  // Content and Controls
+  // UI Components
   {
     type: 'Label',
     label: 'Display Text',
     defaultProps: { text: 'Display Text' },
-    category: 'Content and Controls',
+    category: 'UI Components',
     icon: TextFieldsIcon,
     tooltip: 'Shows a short piece of text, such as a title, status, or note.'
   },
@@ -23,7 +23,7 @@ export const COMPONENT_TYPES: ComponentType[] = [
     type: 'TextField',
     label: 'Answer Box',
     defaultProps: { label: 'Answer Box', placeholder: 'Enter text...', defaultValue: '' },
-    category: 'Content and Controls',
+    category: 'UI Components',
     icon: InputIcon,
     tooltip: 'Lets someone type a value, note, or answer into the widget.'
   },
@@ -31,7 +31,7 @@ export const COMPONENT_TYPES: ComponentType[] = [
     type: 'Button',
     label: 'Button',
     defaultProps: { text: 'Button', variant: 'contained', showToast: true, toastMessage: 'Action completed!', toastSeverity: 'info' },
-    category: 'Content and Controls',
+    category: 'UI Components',
     icon: SmartButtonIcon,
     tooltip: 'Adds a button for actions like confirming a step, opening a link, or showing a message.'
   },
@@ -39,7 +39,7 @@ export const COMPONENT_TYPES: ComponentType[] = [
     type: 'SwitchEnable',
     label: 'Switch',
     defaultProps: { label: 'Switch', defaultChecked: false },
-    category: 'Content and Controls',
+    category: 'UI Components',
     icon: ToggleOnIcon,
     tooltip: 'Adds a simple on/off choice, such as Enabled, Open, or Needs review.'
   },
@@ -68,17 +68,17 @@ export const COMPONENT_TYPES: ComponentType[] = [
         ]
       }`
     },
-    category: 'Content and Controls',
+    category: 'UI Components',
     icon: PieChartIcon,
     tooltip: 'Shows a pie chart for simple breakdowns, such as ticket types or incident causes.'
   },
   
-  // Layout Helpers
+  // Layout Containers
   {
     type: 'FieldSet',
     label: 'Grouped Section',
     defaultProps: { legend: 'Grouped Section', collapsed: false },
-    category: 'Layout Helpers',
+    category: 'Layout Containers',
     icon: ViewQuiltIcon,
     tooltip: 'Groups related items under one heading. It can be opened or collapsed.'
   },
@@ -92,7 +92,7 @@ export const COMPONENT_TYPES: ComponentType[] = [
       spacing: 0,
       wrap: 'wrap'
     },
-    category: 'Layout Helpers',
+    category: 'Layout Containers',
     icon: FlexibleIcon,
     tooltip: 'Places items next to each other or stacks them, with simple spacing controls.'
   },
@@ -104,7 +104,7 @@ export const COMPONENT_TYPES: ComponentType[] = [
       rows: 1,
       spacing: 2
     },
-    category: 'Layout Helpers',
+    category: 'Layout Containers',
     icon: GridViewIcon,
     tooltip: 'Arranges items into clear columns, like cards on a dashboard.'
   },

--- a/apps/aquamesh/src/components/tutorial/WidgetEditorExplanationModal.tsx
+++ b/apps/aquamesh/src/components/tutorial/WidgetEditorExplanationModal.tsx
@@ -231,7 +231,7 @@ const WidgetEditorExplanationModal: React.FC<
             'Arranges items into clear columns, like dashboard cards or summary boxes.',
         },
         {
-          title: 'Row or Column Group',
+          title: 'Flexible Group',
           icon: <FlexibleIcon />,
           content:
             'Places items next to each other or stacks them, while adapting to the space available on the screen.',

--- a/apps/aquamesh/src/components/tutorial/WidgetEditorExplanationModal.tsx
+++ b/apps/aquamesh/src/components/tutorial/WidgetEditorExplanationModal.tsx
@@ -130,13 +130,13 @@ const WidgetEditorExplanationModal: React.FC<
           title: 'Add Building Blocks',
           icon: <WidgetsIcon />,
           content:
-            'Drag text, inputs, buttons, charts, and layout blocks from the left panel onto the canvas.',
+            'Drag text, answer boxes, buttons, charts, and groups from the left panel into your widget.',
         },
         {
           title: 'Arrange The Canvas',
           icon: <GridViewIcon />,
           content:
-            'Move and configure the blocks until the widget is ready to reuse in dashboards.',
+            'Move each item and adjust its wording or display options until the widget is ready to reuse in dashboards.',
         },
       ],
     },
@@ -164,77 +164,77 @@ const WidgetEditorExplanationModal: React.FC<
       ],
     },
     {
-      title: 'Building Block Types',
+      title: 'Building Blocks You Can Use',
       subsections: [
         {
-          title: 'Inputs and Controls',
+          title: 'Content and Controls',
           icon: <InputIcon />,
           content:
-            'Basic dashboard controls such as buttons, text fields, sliders, checkboxes, and select menus.',
+            'Everyday dashboard items such as text, answer boxes, buttons, switches, and charts.',
         },
         {
-          title: 'Layout Containers',
+          title: 'Layout Helpers',
           icon: <GridViewIcon />,
           content:
-            'Containers that organize the structure of your widget, such as grids, tabs, and fieldsets.',
+            'Helpers that keep related information together or arrange items into rows and columns.',
         },
       ],
     },
     {
-      title: 'Inputs and Controls',
+      title: 'Content and Controls',
       subsections: [
         {
-          title: 'Text Label',
+          title: 'Display Text',
           icon: <TextFieldsIcon />,
           content:
-            'A static text display element for showing information. Can be configured with different styles, sizes, and colors.',
+            'Shows helpful text such as a heading, status, instruction, or note. You can choose its size and color.',
         },
         {
-          title: 'Text Field',
+          title: 'Answer Box',
           icon: <InputIcon />,
           content:
-            'An input field for text entry. Supports single-line, multi-line, validation, and various styling options.',
+            'Lets someone type a value, note, or answer. You can choose the expected answer type and helper message.',
         },
         {
           title: 'Button',
           icon: <SmartButtonIcon />,
           content:
-            'A clickable button element that triggers actions. Configurable properties include button text, variant, colors, and ability to show toast notifications when clicked.',
+            'A button someone can press to show a message or open a link. You can choose the label, style, color, and message.',
         },
         {
           title: 'Switch',
           icon: <ToggleOnIcon />,
           content:
-            'A toggle switch that allows users to choose between on/off states for boolean values. Can be configured with custom labels and default states.',
+            'A simple on/off choice for statuses like Enabled, Open, or Needs review. You can choose its label and starting state.',
         },
         {
           title: 'Pie Chart',
           icon: <PieChartIcon />,
           content:
-            'A data visualization component that displays proportional data using a circular chart. Supports custom colors, labels, and data values.',
+            'Shows a simple breakdown, such as ticket categories or incident causes, in a circular chart.',
         },
       ],
     },
     {
-      title: 'Layout Containers',
+      title: 'Layout Helpers',
       subsections: [
         {
-          title: 'Fieldset',
+          title: 'Grouped Section',
           icon: <ViewQuiltIcon />,
           content:
-            'A collapsible container that can group related blocks. Users can toggle the visibility of its contents, making it useful for organizing complex widgets.',
+            'Groups related items under one heading. People can open or close the section to keep a busy widget tidy.',
         },
         {
-          title: 'Grid Layout',
+          title: 'Grid Group',
           icon: <GridViewIcon />,
           content:
-            'Arranges blocks in a table-like grid with rows and columns. Useful for creating structured layouts with precise alignment.',
+            'Arranges items into clear columns, like dashboard cards or summary boxes.',
         },
         {
-          title: 'Flex Layout',
+          title: 'Row or Column Group',
           icon: <FlexibleIcon />,
           content:
-            'A more dynamic layout system that allows blocks to grow, shrink, and reposition based on available space. Ideal for responsive widgets that adapt to different screen sizes.',
+            'Places items next to each other or stacks them, while adapting to the space available on the screen.',
         },
       ],
     },


### PR DESCRIPTION
## Summary
- Reword Widget Editor palette, settings, dialogs, and editor controls for non-programmers
- Replace developer/CSS jargon like “padding”, “variant”, “fieldset”, “toast”, “URL”, and “flex/grid container” with clearer user-facing wording
- Refresh quick guide/tutorial text to explain building blocks and use cases in more practical dashboard language

## Verification
- `git diff --check`
- `npm --workspace aquamesh run build` ✅ completed with existing warnings about missing `./.env.production`, outdated Browserslist data, and Sass deprecations
- `npm --workspace aquamesh run test:unit` ⚠️ runs after installing missing local ARM64 optional packages, but existing dashboard tests fail looking for “create daily operations widget” while the current UI shows “Create your own widget”
