### PR TITLE
Improve mobile widget editor usability

### DIFF
--- a/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Typography } from '@mui/material'
+import { Box, Typography, useMediaQuery, useTheme } from '@mui/material'
 import { useWidgetEditor } from './hooks/useWidgetEditor'
 import EditComponentDialog from './components/dialogs/EditComponentDialog'
 import SavedWidgetsDialog from './components/dialogs/SavedWidgetsDialog'
@@ -30,6 +30,8 @@ const WidgetEditor: React.FC<{
     initialEditMode?: boolean // Whether to start in edit mode
   }
 }> = ({ customProps }) => {
+  const theme = useTheme()
+  const isPhone = useMediaQuery(theme.breakpoints.down('sm'))
   const {
     // State
     widgetData,
@@ -148,8 +150,15 @@ const WidgetEditor: React.FC<{
   }
 
   const onboardingActive = editMode && !onboardingDismissed
+  const defaultEditViewMode = isPhone ? 'edit' : 'both'
   const showEditorPane = viewMode === 'both' || viewMode === 'edit'
   const showPreviewPane = viewMode === 'both' || viewMode === 'preview'
+
+  React.useEffect(() => {
+    if (isPhone && viewMode === 'both') {
+      setViewMode('edit')
+    }
+  }, [isPhone, setViewMode, viewMode])
 
   const handleSkipOnboarding = React.useCallback(() => {
     setOnboardingDismissed(true)
@@ -242,8 +251,9 @@ const WidgetEditor: React.FC<{
       if (customEvent.detail && customEvent.detail.widget) {
         const requestedViewMode =
           customEvent.detail.viewMode ??
-          (customEvent.detail.editMode ? 'edit' : 'preview')
-        const nextViewMode = requestedViewMode === 'both' ? 'edit' : requestedViewMode
+          (customEvent.detail.editMode ? defaultEditViewMode : 'preview')
+        const nextViewMode =
+          isPhone && requestedViewMode === 'both' ? 'edit' : requestedViewMode
         setViewMode(nextViewMode)
         handleLoadWidget(customEvent.detail.widget, nextViewMode !== 'preview')
       }
@@ -258,7 +268,7 @@ const WidgetEditor: React.FC<{
         handleExternalWidgetLoad,
       )
     }
-  }, [handleLoadWidget, setViewMode])
+  }, [defaultEditViewMode, handleLoadWidget, isPhone, setViewMode])
 
   // Handle initial widget load from customProps
   React.useEffect(() => {
@@ -271,7 +281,7 @@ const WidgetEditor: React.FC<{
 
       // Set the appropriate edit mode first
       if (customProps.initialEditMode !== undefined) {
-        setViewMode(customProps.initialEditMode ? 'edit' : 'preview')
+        setViewMode(customProps.initialEditMode ? defaultEditViewMode : 'preview')
       }
 
       // Then load the widget - use a setTimeout to ensure the edit mode is set first
@@ -283,7 +293,7 @@ const WidgetEditor: React.FC<{
         )
       }, 0)
     }
-  }, [customProps, handleLoadWidget, setViewMode])
+  }, [customProps, defaultEditViewMode, handleLoadWidget, setViewMode])
 
   // Listen for save widget dialog requests
   React.useEffect(() => {
@@ -407,7 +417,7 @@ const WidgetEditor: React.FC<{
 
   // Load a template as a new widget
   const handleTemplateSelected = (templateWidget: CustomWidget) => {
-    setViewMode('edit')
+    setViewMode(defaultEditViewMode)
     handleLoadWidget(templateWidget, true)
   }
 
@@ -422,7 +432,7 @@ const WidgetEditor: React.FC<{
       return
     }
 
-    setViewMode('edit')
+    setViewMode(defaultEditViewMode)
     handleLoadWidget(operationsWidget, true)
     if (onboardingActive) {
       setOnboardingStep('save')
@@ -504,7 +514,7 @@ const WidgetEditor: React.FC<{
     }
 
     // Preview the restored version without modifying storage
-    setViewMode('edit')
+    setViewMode(defaultEditViewMode)
     handleLoadWidget(restoredWidget, true)
     // Inform the user this version is loaded for editing
     setComponentToast({

--- a/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
@@ -240,9 +240,10 @@ const WidgetEditor: React.FC<{
     const handleExternalWidgetLoad = (event: Event) => {
       const customEvent = event as CustomEvent
       if (customEvent.detail && customEvent.detail.widget) {
-        const nextViewMode =
+        const requestedViewMode =
           customEvent.detail.viewMode ??
-          (customEvent.detail.editMode ? 'both' : 'preview')
+          (customEvent.detail.editMode ? 'edit' : 'preview')
+        const nextViewMode = requestedViewMode === 'both' ? 'edit' : requestedViewMode
         setViewMode(nextViewMode)
         handleLoadWidget(customEvent.detail.widget, nextViewMode !== 'preview')
       }
@@ -270,7 +271,7 @@ const WidgetEditor: React.FC<{
 
       // Set the appropriate edit mode first
       if (customProps.initialEditMode !== undefined) {
-        setViewMode(customProps.initialEditMode ? 'both' : 'preview')
+        setViewMode(customProps.initialEditMode ? 'edit' : 'preview')
       }
 
       // Then load the widget - use a setTimeout to ensure the edit mode is set first
@@ -406,7 +407,7 @@ const WidgetEditor: React.FC<{
 
   // Load a template as a new widget
   const handleTemplateSelected = (templateWidget: CustomWidget) => {
-    setViewMode('both')
+    setViewMode('edit')
     handleLoadWidget(templateWidget, true)
   }
 
@@ -421,7 +422,7 @@ const WidgetEditor: React.FC<{
       return
     }
 
-    setViewMode('both')
+    setViewMode('edit')
     handleLoadWidget(operationsWidget, true)
     if (onboardingActive) {
       setOnboardingStep('save')
@@ -503,7 +504,7 @@ const WidgetEditor: React.FC<{
     }
 
     // Preview the restored version without modifying storage
-    setViewMode('both')
+    setViewMode('edit')
     handleLoadWidget(restoredWidget, true)
     // Inform the user this version is loaded for editing
     setComponentToast({

--- a/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
@@ -648,7 +648,7 @@ const WidgetEditor: React.FC<{
             sx={{
               flex: viewMode === 'both' ? '1 1 50%' : '1 1 auto',
               minWidth: 0,
-              minHeight: 0,
+              minHeight: { xs: viewMode === 'both' ? 360 : 0, md: 0 },
               display: 'flex',
             }}
           >
@@ -693,7 +693,7 @@ const WidgetEditor: React.FC<{
             sx={{
               flex: viewMode === 'both' ? '1 1 50%' : '1 1 auto',
               minWidth: 0,
-              minHeight: viewMode === 'both' ? { xs: 360, md: 0 } : 0,
+              minHeight: viewMode === 'both' ? { xs: 260, md: 0 } : 0,
               borderLeft: { xs: 0, md: viewMode === 'both' ? 1 : 0 },
               borderTop: { xs: viewMode === 'both' ? 1 : 0, md: 0 },
               borderColor: 'divider',

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
@@ -220,8 +220,9 @@ const ComponentPalette = ({
               lineHeight: 1.35,
             }}
           >
-            Grab a block below and drag it into the Daily Operations widget
-            canvas.
+            {isPhone
+              ? 'Tap the + button on any block below to add it to your widget.'
+              : 'Grab a block below and drag it into the Daily Operations widget canvas.'}
           </Typography>
         </Box>
       )}

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
@@ -287,8 +287,12 @@ const ComponentPalette = ({
           width: '100%',
           overflowY: 'auto',
           flexGrow: 1,
-          pt: 0,
-          overflowX: isPhone ? 'auto' : 'hidden',
+          pt: isPhone ? 0.5 : 0,
+          px: isPhone ? 0.75 : 0,
+          display: isPhone ? 'flex' : 'block',
+          gap: isPhone ? 0.75 : 0,
+          alignItems: isPhone ? 'flex-start' : 'stretch',
+          overflowX: 'hidden',
           pb: isPhone ? 0.5 : 0,
           '& .MuiListSubheader-root': {
             py: isPhone ? 0.5 : 1,
@@ -303,7 +307,18 @@ const ComponentPalette = ({
           }
 
           return (
-            <Box key={category} sx={{ mb: isPhone ? 1 : 2 }}>
+            <Box
+              key={category}
+              sx={{
+                mb: isPhone ? 0 : 2,
+                flex: isPhone ? '1 1 0' : 'initial',
+                minWidth: isPhone ? 0 : undefined,
+                border: isPhone ? 1 : 0,
+                borderColor: 'divider',
+                borderRadius: isPhone ? 1 : 0,
+                overflow: 'hidden',
+              }}
+            >
               <ListSubheader
                 sx={{
                   display: 'flex',
@@ -314,18 +329,23 @@ const ComponentPalette = ({
                   color: 'foreground.contrastSecondary',
                   fontWeight: 'bold',
                   cursor: 'pointer',
-                  py: isPhone ? 0.5 : 1,
-                  fontSize: isPhone ? '0.7rem' : undefined,
+                  py: isPhone ? 0.4 : 1,
+                  px: isPhone ? 0.5 : 2,
+                  minHeight: isPhone ? 30 : undefined,
+                  fontSize: isPhone ? '0.66rem' : undefined,
                   lineHeight: isPhone ? 1.3 : undefined,
                 }}
                 onClick={() => toggleCategory(category)}
               >
-                {PALETTE_GROUP_LABELS[category] || category}
+                <Box component="span" sx={{ minWidth: 0, mr: 0.25 }}>
+                  {PALETTE_GROUP_LABELS[category] || category}
+                </Box>
                 <IconButton
                   size="small"
                   sx={{
                     color: 'foreground.contrastSecondary',
                     padding: isPhone ? 0.25 : '4px',
+                    flexShrink: 0,
                   }}
                 >
                   {expandedCategories[category] ? (
@@ -345,6 +365,7 @@ const ComponentPalette = ({
                   sx={{
                     px: isPhone ? 0.5 : 1,
                     pt: isPhone ? 0.5 : 1,
+                    pb: isPhone ? 0.5 : 0,
                     display: isPhone ? 'flex' : 'block',
                     gap: isPhone ? 0.75 : 0,
                     overflowX: isPhone ? 'auto' : 'visible',

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
@@ -77,7 +77,7 @@ const ComponentPalette = ({
   const theme = useTheme()
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'))
   const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'lg'))
-  const drawerWidth = isPhone ? 130 : isTablet ? 220 : 250
+  const drawerWidth = isPhone ? '100%' : isTablet ? 220 : 250
 
   // Group component types by category - memoized to prevent recalculation on each render
   const groupedComponents = useMemo(() => groupByCategory(COMPONENT_TYPES), [])
@@ -158,14 +158,16 @@ const ComponentPalette = ({
     <Box
       sx={{
         width: drawerWidth,
-        minWidth: drawerWidth,
+        minWidth: isPhone ? 0 : drawerWidth,
         maxWidth: drawerWidth,
-        flex: `0 0 ${drawerWidth}px`,
+        flex: isPhone ? '0 0 auto' : `0 0 ${drawerWidth}px`,
         bgcolor: '#FFFFFF',
-        borderRight: 1,
+        borderRight: { xs: 0, sm: 1 },
+        borderBottom: { xs: 1, sm: 0 },
         borderColor: 'divider',
-        height: '100%',
-        overflow: 'auto',
+        height: { xs: 'auto', sm: '100%' },
+        maxHeight: { xs: 236, sm: 'none' },
+        overflow: 'hidden',
         display: 'flex',
         flexDirection: 'column',
       }}
@@ -285,7 +287,8 @@ const ComponentPalette = ({
           overflowY: 'auto',
           flexGrow: 1,
           pt: 0,
-          overflowX: 'hidden',
+          overflowX: isPhone ? 'auto' : 'hidden',
+          pb: isPhone ? 0.5 : 0,
           '& .MuiListSubheader-root': {
             py: isPhone ? 0.5 : 1,
           },
@@ -337,7 +340,17 @@ const ComponentPalette = ({
               </ListSubheader>
 
               <Collapse in={expandedCategories[category]} timeout="auto">
-                <Box sx={{ px: isPhone ? 0.5 : 1, pt: isPhone ? 0.5 : 1 }}>
+                <Box
+                  sx={{
+                    px: isPhone ? 0.5 : 1,
+                    pt: isPhone ? 0.5 : 1,
+                    display: isPhone ? 'flex' : 'block',
+                    gap: isPhone ? 0.75 : 0,
+                    overflowX: isPhone ? 'auto' : 'visible',
+                    scrollSnapType: isPhone ? 'x proximity' : 'none',
+                    WebkitOverflowScrolling: 'touch',
+                  }}
+                >
                   {components.map((component) => (
                     <ComponentPaletteItem
                       key={component.type}

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPaletteItem.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPaletteItem.tsx
@@ -108,7 +108,14 @@ const ComponentPaletteItem: React.FC<ComponentPaletteItemProps> = ({
   }
   
   return (
-    <Box key={component.type} sx={{ mb: isPhone ? 0.5 : 1 }}>
+    <Box
+      key={component.type}
+      sx={{
+        mb: isPhone ? 0 : 1,
+        flex: isPhone ? '0 0 128px' : 'initial',
+        scrollSnapAlign: isPhone ? 'start' : 'none',
+      }}
+    >
       <TooltipStyled
         title={showTooltips ? component.tooltip || '' : ''}
         placement="right"
@@ -125,6 +132,7 @@ const ComponentPaletteItem: React.FC<ComponentPaletteItemProps> = ({
           onTouchCancel={handleTouchEnd}
           sx={{
             p: isPhone ? 0.75 : 1.5,
+            minHeight: isPhone ? 44 : 'auto',
             display: 'flex',
             alignItems: 'center',
             cursor: 'grab',
@@ -160,6 +168,7 @@ const ComponentPaletteItem: React.FC<ComponentPaletteItemProps> = ({
               flexGrow: 1,
               pr: isPhone ? 2 : 0, // Add padding if there's an add button
               fontSize: isPhone ? '0.7rem' : undefined,
+              lineHeight: isPhone ? 1.15 : undefined,
             }}
           >
             {component.label}

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPaletteItem.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPaletteItem.tsx
@@ -122,7 +122,7 @@ const ComponentPaletteItem: React.FC<ComponentPaletteItemProps> = ({
       key={component.type}
       sx={{
         mb: isPhone ? 0 : 1,
-        flex: isPhone ? '0 0 128px' : 'initial',
+        flex: isPhone ? '0 0 112px' : 'initial',
         scrollSnapAlign: isPhone ? 'start' : 'none',
       }}
     >

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPaletteItem.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPaletteItem.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react'
-import { 
-  Box, 
-  Typography, 
+import {
+  Box,
+  Typography,
   Paper,
   IconButton,
   useMediaQuery
@@ -27,41 +27,41 @@ const ComponentPaletteItem: React.FC<ComponentPaletteItemProps> = ({
   // Create the icon element dynamically from the component's icon property
   const IconComponent = component.icon
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'))
-  
+
   // Touch handling state
   const [isTouching, setIsTouching] = useState(false)
   const touchTimeoutRef = useRef<number | null>(null)
   const touchStartPositionRef = useRef({ x: 0, y: 0 })
   const itemRef = useRef<HTMLDivElement>(null)
-  
+
   // Handle touch start
   const handleTouchStart = (e: React.TouchEvent) => {
     // Store initial touch position
-    touchStartPositionRef.current = { 
-      x: e.touches[0].clientX, 
-      y: e.touches[0].clientY 
+    touchStartPositionRef.current = {
+      x: e.touches[0].clientX,
+      y: e.touches[0].clientY
     }
-    
+
     // Set a timeout to determine if it's a touch-and-hold gesture
     touchTimeoutRef.current = window.setTimeout(() => {
       // After the timeout, mark as "touching" to create a draggable state
       setIsTouching(true)
-      
+
       // Create and dispatch a custom drag start event
       if (itemRef.current) {
         const dataTransfer = new DataTransfer()
         dataTransfer.setData('componentType', component.type)
-        
+
         // Create a synthetic drag event
-        const dragEvent = new DragEvent('dragstart', { 
+        const dragEvent = new DragEvent('dragstart', {
           bubbles: true,
           cancelable: true,
-          dataTransfer 
+          dataTransfer
         })
-        
+
         // Dispatch the event on the element
         itemRef.current.dispatchEvent(dragEvent)
-        
+
         // Call the handler with the created event
         // Use a cast that preserves type safety better than 'any'
         const syntheticDragEvent = dragEvent as unknown as React.DragEvent<HTMLDivElement>
@@ -69,7 +69,7 @@ const ComponentPaletteItem: React.FC<ComponentPaletteItemProps> = ({
       }
     }, 300) // 300ms is a good balance for touch-and-hold
   }
-  
+
   // Handle touch move
   const handleTouchMove = (e: React.TouchEvent) => {
     // Calculate movement distance
@@ -77,7 +77,7 @@ const ComponentPaletteItem: React.FC<ComponentPaletteItemProps> = ({
     const currentY = e.touches[0].clientY
     const deltaX = Math.abs(currentX - touchStartPositionRef.current.x)
     const deltaY = Math.abs(currentY - touchStartPositionRef.current.y)
-    
+
     // If user moved more than 10px in any direction before the touch timeout,
     // cancel the timeout to allow scrolling
     if ((deltaX > 10 || deltaY > 10) && touchTimeoutRef.current) {
@@ -85,7 +85,7 @@ const ComponentPaletteItem: React.FC<ComponentPaletteItemProps> = ({
       touchTimeoutRef.current = null
     }
   }
-  
+
   // Handle touch end
   const handleTouchEnd = () => {
     // Clear timeout if touch ends
@@ -93,20 +93,30 @@ const ComponentPaletteItem: React.FC<ComponentPaletteItemProps> = ({
       window.clearTimeout(touchTimeoutRef.current)
       touchTimeoutRef.current = null
     }
-    
+
     // Reset touching state
     setIsTouching(false)
   }
 
   // Handle direct add click
-  const handleAddClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation()
-    
+  const addComponent = () => {
     if (onDirectAdd) {
       onDirectAdd(component.type)
     }
   }
-  
+
+  const handleAddClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+
+    addComponent()
+  }
+
+  const handleItemClick = () => {
+    if (!isTouching) {
+      addComponent()
+    }
+  }
+
   return (
     <Box
       key={component.type}
@@ -125,6 +135,7 @@ const ComponentPaletteItem: React.FC<ComponentPaletteItemProps> = ({
           ref={itemRef}
           elevation={1}
           draggable
+          onClick={onDirectAdd ? handleItemClick : undefined}
           onDragStart={(e) => handleDragStart(e, component.type)}
           onTouchStart={handleTouchStart}
           onTouchMove={handleTouchMove}
@@ -135,15 +146,15 @@ const ComponentPaletteItem: React.FC<ComponentPaletteItemProps> = ({
             minHeight: isPhone ? 44 : 'auto',
             display: 'flex',
             alignItems: 'center',
-            cursor: 'grab',
+            cursor: onDirectAdd ? 'pointer' : 'grab',
             transition: 'all 0.2s',
             '&:hover': {
               bgcolor: 'background.paper',
               transform: 'translateY(-2px)',
               boxShadow: 2,
             },
-            bgcolor: isTouching 
-              ? 'rgba(25, 118, 210, 0.12)' 
+            bgcolor: isTouching
+              ? 'rgba(25, 118, 210, 0.12)'
               : 'rgba(255, 255, 255, 0.05)',
             borderRadius: 1,
             position: 'relative',
@@ -162,18 +173,18 @@ const ComponentPaletteItem: React.FC<ComponentPaletteItemProps> = ({
           </Box>
           <Typography
             variant={isPhone ? "caption" : "body2"}
-            sx={{ 
-              fontWeight: 'medium', 
+            sx={{
+              fontWeight: 'medium',
               color: 'foreground.contrastPrimary',
               flexGrow: 1,
-              pr: isPhone ? 2 : 0, // Add padding if there's an add button
+              pr: onDirectAdd ? (isPhone ? 2.5 : 3.5) : 0,
               fontSize: isPhone ? '0.7rem' : undefined,
               lineHeight: isPhone ? 1.15 : undefined,
             }}
           >
             {component.label}
           </Typography>
-          
+
           {/* Add button for mobile devices */}
           {onDirectAdd && (
             <IconButton
@@ -186,8 +197,8 @@ const ComponentPaletteItem: React.FC<ComponentPaletteItemProps> = ({
                 transform: 'translateY(-50%)',
                 color: 'primary.main',
                 bgcolor: 'background.paper',
-                width: isPhone ? 18 : 24,
-                height: isPhone ? 18 : 24,
+                width: isPhone ? 24 : 28,
+                height: isPhone ? 24 : 28,
                 '&:hover': {
                   bgcolor: 'primary.light',
                   color: 'white',
@@ -203,4 +214,4 @@ const ComponentPaletteItem: React.FC<ComponentPaletteItemProps> = ({
   )
 }
 
-export default ComponentPaletteItem 
+export default ComponentPaletteItem

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/EditorToolbar.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/EditorToolbar.tsx
@@ -154,12 +154,13 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({
         >
           {editMode && (
             <IconButton
-              edge="start"
+              edge={isPhone ? false : 'start'}
               color="inherit"
               aria-label="menu"
               onClick={toggleSidebar}
               sx={{
                 mr: isPhone ? 0.25 : 2,
+                ml: isPhone ? 0.5 : 0,
                 p: isPhone ? 0.5 : 1,
                 color: showSidebar
                   ? 'primary.main'

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/EditorToolbar.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/EditorToolbar.tsx
@@ -148,7 +148,9 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({
           variant={isPhone ? 'dense' : 'regular'}
           sx={{
             minHeight: isPhone ? 48 : 64,
-            padding: isPhone ? '0px 4px' : '0px 16px',
+            padding: isPhone ? '0px 2px' : '0px 16px',
+            gap: isPhone ? 0.25 : 0,
+            overflow: 'hidden',
           }}
         >
           {editMode && (
@@ -158,7 +160,8 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({
               aria-label="menu"
               onClick={toggleSidebar}
               sx={{
-                mr: 2,
+                mr: isPhone ? 0.25 : 2,
+                p: isPhone ? 0.5 : 1,
                 color: showSidebar
                   ? 'primary.main'
                   : 'foreground.contrastSecondary',
@@ -168,7 +171,7 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({
               <MenuIcon
                 sx={{
                   fontSize: isPhone ? '1.25rem' : '1.5rem',
-                  ml: isPhone ? '1rem' : '0rem',
+                  ml: 0,
                 }}
               />
             </IconButton>
@@ -194,7 +197,7 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({
             </Typography>
           )}
 
-          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', minWidth: 0 }}>
             {/* Undo/Redo buttons */}
             {!!handleUndo && !!handleRedo && (
               <>
@@ -266,8 +269,8 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({
                 mr: isPhone ? 0.5 : 1,
                 height: isPhone ? 30 : 34,
                 '& .MuiToggleButton-root': {
-                  minWidth: isPhone ? 52 : 86,
-                  px: isPhone ? 0.75 : 1,
+                  minWidth: isPhone ? 34 : 86,
+                  px: isPhone ? 0.5 : 1,
                   py: 0,
                   gap: 0.5,
                   color: 'foreground.contrastSecondary',
@@ -289,15 +292,15 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({
                 <ViewColumnIcon
                   sx={{ fontSize: isPhone ? '1rem' : '1.15rem' }}
                 />
-                Both
+                {!isPhone && 'Both'}
               </ToggleButton>
               <ToggleButton value="edit" aria-label="Edit view">
                 <EditIcon sx={{ fontSize: isPhone ? '1rem' : '1.15rem' }} />
-                Edit
+                {!isPhone && 'Edit'}
               </ToggleButton>
               <ToggleButton value="preview" aria-label="Preview view">
                 <PreviewIcon sx={{ fontSize: isPhone ? '1rem' : '1.15rem' }} />
-                Preview
+                {!isPhone && 'Preview'}
               </ToggleButton>
             </ToggleButtonGroup>
             {!isPhone && !!handleOpenSearchDialog && (
@@ -432,15 +435,17 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({
               </TooltipStyled>
             )}
 
-            <Divider
-              orientation="vertical"
-              flexItem
-              sx={{
-                mr: isPhone ? 1 : 2,
-                height: isPhone ? '20px' : '24px',
-                alignSelf: 'center',
-              }}
-            />
+            {!isPhone && (
+              <Divider
+                orientation="vertical"
+                flexItem
+                sx={{
+                  mr: 2,
+                  height: '24px',
+                  alignSelf: 'center',
+                }}
+              />
+            )}
 
             {/* Advanced Features Menu */}
             <Menu

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/EditorToolbar.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/EditorToolbar.tsx
@@ -20,7 +20,6 @@ import {
 import MenuIcon from '@mui/icons-material/Menu'
 import EditIcon from '@mui/icons-material/Edit'
 import PreviewIcon from '@mui/icons-material/Preview'
-import ViewColumnIcon from '@mui/icons-material/ViewColumn'
 import SettingsIcon from '@mui/icons-material/Settings'
 import SaveIcon from '@mui/icons-material/Save'
 import FolderOpenIcon from '@mui/icons-material/FolderOpen'
@@ -288,12 +287,6 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({
                 },
               }}
             >
-              <ToggleButton value="both" aria-label="Both view">
-                <ViewColumnIcon
-                  sx={{ fontSize: isPhone ? '1rem' : '1.15rem' }}
-                />
-                {!isPhone && 'Both'}
-              </ToggleButton>
               <ToggleButton value="edit" aria-label="Edit view">
                 <EditIcon sx={{ fontSize: isPhone ? '1rem' : '1.15rem' }} />
                 {!isPhone && 'Edit'}

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/EditorToolbar.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/EditorToolbar.tsx
@@ -20,6 +20,7 @@ import {
 import MenuIcon from '@mui/icons-material/Menu'
 import EditIcon from '@mui/icons-material/Edit'
 import PreviewIcon from '@mui/icons-material/Preview'
+import ViewColumnIcon from '@mui/icons-material/ViewColumn'
 import SettingsIcon from '@mui/icons-material/Settings'
 import SaveIcon from '@mui/icons-material/Save'
 import FolderOpenIcon from '@mui/icons-material/FolderOpen'
@@ -288,6 +289,12 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({
                 },
               }}
             >
+              {!isPhone && (
+                <ToggleButton value="both" aria-label="Both view">
+                  <ViewColumnIcon sx={{ fontSize: '1.15rem' }} />
+                  Both
+                </ToggleButton>
+              )}
               <ToggleButton value="edit" aria-label="Edit view">
                 <EditIcon sx={{ fontSize: isPhone ? '1rem' : '1.15rem' }} />
                 {!isPhone && 'Edit'}

--- a/apps/aquamesh/src/components/WidgetEditor/components/preview/ComponentPreview.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/preview/ComponentPreview.tsx
@@ -69,6 +69,8 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
   const isActiveContainer = activeContainerId === component.id
   const isContainer = ['FieldSet', 'FlexBox', 'GridBox'].includes(component.type)
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'))
+  const actionButtonSize = isPhone ? 32 : 28
+  const actionIconSize = isPhone ? '1.15rem' : '1.3rem'
 
   // Get the component icon for display
   const ComponentIcon = getComponentIcon(component.type) as IconType
@@ -130,7 +132,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
         const legendColor = useCustomLegendColor ? (component.props.legendColor as string || '#00C49A') : '#00C49A';
         const iconPosition = component.props.iconPosition as string || 'start';
         const animated = component.props.animated !== false;
-        
+
         return (
           <Box
             sx={{
@@ -149,9 +151,9 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
             onDrop={(e) => handleContainerDrop(e, component.id)}
           >
             {/* Legend */}
-            <Box sx={{ 
-              position: 'absolute', 
-              top: -10, 
+            <Box sx={{
+              position: 'absolute',
+              top: -10,
               left: 10,
               bgcolor: 'background.paper',
               px: 1,
@@ -159,34 +161,34 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
               alignItems: 'center'
             }}>
               {iconPosition === 'start' && (
-                <Box 
-                  component="span" 
-                  sx={{ 
-                    cursor: 'pointer', 
+                <Box
+                  component="span"
+                  sx={{
+                    cursor: 'pointer',
                     color: legendColor,
                     display: 'inline-flex',
                     alignItems: 'center'
                   }}
-                  onClick={(e) => { 
-                    e.stopPropagation(); 
+                  onClick={(e) => {
+                    e.stopPropagation();
                     if (onToggleCollapse) {
-                      onToggleCollapse(component.id); 
+                      onToggleCollapse(component.id);
                     }
                   }}
                 >
                   {isCollapsed ? <KeyboardArrowDownIcon fontSize="small" /> : <KeyboardArrowUpIcon fontSize="small" />}
                 </Box>
               )}
-              
-              <Typography 
-                variant="subtitle2" 
-                sx={{ 
+
+              <Typography
+                variant="subtitle2"
+                sx={{
                   color: legendColor,
                   fontWeight: 'bold',
                   mx: 0.5,
                   cursor: 'pointer'
                 }}
-                onClick={(e) => { 
+                onClick={(e) => {
                   e.stopPropagation();
                   if (onToggleCollapse) {
                     onToggleCollapse(component.id);
@@ -195,20 +197,20 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
               >
                 {component.props.legend as string || 'Field Set'}
               </Typography>
-              
+
               {iconPosition === 'end' && (
-                <Box 
-                  component="span" 
-                  sx={{ 
-                    cursor: 'pointer', 
+                <Box
+                  component="span"
+                  sx={{
+                    cursor: 'pointer',
                     color: legendColor,
                     display: 'inline-flex',
                     alignItems: 'center'
                   }}
-                  onClick={(e) => { 
-                    e.stopPropagation(); 
+                  onClick={(e) => {
+                    e.stopPropagation();
                     if (onToggleCollapse) {
-                      onToggleCollapse(component.id); 
+                      onToggleCollapse(component.id);
                     }
                   }}
                 >
@@ -216,7 +218,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
                 </Box>
               )}
             </Box>
-            
+
             {/* Content area */}
             <Collapse in={!isCollapsed} timeout={animated ? 300 : 0}>
               {component.children && component.children.length > 0 ? (
@@ -328,14 +330,14 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
                   borderColor: component.props.customColor as string,
                   color: customTextColor ?? (component.props.variant === 'contained' ? '#fff' : component.props.customColor as string),
                   '&:hover': {
-                    backgroundColor: component.props.variant === 'contained' 
-                      ? component.props.customHoverColor || component.props.customColor 
+                    backgroundColor: component.props.variant === 'contained'
+                      ? component.props.customHoverColor || component.props.customColor
                       : 'rgba(25, 118, 210, 0.04)',
                     borderColor: component.props.customHoverColor || component.props.customColor
                   }
                 } : {}),
-                ...(component.props.clickAction === 'openUrl' ? { 
-                  '&::after': { 
+                ...(component.props.clickAction === 'openUrl' ? {
+                  '&::after': {
                     content: '""',
                     display: 'inline-block',
                     width: '1em',
@@ -344,7 +346,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
                     backgroundImage: 'url("data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 24 24\'%3E%3Cpath d=\'M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z\'/%3E%3C/svg%3E")',
                     backgroundSize: 'contain',
                     verticalAlign: 'middle',
-                  } 
+                  }
                 } : {})
               }}
               startIcon={component.props.showStartIcon ? (() => {
@@ -438,7 +440,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
         const padding = (component.props.padding as number) || 1;
         const useCustomColor = Boolean(component.props.useCustomColor);
         const backgroundColor = useCustomColor ? (component.props.backgroundColor as string || 'transparent') : 'transparent';
-        
+
         return (
           <Box
             sx={{
@@ -487,9 +489,9 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
                 />
               ))
             ) : (
-              <Box sx={{ 
-                width: '100%', 
-                textAlign: 'center', 
+              <Box sx={{
+                width: '100%',
+                textAlign: 'center',
                 color: 'text.secondary',
                 display: 'flex',
                 justifyContent: 'center',
@@ -509,7 +511,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
         const useCustomColor = Boolean(component.props.useCustomColor);
         const backgroundColor = useCustomColor ? (component.props.backgroundColor as string) : 'transparent';
         const borderColor = useCustomColor ? (component.props.borderColor as string) : '#e0e0e0';
-        
+
         return (
           <Box
             sx={{
@@ -563,13 +565,13 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
                 </Box>
               ))
             ) : (
-              <Box sx={{ 
-                width: '100%', 
+              <Box sx={{
+                width: '100%',
                 height: '100%',
                 display: 'flex',
                 justifyContent: 'center',
                 alignItems: 'center',
-                textAlign: 'center', 
+                textAlign: 'center',
                 color: 'text.secondary',
                 gridColumn: `span ${columns}`,
                 minHeight: '40px'
@@ -583,7 +585,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
       case 'Chart': {
         const chartType = component.props.chartType as string || 'pie'
         const title = component.props.title as string || ''
-        
+
         // Parse data for the preview from the actual component data
         let chartData: {
           labels: string[]
@@ -596,7 +598,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
           labels: [],
           datasets: []
         }
-        
+
         try {
           const dataString = component.props.data as string || '{}'
           if (dataString.trim().startsWith('<')) {
@@ -688,23 +690,23 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
   }
 
   return (
-    <Paper 
+    <Paper
       elevation={editMode ? 1 : 0}
-      sx={{ 
-        p: editMode ? (isPhone ? 1 : 2) : 0, 
+      sx={{
+        p: editMode ? (isPhone ? 1 : 2) : 0,
         mb: editMode ? (isPhone ? 1 : 2) : (isPhone ? 0.5 : 1),
         position: 'relative',
         borderRadius: 1,
-        bgcolor: isActiveContainer 
-          ? 'rgba(0, 188, 162, 0.1)' 
-          : isCurrentTarget 
-            ? 'rgba(25, 118, 210, 0.05)' 
+        bgcolor: isActiveContainer
+          ? 'rgba(0, 188, 162, 0.1)'
+          : isCurrentTarget
+            ? 'rgba(25, 118, 210, 0.05)'
             : (isHidden && editMode ? 'rgba(0, 0, 0, 0.3)' : (editMode ? 'background.paper' : 'transparent')),
         border: isActiveContainer
           ? '2px solid #00C49A'
-          : (isCurrentTarget 
-              ? '1px dashed #1976d2' 
-              : editMode 
+          : (isCurrentTarget
+              ? '1px dashed #1976d2'
+              : editMode
                 ? (isHidden ? '1px solid rgba(255, 0, 0, 0.4)' : '1px solid rgba(255, 255, 255, 0.1)')
                 : 'none'),
         opacity: isHidden && editMode ? 0.5 : 1,
@@ -721,36 +723,38 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
     >
       {/* Render the component controls in edit mode */}
       {editMode && (
-        <Box 
-          sx={{ 
-            position: 'absolute', 
-            top: isPhone ? 2 : 4, 
-            right: isPhone ? 2 : 4, 
-            display: 'flex', 
+        <Box
+          sx={{
+            position: 'absolute',
+            top: isPhone ? 2 : 4,
+            right: isPhone ? 2 : 4,
+            display: 'flex',
             zIndex: 10,
             bgcolor: 'background.paper',
             borderRadius: 1,
             boxShadow: 1,
             '& .MuiIconButton-root': {
-              padding: isPhone ? '2px' : '4px',
-              fontSize: isPhone ? '0.75rem' : '1.3rem'
+              padding: isPhone ? '6px' : '4px',
+              minWidth: actionButtonSize,
+              minHeight: actionButtonSize,
+              fontSize: actionIconSize
             }
           }}
         >
           {/* Visibility toggle button */}
           <TooltipStyled title={isHidden ? "Show component" : "Hide component"}>
-            <IconButton 
-              size="small" 
+            <IconButton
+              size="small"
               onClick={() => onToggleVisibility && onToggleVisibility(component.id)}
               sx={{ color: isHidden ? 'error.light' : 'success.light' }}
             >
-              {isHidden ? 
-                <VisibilityOffIcon fontSize="small" sx={{ fontSize: isPhone ? '0.875rem' : '1.3rem' }} /> : 
-                <VisibilityIcon fontSize="small" sx={{ fontSize: isPhone ? '0.875rem' : '1.3rem' }} />
+              {isHidden ?
+                <VisibilityOffIcon fontSize="small" sx={{ fontSize: actionIconSize }} /> :
+                <VisibilityIcon fontSize="small" sx={{ fontSize: actionIconSize }} />
               }
             </IconButton>
           </TooltipStyled>
-          
+
           {/* If this is a container component, add a button to select it as the active target for mobile */}
           {isContainer && onSelectContainer && (
             <TooltipStyled title={isActiveContainer ? "Active target container" : "Make this the active target container"}>
@@ -763,50 +767,50 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
                     onSelectContainer(component.id)
                   }
                 }}
-                sx={{ 
+                sx={{
                   color: isActiveContainer ? 'success.main' : 'info.main',
                   bgcolor: isActiveContainer ? 'rgba(0, 188, 162, 0.1)' : 'transparent'
                 }}
               >
-                <TargetIcon fontSize="small" sx={{ fontSize: isPhone ? '0.875rem' : '1.3rem' }} />
+                <TargetIcon fontSize="small" sx={{ fontSize: actionIconSize }} />
               </IconButton>
             </TooltipStyled>
           )}
-          
-          <IconButton 
-            size="small" 
+
+          <IconButton
+            size="small"
             onClick={() => onEdit(component.id)}
             sx={{ color: 'info.light' }}
           >
-            <EditIcon fontSize="small" sx={{ fontSize: isPhone ? '0.875rem' : '1.3rem' }} />
+            <EditIcon fontSize="small" sx={{ fontSize: actionIconSize }} />
           </IconButton>
-          
+
           {!isFirst && (
-            <IconButton 
-              size="small" 
+            <IconButton
+              size="small"
               onClick={() => onMoveUp(component.id)}
               sx={{ color: 'warning.light' }}
             >
-              <KeyboardArrowUpIcon fontSize="small" sx={{ fontSize: isPhone ? '0.875rem' : '1.3rem' }} />
+              <KeyboardArrowUpIcon fontSize="small" sx={{ fontSize: actionIconSize }} />
             </IconButton>
           )}
-          
+
           {!isLast && (
-            <IconButton 
-              size="small" 
+            <IconButton
+              size="small"
               onClick={() => onMoveDown(component.id)}
               sx={{ color: 'warning.light' }}
             >
-              <KeyboardArrowDownIcon fontSize="small" sx={{ fontSize: isPhone ? '0.875rem' : '1.3rem' }} />
+              <KeyboardArrowDownIcon fontSize="small" sx={{ fontSize: actionIconSize }} />
             </IconButton>
           )}
-          
-          <IconButton 
-            size="small" 
+
+          <IconButton
+            size="small"
             onClick={() => onDelete(component.id)}
             sx={{ color: 'error.main' }}
           >
-            <DeleteIcon fontSize="small" sx={{ fontSize: isPhone ? '0.875rem' : '1.3rem' }} />
+            <DeleteIcon fontSize="small" sx={{ fontSize: actionIconSize }} />
           </IconButton>
         </Box>
       )}
@@ -815,19 +819,19 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
       {editMode && (
         <Box sx={{ display: 'flex', alignItems: 'center', mb: isPhone ? 0.5 : 1 }}>
           {ComponentIcon && (
-            <Box 
-              component={ComponentIcon} 
-              sx={{ 
-                mr: isPhone ? 0.5 : 1, 
-                opacity: 0.7, 
-                fontSize: isPhone ? '0.75rem' : '1.3rem' 
-              }} 
+            <Box
+              component={ComponentIcon}
+              sx={{
+                mr: isPhone ? 0.5 : 1,
+                opacity: 0.7,
+                fontSize: isPhone ? '0.75rem' : '1.3rem'
+              }}
             />
           )}
-          <Typography 
-            variant="caption" 
-            sx={{ 
-              color: 'text.secondary', 
+          <Typography
+            variant="caption"
+            sx={{
+              color: 'text.secondary',
               fontFamily: 'monospace',
               fontSize: isPhone ? '0.65rem' : undefined
             }}
@@ -845,4 +849,4 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
   )
 }
 
-export default ComponentPreview 
+export default ComponentPreview

--- a/apps/aquamesh/src/components/WidgetEditor/hooks/useWidgetEditor.ts
+++ b/apps/aquamesh/src/components/WidgetEditor/hooks/useWidgetEditor.ts
@@ -48,7 +48,7 @@ export const useWidgetEditor = () => {
     name: 'New Widget',
     components: [],
   })
-  const [viewMode, setViewMode] = useState<WidgetEditorViewMode>('edit')
+  const [viewMode, setViewMode] = useState<WidgetEditorViewMode>('both')
   const editMode = viewMode !== 'preview'
   const setEditMode = React.useCallback((nextEditMode: boolean) => {
     setViewMode(nextEditMode ? 'edit' : 'preview')

--- a/apps/aquamesh/src/components/WidgetEditor/hooks/useWidgetEditor.ts
+++ b/apps/aquamesh/src/components/WidgetEditor/hooks/useWidgetEditor.ts
@@ -48,7 +48,7 @@ export const useWidgetEditor = () => {
     name: 'New Widget',
     components: [],
   })
-  const [viewMode, setViewMode] = useState<WidgetEditorViewMode>('both')
+  const [viewMode, setViewMode] = useState<WidgetEditorViewMode>('edit')
   const editMode = viewMode !== 'preview'
   const setEditMode = React.useCallback((nextEditMode: boolean) => {
     setViewMode(nextEditMode ? 'edit' : 'preview')
@@ -91,7 +91,7 @@ export const useWidgetEditor = () => {
   const [showSettingsModal, setShowSettingsModal] = useState(false)
   const [showTooltips, setShowTooltips] = useState<boolean>(() => {
     const savedValue = localStorage.getItem('widget-editor-show-tooltips')
-    return savedValue ? JSON.parse(savedValue) : true
+    return savedValue ? JSON.parse(savedValue) : false
   })
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState<boolean>(
     () => {
@@ -111,7 +111,7 @@ export const useWidgetEditor = () => {
   const [showComponentPaletteHelp, setShowComponentPaletteHelp] =
     useState<boolean>(() => {
       const savedValue = localStorage.getItem('widget-editor-show-palette-help')
-      return savedValue ? JSON.parse(savedValue) : true
+      return savedValue ? JSON.parse(savedValue) : false
     })
 
   // Dashboard deletion confirmation setting

--- a/apps/aquamesh/src/components/topnavbar/TopNavBar.tsx
+++ b/apps/aquamesh/src/components/topnavbar/TopNavBar.tsx
@@ -72,9 +72,9 @@ const ButtonWithLabel: React.FC<ButtonWithLabelProps> = ({
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        minWidth: '48px',
-        mx: 0.5,
-        px: 1,
+        minWidth: '44px',
+        mx: 0.25,
+        px: 0.5,
         ...sx,
       }}
       {...props}
@@ -191,34 +191,39 @@ const TopNavBar: React.FC<TopNavBarProps> = () => {
           height: isPhone ? '72px' : '64px',
         }}
       >
-        <Toolbar sx={{ height: isPhone ? '72px' : '64px' }}>
+        <Toolbar
+          sx={{
+            height: isPhone ? '72px' : '64px',
+            px: isPhone ? 0.5 : 2,
+            gap: isPhone ? 0.25 : 0,
+          }}
+        >
           {/* Logo and Brand */}
-          {!isPhone && (
-            <Button
-              variant="text"
-              onClick={() => navigate('/')}
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                fontWeight: isDesktop ? 'bold' : 'normal',
-                mr: isDesktop ? 4 : 1,
-                color: 'foreground.contrastPrimary',
-                textTransform: 'none',
-                minWidth: 'auto',
-                px: 0,
-              }}
-            >
-              <Logo
-                height="32px"
-                width="32px"
-                style={{ marginRight: isDesktop ? '12px' : '0' }}
-              />
-              {isDesktop && 'AquaMesh'}
-            </Button>
-          )}
+          <Button
+            variant="text"
+            onClick={() => navigate('/')}
+            aria-label="Go to AquaMesh home and tutorial"
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              fontWeight: isDesktop ? 'bold' : 'normal',
+              mr: isPhone ? 0.25 : isDesktop ? 4 : 1,
+              color: 'foreground.contrastPrimary',
+              textTransform: 'none',
+              minWidth: 'auto',
+              px: isPhone ? 0.5 : 0,
+            }}
+          >
+            <Logo
+              height={isPhone ? '28px' : '32px'}
+              width={isPhone ? '28px' : '32px'}
+              style={{ marginRight: isDesktop ? '12px' : '0' }}
+            />
+            {isDesktop && 'AquaMesh'}
+          </Button>
 
           {/* Main Navigation Items */}
-          <Box sx={{ flexGrow: 1, display: 'flex' }}>
+          <Box sx={{ flexGrow: 1, display: 'flex', minWidth: 0 }}>
             {/* Dashboard Options Menu */}
             {isPhone || isTablet ? (
               <DashboardOptionsMenu />

--- a/apps/aquamesh/src/components/tutorial/WidgetEditorExplanationModal.tsx
+++ b/apps/aquamesh/src/components/tutorial/WidgetEditorExplanationModal.tsx
@@ -129,8 +129,9 @@ const WidgetEditorExplanationModal: React.FC<
         {
           title: 'Add Building Blocks',
           icon: <WidgetsIcon />,
-          content:
-            'Drag text, answer boxes, buttons, charts, and groups from the left panel into your widget.',
+          content: isMobile
+            ? 'Tap the + button on text, answer boxes, buttons, charts, and groups to add them to your widget.'
+            : 'Drag text, answer boxes, buttons, charts, and groups from the left panel into your widget.',
         },
         {
           title: 'Arrange The Canvas',


### PR DESCRIPTION
## Summary
- Restore the AquaMesh logo in the phone top bar so mobile users can return to the landing/tutorial page
- Make the Widget Editor building-block palette full-width on phones, with horizontally scrollable block rows and easier tap-to-add cards
- Rebalance phone editor space by giving the edit canvas more room and reducing preview height in `both` mode
- Compact the phone Widget Editor toolbar so the `both/edit/preview` switch shows icons only and the save button stays reachable

## Verification
- `git diff --check`
- `npm --workspace aquamesh run build` ✅ completed with existing warnings about missing `./.env.production`, outdated Browserslist data, Sass deprecations, and asset size
