### PR TITLE
Refine dashboard onboarding on mobile

### DIFF
--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -14,8 +14,6 @@ import {
   Chip,
   Paper,
   Stack,
-  useMediaQuery,
-  useTheme,
 } from '@mui/material'
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs'
 import TooltipStyled from '../TooltipStyled'
@@ -61,20 +59,6 @@ const hasPlacedSavedWidget = (layout?: DashboardLayout): boolean => {
   }
 
   return Boolean(layout.children?.some((child) => hasPlacedSavedWidget(child)))
-}
-
-const countPlacedWidgets = (layout?: DashboardLayout): number => {
-  if (!layout) {
-    return 0
-  }
-
-  const current = layout.component ? 1 : 0
-  const children = layout.children?.reduce(
-    (total, child) => total + countPlacedWidgets(child),
-    0,
-  )
-
-  return current + (children || 0)
 }
 
 const countWidgetPanels = (layout?: DashboardLayout): number => {
@@ -264,9 +248,7 @@ const DashboardEmptyState = ({
 interface DashboardOnboardingCoachProps {
   step: Exclude<DashboardOnboardingStep, 'done'>
   hasUnsavedChanges: boolean
-  hasMultipleWidgets: boolean
   hasSplitDashboard: boolean
-  isPhone: boolean
   onNext: () => void
   onDone: () => void
 }
@@ -274,9 +256,7 @@ interface DashboardOnboardingCoachProps {
 const DashboardOnboardingCoach = ({
   step,
   hasUnsavedChanges,
-  hasMultipleWidgets,
   hasSplitDashboard,
-  isPhone,
   onNext,
   onDone,
 }: DashboardOnboardingCoachProps) => {
@@ -288,7 +268,8 @@ const DashboardOnboardingCoach = ({
       elevation={6}
       sx={{
         position: 'absolute',
-        top: { xs: 8, sm: 12 },
+        top: { xs: 'auto', sm: 12 },
+        bottom: { xs: 8, sm: 'auto' },
         right: { xs: 8, sm: 12 },
         left: { xs: 8, sm: 'auto' },
         zIndex: 10,
@@ -312,11 +293,9 @@ const DashboardOnboardingCoach = ({
           sx={{ color: 'rgba(255, 255, 255, 0.84)', lineHeight: 1.45 }}
         >
           {isLayoutStep
-            ? hasMultipleWidgets
-              ? 'Drag one widget tab to another side of the dashboard. As soon as the dashboard splits, you can save it.'
-              : `Open ${isPhone ? 'Add' : 'Add Widget'} and add one more saved widget, then drag one tab to another side of the dashboard.`
+            ? 'Drag the widget tab to another side of the dashboard. As soon as the dashboard splits, you can save it.'
             : hasUnsavedChanges
-              ? 'Click the dashboard tab at the top, then click the small save button on that tab to save the whole multi-widget dashboard.'
+              ? 'Save the dashboard using the disk icon on the Dashboard tab.'
               : 'Nice — this dashboard is saved. You can reopen it later from your saved dashboards.'}
         </Typography>
         <Stack direction="row" spacing={1} justifyContent="flex-end">
@@ -330,9 +309,7 @@ const DashboardOnboardingCoach = ({
             >
               {hasSplitDashboard
                 ? 'Next: save dashboard'
-                : hasMultipleWidgets
-                  ? 'Drag a tab to split first'
-                  : 'Add another widget first'}
+                : 'Split the dashboard first'}
             </Button>
           ) : (
             <Button
@@ -351,8 +328,6 @@ const DashboardOnboardingCoach = ({
 }
 
 const Dashboards = () => {
-  const theme = useTheme()
-  const isPhone = useMediaQuery(theme.breakpoints.down('sm'))
   const {
     openDashboards,
     selectedDashboard,
@@ -667,7 +642,6 @@ const Dashboards = () => {
             index === selectedDashboard &&
             dashboardOnboardingStep !== 'done' &&
             hasPlacedSavedWidget(dashboard.layout)
-          const hasMultipleWidgets = countPlacedWidgets(dashboard.layout) > 1
           const hasSplitDashboard = countWidgetPanels(dashboard.layout) > 1
 
           return (
@@ -685,9 +659,7 @@ const Dashboards = () => {
                     <DashboardOnboardingCoach
                       step={dashboardOnboardingStep}
                       hasUnsavedChanges={Boolean(hasChanges[index])}
-                      hasMultipleWidgets={hasMultipleWidgets}
                       hasSplitDashboard={hasSplitDashboard}
-                      isPhone={isPhone}
                       onNext={advanceDashboardOnboarding}
                       onDone={completeDashboardOnboarding}
                     />

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -312,7 +312,9 @@ const DashboardOnboardingCoach = ({
           sx={{ color: 'rgba(255, 255, 255, 0.84)', lineHeight: 1.45 }}
         >
           {isLayoutStep
-            ? `To build a multi-widget dashboard, ${hasMultipleWidgets ? 'drag a widget tab to another side of the dashboard' : `open ${isPhone ? 'Add' : 'Add Widget'} and add another saved widget, then drag a widget tab to another side of the dashboard`}. Use the thin separator line between widgets to make one bigger or smaller.`
+            ? hasMultipleWidgets
+              ? 'Drag one widget tab to another side of the dashboard. As soon as the dashboard splits, you can save it.'
+              : `Open ${isPhone ? 'Add' : 'Add Widget'} and add one more saved widget, then drag one tab to another side of the dashboard.`
             : hasUnsavedChanges
               ? 'Click the dashboard tab at the top, then click the small save button on that tab to save the whole multi-widget dashboard.'
               : 'Nice — this dashboard is saved. You can reopen it later from your saved dashboards.'}

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -45,9 +45,10 @@ interface SavedDashboard {
   updatedAt: string
 }
 
-type DashboardOnboardingStep = 'layout' | 'save' | 'done'
+type DashboardOnboardingStep = 'layout' | 'save' | 'complete' | 'done'
 
 const DASHBOARD_ONBOARDING_KEY = 'aquamesh-dashboard-onboarding-step-v2'
+const WIDGET_EDITOR_ONBOARDING_KEY = 'aquamesh-widget-editor-onboarding-done'
 
 const hasPlacedSavedWidget = (layout?: DashboardLayout): boolean => {
   if (!layout) {
@@ -231,15 +232,18 @@ const DashboardEmptyState = ({
 interface DashboardOnboardingCoachProps {
   step: Exclude<DashboardOnboardingStep, 'done'>
   hasUnsavedChanges: boolean
-  onDone: () => void
+  onDismiss: () => void
+  onGotIt: () => void
 }
 
 const DashboardOnboardingCoach = ({
   step,
   hasUnsavedChanges,
-  onDone,
+  onDismiss,
+  onGotIt,
 }: DashboardOnboardingCoachProps) => {
   const isLayoutStep = step === 'layout'
+  const isCompleteStep = step === 'complete'
 
   return (
     <Paper
@@ -262,27 +266,45 @@ const DashboardOnboardingCoach = ({
     >
       <Stack spacing={1}>
         <Typography variant="caption" sx={{ fontWeight: 800, opacity: 0.8 }}>
-          Step {isLayoutStep ? '4' : '5'}
+          Step {isLayoutStep ? '4' : isCompleteStep ? '6' : '5'}
         </Typography>
         <Typography variant="subtitle2" sx={{ fontWeight: 800 }}>
-          {isLayoutStep ? 'Shape your dashboard' : 'Save this dashboard'}
+          {isLayoutStep
+            ? 'Shape your dashboard'
+            : isCompleteStep
+              ? 'Congratulations 🎉'
+              : 'Save this dashboard'}
         </Typography>
         <Typography
           variant="body2"
           sx={{ color: 'rgba(255, 255, 255, 0.84)', lineHeight: 1.45 }}
         >
-          {isLayoutStep
-            ? 'Drag the widget tab to a new spot in the dashboard. Step 5 appears after you move it.'
-            : hasUnsavedChanges
-              ? 'Save the dashboard using the disk icon on the Dashboard tab.'
-              : 'Nice — this dashboard is saved. You can reopen it later from your saved dashboards.'}
+          {isCompleteStep
+            ? 'You finished the AquaMesh onboarding. You can keep exploring or hide these steps for next time.'
+            : isLayoutStep
+              ? 'Drag the widget tab to a new spot in the dashboard. Step 5 appears after you move it.'
+              : hasUnsavedChanges
+                ? 'Save the dashboard using the disk icon on the Dashboard tab.'
+                : 'Nice — this dashboard is saved. You can reopen it later from your saved dashboards.'}
         </Typography>
-        {!isLayoutStep && (
+        {isCompleteStep && (
           <Stack direction="row" spacing={1} justifyContent="flex-end">
             <Button
               size="small"
+              variant="outlined"
+              onClick={onDismiss}
+              sx={{
+                textTransform: 'none',
+                color: 'primary.contrastText',
+                borderColor: 'rgba(255, 255, 255, 0.6)',
+              }}
+            >
+              Dismiss
+            </Button>
+            <Button
+              size="small"
               variant="contained"
-              onClick={onDone}
+              onClick={onGotIt}
               sx={{ textTransform: 'none' }}
             >
               Got it
@@ -336,7 +358,12 @@ const Dashboards = () => {
     setDashboardOnboardingStep('done')
     if (typeof window !== 'undefined') {
       window.localStorage.setItem(DASHBOARD_ONBOARDING_KEY, 'done')
+      window.localStorage.setItem(WIDGET_EDITOR_ONBOARDING_KEY, 'true')
     }
+  }
+
+  const dismissDashboardOnboarding = () => {
+    setDashboardOnboardingStep('done')
   }
 
   const advanceDashboardOnboarding = () => {
@@ -381,6 +408,21 @@ const Dashboards = () => {
     const currentLayout = currentDashboard?.layout
     const hasWidget = hasPlacedSavedWidget(currentLayout)
 
+    const currentChangeStateKnown = Object.prototype.hasOwnProperty.call(
+      hasChanges,
+      selectedDashboard,
+    )
+
+    if (
+      dashboardOnboardingStep === 'save' &&
+      hasWidget &&
+      currentChangeStateKnown &&
+      !hasChanges[selectedDashboard]
+    ) {
+      setDashboardOnboardingStep('complete')
+      return
+    }
+
     if (dashboardOnboardingStep !== 'layout' || !hasWidget) {
       dashboardOnboardingLayoutBaseline.current = null
       return
@@ -399,7 +441,7 @@ const Dashboards = () => {
       dashboardOnboardingLayoutBaseline.current = null
       advanceDashboardOnboarding()
     }
-  }, [dashboardOnboardingStep, openDashboards, selectedDashboard])
+  }, [dashboardOnboardingStep, hasChanges, openDashboards, selectedDashboard])
 
   const handleSaveDialogOpen = (index: number) => {
     const currentDashboard = openDashboards[index]
@@ -632,7 +674,8 @@ const Dashboards = () => {
                     <DashboardOnboardingCoach
                       step={dashboardOnboardingStep}
                       hasUnsavedChanges={Boolean(hasChanges[index])}
-                      onDone={completeDashboardOnboarding}
+                      onDismiss={dismissDashboardOnboarding}
+                      onGotIt={completeDashboardOnboarding}
                     />
                   )}
                   {isEmptyDashboard ? (

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -14,6 +14,8 @@ import {
   Chip,
   Paper,
   Stack,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material'
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs'
 import TooltipStyled from '../TooltipStyled'
@@ -43,6 +45,53 @@ interface SavedDashboard {
   isPublic?: boolean
   createdAt: string
   updatedAt: string
+}
+
+type DashboardOnboardingStep = 'layout' | 'save' | 'done'
+
+const DASHBOARD_ONBOARDING_KEY = 'aquamesh-dashboard-onboarding-step'
+
+const hasPlacedSavedWidget = (layout?: DashboardLayout): boolean => {
+  if (!layout) {
+    return false
+  }
+
+  if (layout.component === 'CustomWidget') {
+    return true
+  }
+
+  return Boolean(layout.children?.some((child) => hasPlacedSavedWidget(child)))
+}
+
+const countPlacedWidgets = (layout?: DashboardLayout): number => {
+  if (!layout) {
+    return 0
+  }
+
+  const current = layout.component ? 1 : 0
+  const children = layout.children?.reduce(
+    (total, child) => total + countPlacedWidgets(child),
+    0,
+  )
+
+  return current + (children || 0)
+}
+
+const countWidgetPanels = (layout?: DashboardLayout): number => {
+  if (!layout) {
+    return 0
+  }
+
+  if (layout.type === 'tabset') {
+    return hasPlacedSavedWidget(layout) ? 1 : 0
+  }
+
+  return (
+    layout.children?.reduce(
+      (total, child) => total + countWidgetPanels(child),
+      0,
+    ) || 0
+  )
 }
 
 // Dashboard Storage utilities
@@ -212,7 +261,96 @@ const DashboardEmptyState = ({
   </Box>
 )
 
+interface DashboardOnboardingCoachProps {
+  step: Exclude<DashboardOnboardingStep, 'done'>
+  hasUnsavedChanges: boolean
+  hasMultipleWidgets: boolean
+  hasSplitDashboard: boolean
+  isPhone: boolean
+  onNext: () => void
+  onDone: () => void
+}
+
+const DashboardOnboardingCoach = ({
+  step,
+  hasUnsavedChanges,
+  hasMultipleWidgets,
+  hasSplitDashboard,
+  isPhone,
+  onNext,
+  onDone,
+}: DashboardOnboardingCoachProps) => {
+  const isLayoutStep = step === 'layout'
+
+  return (
+    <Paper
+      data-testid={`dashboard-onboarding-coach-${step}`}
+      elevation={6}
+      sx={{
+        position: 'absolute',
+        top: { xs: 8, sm: 12 },
+        right: { xs: 8, sm: 12 },
+        left: { xs: 8, sm: 'auto' },
+        zIndex: 10,
+        width: { xs: 'auto', sm: 420 },
+        p: { xs: 1.25, sm: 1.5 },
+        borderRadius: 2,
+        border: '1px solid rgba(0, 188, 162, 0.36)',
+        bgcolor: 'rgba(0, 66, 50, 0.96)',
+        color: 'primary.contrastText',
+      }}
+    >
+      <Stack spacing={1}>
+        <Typography variant="caption" sx={{ fontWeight: 800, opacity: 0.8 }}>
+          Step {isLayoutStep ? '4' : '5'}
+        </Typography>
+        <Typography variant="subtitle2" sx={{ fontWeight: 800 }}>
+          {isLayoutStep ? 'Shape your dashboard' : 'Save this dashboard'}
+        </Typography>
+        <Typography
+          variant="body2"
+          sx={{ color: 'rgba(255, 255, 255, 0.84)', lineHeight: 1.45 }}
+        >
+          {isLayoutStep
+            ? `To build a multi-widget dashboard, ${hasMultipleWidgets ? 'drag a widget tab to another side of the dashboard' : `open ${isPhone ? 'Add' : 'Add Widget'} and add another saved widget, then drag a widget tab to another side of the dashboard`}. Use the thin separator line between widgets to make one bigger or smaller.`
+            : hasUnsavedChanges
+              ? 'Click the dashboard tab at the top, then click the small save button on that tab to save the whole multi-widget dashboard.'
+              : 'Nice — this dashboard is saved. You can reopen it later from your saved dashboards.'}
+        </Typography>
+        <Stack direction="row" spacing={1} justifyContent="flex-end">
+          {isLayoutStep ? (
+            <Button
+              size="small"
+              variant="contained"
+              onClick={onNext}
+              disabled={!hasSplitDashboard}
+              sx={{ textTransform: 'none' }}
+            >
+              {hasSplitDashboard
+                ? 'Next: save dashboard'
+                : hasMultipleWidgets
+                  ? 'Drag a tab to split first'
+                  : 'Add another widget first'}
+            </Button>
+          ) : (
+            <Button
+              size="small"
+              variant="contained"
+              onClick={onDone}
+              sx={{ textTransform: 'none' }}
+            >
+              Got it
+            </Button>
+          )}
+        </Stack>
+      </Stack>
+    </Paper>
+  )
+}
+
 const Dashboards = () => {
+  const theme = useTheme()
+  const isPhone = useMediaQuery(theme.breakpoints.down('sm'))
   const {
     openDashboards,
     selectedDashboard,
@@ -232,10 +370,40 @@ const Dashboards = () => {
   const [currentTabIndex, setCurrentTabIndex] = useState<number | null>(null)
   const [hasChanges, setHasChanges] = useState<Record<string, boolean>>({})
   const [isAdmin, setIsAdmin] = useState(false)
+  const [dashboardOnboardingStep, setDashboardOnboardingStep] =
+    useState<DashboardOnboardingStep>(() => {
+      if (typeof window === 'undefined') {
+        return 'layout'
+      }
+
+      const savedStep = window.localStorage.getItem(DASHBOARD_ONBOARDING_KEY)
+      return savedStep === 'save' || savedStep === 'done' ? savedStep : 'layout'
+    })
   const navigate = useNavigate()
   const { openCreateWidget, openOperationsExample, openWidgetMenu } =
     useWorkspaceActions()
   const openQuickGuide = () => navigate('/')
+
+  const completeDashboardOnboarding = () => {
+    setDashboardOnboardingStep('done')
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(DASHBOARD_ONBOARDING_KEY, 'done')
+    }
+  }
+
+  const advanceDashboardOnboarding = () => {
+    setDashboardOnboardingStep('save')
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(DASHBOARD_ONBOARDING_KEY, 'save')
+    }
+  }
+
+  const returnDashboardOnboardingToLayout = () => {
+    setDashboardOnboardingStep('layout')
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(DASHBOARD_ONBOARDING_KEY, 'layout')
+    }
+  }
 
   // Check if user is admin on component mount
   useEffect(() => {
@@ -266,6 +434,29 @@ const Dashboards = () => {
 
     setHasChanges(changes)
   }, [openDashboards])
+
+  useEffect(() => {
+    const currentLayout = openDashboards[selectedDashboard]?.layout
+    const hasSplitLayout = countWidgetPanels(currentLayout) > 1
+
+    if (dashboardOnboardingStep === 'layout' && hasSplitLayout) {
+      advanceDashboardOnboarding()
+      return
+    }
+
+    if (dashboardOnboardingStep === 'save' && !hasSplitLayout) {
+      returnDashboardOnboardingToLayout()
+      return
+    }
+
+    if (dashboardOnboardingStep !== 'save') {
+      return
+    }
+
+    if (hasChanges[selectedDashboard] === false) {
+      completeDashboardOnboarding()
+    }
+  }, [dashboardOnboardingStep, hasChanges, openDashboards, selectedDashboard])
 
   const handleSaveDialogOpen = (index: number) => {
     const currentDashboard = openDashboards[index]
@@ -395,6 +586,8 @@ const Dashboards = () => {
                 {hasChanges[index] && (
                   <TooltipStyled title="Save Dashboard">
                     <IconButton
+                      aria-label={`Save dashboard ${dashboard.name}`}
+                      data-testid={`save-dashboard-${index}`}
                       size="small"
                       onClick={(ev) => {
                         ev.stopPropagation()
@@ -472,10 +665,16 @@ const Dashboards = () => {
             onClick={() => addDashboard()}
           />
         </TabList>
-        {openDashboards.map((dashboard) => {
+        {openDashboards.map((dashboard, index) => {
           const isEmptyDashboard =
             !dashboard.layout?.children ||
             dashboard.layout.children.length === 0
+          const showDashboardOnboarding =
+            index === selectedDashboard &&
+            dashboardOnboardingStep !== 'done' &&
+            hasPlacedSavedWidget(dashboard.layout)
+          const hasMultipleWidgets = countPlacedWidgets(dashboard.layout) > 1
+          const hasSplitDashboard = countWidgetPanels(dashboard.layout) > 1
 
           return (
             <TabPanel key={dashboard.id}>
@@ -488,6 +687,17 @@ const Dashboards = () => {
                 }}
               >
                 <Box sx={{ position: 'relative', flex: '1' }}>
+                  {showDashboardOnboarding && (
+                    <DashboardOnboardingCoach
+                      step={dashboardOnboardingStep}
+                      hasUnsavedChanges={Boolean(hasChanges[index])}
+                      hasMultipleWidgets={hasMultipleWidgets}
+                      hasSplitDashboard={hasSplitDashboard}
+                      isPhone={isPhone}
+                      onNext={advanceDashboardOnboarding}
+                      onDone={completeDashboardOnboarding}
+                    />
+                  )}
                   {isEmptyDashboard ? (
                     <DashboardEmptyState
                       isAdmin={isAdmin}

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -232,14 +232,12 @@ const DashboardEmptyState = ({
 interface DashboardOnboardingCoachProps {
   step: Exclude<DashboardOnboardingStep, 'done'>
   hasUnsavedChanges: boolean
-  onDismiss: () => void
   onGotIt: () => void
 }
 
 const DashboardOnboardingCoach = ({
   step,
   hasUnsavedChanges,
-  onDismiss,
   onGotIt,
 }: DashboardOnboardingCoachProps) => {
   const isLayoutStep = step === 'layout'
@@ -265,9 +263,11 @@ const DashboardOnboardingCoach = ({
       }}
     >
       <Stack spacing={1}>
-        <Typography variant="caption" sx={{ fontWeight: 800, opacity: 0.8 }}>
-          Step {isLayoutStep ? '4' : isCompleteStep ? '6' : '5'}
-        </Typography>
+        {!isCompleteStep && (
+          <Typography variant="caption" sx={{ fontWeight: 800, opacity: 0.8 }}>
+            Step {isLayoutStep ? '4' : '5'}
+          </Typography>
+        )}
         <Typography variant="subtitle2" sx={{ fontWeight: 800 }}>
           {isLayoutStep
             ? 'Shape your dashboard'
@@ -291,23 +291,11 @@ const DashboardOnboardingCoach = ({
           <Stack direction="row" spacing={1} justifyContent="flex-end">
             <Button
               size="small"
-              variant="outlined"
-              onClick={onDismiss}
-              sx={{
-                textTransform: 'none',
-                color: 'primary.contrastText',
-                borderColor: 'rgba(255, 255, 255, 0.6)',
-              }}
-            >
-              Dismiss
-            </Button>
-            <Button
-              size="small"
               variant="contained"
               onClick={onGotIt}
               sx={{ textTransform: 'none' }}
             >
-              Don’t show onboarding again
+              Got it
             </Button>
           </Stack>
         )}
@@ -356,14 +344,13 @@ const Dashboards = () => {
 
   const completeDashboardOnboarding = () => {
     setDashboardOnboardingStep('done')
+  }
+
+  const persistDashboardOnboardingDone = () => {
     if (typeof window !== 'undefined') {
       window.localStorage.setItem(DASHBOARD_ONBOARDING_KEY, 'done')
       window.localStorage.setItem(WIDGET_EDITOR_ONBOARDING_KEY, 'true')
     }
-  }
-
-  const dismissDashboardOnboarding = () => {
-    setDashboardOnboardingStep('done')
   }
 
   const advanceDashboardOnboarding = () => {
@@ -420,6 +407,7 @@ const Dashboards = () => {
       !hasChanges[selectedDashboard]
     ) {
       setDashboardOnboardingStep('complete')
+      persistDashboardOnboardingDone()
       return
     }
 
@@ -674,7 +662,6 @@ const Dashboards = () => {
                     <DashboardOnboardingCoach
                       step={dashboardOnboardingStep}
                       hasUnsavedChanges={Boolean(hasChanges[index])}
-                      onDismiss={dismissDashboardOnboarding}
                       onGotIt={completeDashboardOnboarding}
                     />
                   )}

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -49,7 +49,7 @@ interface SavedDashboard {
 
 type DashboardOnboardingStep = 'layout' | 'save' | 'done'
 
-const DASHBOARD_ONBOARDING_KEY = 'aquamesh-dashboard-onboarding-step'
+const DASHBOARD_ONBOARDING_KEY = 'aquamesh-dashboard-onboarding-step-v2'
 
 const hasPlacedSavedWidget = (layout?: DashboardLayout): boolean => {
   if (!layout) {
@@ -447,14 +447,6 @@ const Dashboards = () => {
     if (dashboardOnboardingStep === 'save' && !hasSplitLayout) {
       returnDashboardOnboardingToLayout()
       return
-    }
-
-    if (dashboardOnboardingStep !== 'save') {
-      return
-    }
-
-    if (hasChanges[selectedDashboard] === false) {
-      completeDashboardOnboarding()
     }
   }, [dashboardOnboardingStep, hasChanges, openDashboards, selectedDashboard])
 

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -255,7 +255,7 @@ const DashboardOnboardingCoach = ({
         bottom: { xs: 8, sm: 'auto' },
         right: { xs: 8, sm: 12 },
         left: { xs: 8, sm: 'auto' },
-        zIndex: 10,
+        zIndex: 1300,
         width: { xs: 'auto', sm: 420 },
         p: { xs: 1.25, sm: 1.5 },
         borderRadius: 2,
@@ -280,9 +280,9 @@ const DashboardOnboardingCoach = ({
           sx={{ color: 'rgba(255, 255, 255, 0.84)', lineHeight: 1.45 }}
         >
           {isCompleteStep
-            ? 'You finished the AquaMesh onboarding. You can keep exploring or hide these steps for next time.'
+            ? 'You finished the AquaMesh onboarding. You can keep exploring the app and creating your own widgets and dashboards.'
             : isLayoutStep
-              ? 'Drag the widget tab to a new spot in the dashboard. Step 5 appears after you move it.'
+              ? 'Drag the widget tab to a new spot in the dashboard.'
               : hasUnsavedChanges
                 ? 'Save the dashboard using the disk icon on the Dashboard tab.'
                 : 'Nice — this dashboard is saved. You can reopen it later from your saved dashboards.'}
@@ -307,7 +307,7 @@ const DashboardOnboardingCoach = ({
               onClick={onGotIt}
               sx={{ textTransform: 'none' }}
             >
-              Got it
+              Don’t show onboarding again
             </Button>
           </Stack>
         )}

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import {
   Box,
   Typography,
@@ -59,23 +59,6 @@ const hasPlacedSavedWidget = (layout?: DashboardLayout): boolean => {
   }
 
   return Boolean(layout.children?.some((child) => hasPlacedSavedWidget(child)))
-}
-
-const countWidgetPanels = (layout?: DashboardLayout): number => {
-  if (!layout) {
-    return 0
-  }
-
-  if (layout.type === 'tabset') {
-    return hasPlacedSavedWidget(layout) ? 1 : 0
-  }
-
-  return (
-    layout.children?.reduce(
-      (total, child) => total + countWidgetPanels(child),
-      0,
-    ) || 0
-  )
 }
 
 // Dashboard Storage utilities
@@ -248,16 +231,12 @@ const DashboardEmptyState = ({
 interface DashboardOnboardingCoachProps {
   step: Exclude<DashboardOnboardingStep, 'done'>
   hasUnsavedChanges: boolean
-  hasSplitDashboard: boolean
-  onNext: () => void
   onDone: () => void
 }
 
 const DashboardOnboardingCoach = ({
   step,
   hasUnsavedChanges,
-  hasSplitDashboard,
-  onNext,
   onDone,
 }: DashboardOnboardingCoachProps) => {
   const isLayoutStep = step === 'layout'
@@ -293,25 +272,13 @@ const DashboardOnboardingCoach = ({
           sx={{ color: 'rgba(255, 255, 255, 0.84)', lineHeight: 1.45 }}
         >
           {isLayoutStep
-            ? 'Drag the widget tab to another side of the dashboard. As soon as the dashboard splits, you can save it.'
+            ? 'Drag the widget tab to a new spot in the dashboard. Step 5 appears after you move it.'
             : hasUnsavedChanges
               ? 'Save the dashboard using the disk icon on the Dashboard tab.'
               : 'Nice — this dashboard is saved. You can reopen it later from your saved dashboards.'}
         </Typography>
-        <Stack direction="row" spacing={1} justifyContent="flex-end">
-          {isLayoutStep ? (
-            <Button
-              size="small"
-              variant="contained"
-              onClick={onNext}
-              disabled={!hasSplitDashboard}
-              sx={{ textTransform: 'none' }}
-            >
-              {hasSplitDashboard
-                ? 'Next: save dashboard'
-                : 'Split the dashboard first'}
-            </Button>
-          ) : (
+        {!isLayoutStep && (
+          <Stack direction="row" spacing={1} justifyContent="flex-end">
             <Button
               size="small"
               variant="contained"
@@ -320,8 +287,8 @@ const DashboardOnboardingCoach = ({
             >
               Got it
             </Button>
-          )}
-        </Stack>
+          </Stack>
+        )}
       </Stack>
     </Paper>
   )
@@ -347,6 +314,10 @@ const Dashboards = () => {
   const [currentTabIndex, setCurrentTabIndex] = useState<number | null>(null)
   const [hasChanges, setHasChanges] = useState<Record<string, boolean>>({})
   const [isAdmin, setIsAdmin] = useState(false)
+  const dashboardOnboardingLayoutBaseline = useRef<{
+    dashboardId: string
+    layoutJson: string
+  } | null>(null)
   const [dashboardOnboardingStep, setDashboardOnboardingStep] =
     useState<DashboardOnboardingStep>(() => {
       if (typeof window === 'undefined') {
@@ -372,13 +343,6 @@ const Dashboards = () => {
     setDashboardOnboardingStep('save')
     if (typeof window !== 'undefined') {
       window.localStorage.setItem(DASHBOARD_ONBOARDING_KEY, 'save')
-    }
-  }
-
-  const returnDashboardOnboardingToLayout = () => {
-    setDashboardOnboardingStep('layout')
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(DASHBOARD_ONBOARDING_KEY, 'layout')
     }
   }
 
@@ -413,19 +377,29 @@ const Dashboards = () => {
   }, [openDashboards])
 
   useEffect(() => {
-    const currentLayout = openDashboards[selectedDashboard]?.layout
-    const hasSplitLayout = countWidgetPanels(currentLayout) > 1
+    const currentDashboard = openDashboards[selectedDashboard]
+    const currentLayout = currentDashboard?.layout
+    const hasWidget = hasPlacedSavedWidget(currentLayout)
 
-    if (dashboardOnboardingStep === 'layout' && hasSplitLayout) {
+    if (dashboardOnboardingStep !== 'layout' || !hasWidget) {
+      dashboardOnboardingLayoutBaseline.current = null
+      return
+    }
+
+    const dashboardId = currentDashboard?.id || String(selectedDashboard)
+    const layoutJson = JSON.stringify(currentLayout || {})
+    const baseline = dashboardOnboardingLayoutBaseline.current
+
+    if (!baseline || baseline.dashboardId !== dashboardId) {
+      dashboardOnboardingLayoutBaseline.current = { dashboardId, layoutJson }
+      return
+    }
+
+    if (baseline.layoutJson !== layoutJson) {
+      dashboardOnboardingLayoutBaseline.current = null
       advanceDashboardOnboarding()
-      return
     }
-
-    if (dashboardOnboardingStep === 'save' && !hasSplitLayout) {
-      returnDashboardOnboardingToLayout()
-      return
-    }
-  }, [dashboardOnboardingStep, hasChanges, openDashboards, selectedDashboard])
+  }, [dashboardOnboardingStep, openDashboards, selectedDashboard])
 
   const handleSaveDialogOpen = (index: number) => {
     const currentDashboard = openDashboards[index]
@@ -642,7 +616,6 @@ const Dashboards = () => {
             index === selectedDashboard &&
             dashboardOnboardingStep !== 'done' &&
             hasPlacedSavedWidget(dashboard.layout)
-          const hasSplitDashboard = countWidgetPanels(dashboard.layout) > 1
 
           return (
             <TabPanel key={dashboard.id}>
@@ -659,8 +632,6 @@ const Dashboards = () => {
                     <DashboardOnboardingCoach
                       step={dashboardOnboardingStep}
                       hasUnsavedChanges={Boolean(hasChanges[index])}
-                      hasSplitDashboard={hasSplitDashboard}
-                      onNext={advanceDashboardOnboarding}
                       onDone={completeDashboardOnboarding}
                     />
                   )}

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -14,6 +14,8 @@ import {
   Chip,
   Paper,
   Stack,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material'
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs'
 import TooltipStyled from '../TooltipStyled'
@@ -232,16 +234,21 @@ const DashboardEmptyState = ({
 interface DashboardOnboardingCoachProps {
   step: Exclude<DashboardOnboardingStep, 'done'>
   hasUnsavedChanges: boolean
+  dashboardName: string
   onGotIt: () => void
 }
 
 const DashboardOnboardingCoach = ({
   step,
   hasUnsavedChanges,
+  dashboardName,
   onGotIt,
 }: DashboardOnboardingCoachProps) => {
+  const theme = useTheme()
+  const isPhone = useMediaQuery(theme.breakpoints.down('sm'))
   const isLayoutStep = step === 'layout'
   const isCompleteStep = step === 'complete'
+  const dashboardMenuName = isPhone ? 'Dash' : 'Dashboards'
 
   return (
     <Paper
@@ -280,7 +287,7 @@ const DashboardOnboardingCoach = ({
           sx={{ color: 'rgba(255, 255, 255, 0.84)', lineHeight: 1.45 }}
         >
           {isCompleteStep
-            ? 'You finished the AquaMesh onboarding. You can keep exploring the app and creating your own widgets and dashboards.'
+            ? `You finished the AquaMesh onboarding. You can keep exploring the app and creating your own widgets and dashboards. You’ll be able to find your saved dashboard “${dashboardName}” inside the ${dashboardMenuName} menu.`
             : isLayoutStep
               ? 'Drag the widget tab to a new spot in the dashboard.'
               : hasUnsavedChanges
@@ -662,6 +669,7 @@ const Dashboards = () => {
                     <DashboardOnboardingCoach
                       step={dashboardOnboardingStep}
                       hasUnsavedChanges={Boolean(hasChanges[index])}
+                      dashboardName={dashboard.name}
                       onGotIt={completeDashboardOnboarding}
                     />
                   )}

--- a/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
@@ -306,20 +306,7 @@ const WidgetEditor: React.FC<{
 
   // Handle saving with a custom name from the dialog
   const handleSaveWidgetWithName = (name: string) => {
-    // Update widget data with the new name
-    setWidgetData((prev) => ({ ...prev, name }))
-
-    // Set a short timeout to allow state update to process
-    setTimeout(() => {
-      // Then call the actual save function
-      handleSaveWidget()
-      // Reset the dialog request flag
-      document.dispatchEvent(
-        new CustomEvent('resetSaveDialogRequested', {
-          detail: { editorId },
-        }),
-      )
-    }, 0)
+    handleSaveWidget(false, name)
   }
 
   // Handle closing component toasts

--- a/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
@@ -19,7 +19,7 @@ import WidgetStorage, { WidgetVersion } from './WidgetStorage'
 import SaveWidgetDialog from './components/dialogs/SaveWidgetDialog'
 import { cloneTemplate } from './constants/templateWidgets'
 
-type OnboardingStep = 'choose' | 'save'
+type OnboardingStep = 'choose' | 'save' | 'place'
 
 const WIDGET_EDITOR_ONBOARDING_KEY = 'aquamesh-widget-editor-onboarding-done'
 
@@ -239,10 +239,10 @@ const WidgetEditor: React.FC<{
       return
     }
 
-    if (widgetData.components.length > 0) {
+    if (widgetData.components.length > 0 && onboardingStep === 'choose') {
       setOnboardingStep('save')
     }
-  }, [onboardingActive, widgetData.components.length])
+  }, [onboardingActive, onboardingStep, widgetData.components.length])
 
   // Listen for loadWidgetInEditor events from widget management
   React.useEffect(() => {
@@ -281,7 +281,9 @@ const WidgetEditor: React.FC<{
 
       // Set the appropriate edit mode first
       if (customProps.initialEditMode !== undefined) {
-        setViewMode(customProps.initialEditMode ? defaultEditViewMode : 'preview')
+        setViewMode(
+          customProps.initialEditMode ? defaultEditViewMode : 'preview',
+        )
       }
 
       // Then load the widget - use a setTimeout to ensure the edit mode is set first
@@ -377,6 +379,24 @@ const WidgetEditor: React.FC<{
     // Otherwise, compare current components to saved
     return savedJson !== currentJson
   }, [widgetData, savedWidgets, isUpdating])
+
+  React.useEffect(() => {
+    if (
+      onboardingActive &&
+      onboardingStep === 'save' &&
+      widgetData.components.length > 0 &&
+      isUpdating &&
+      !hasChanges
+    ) {
+      setOnboardingStep('place')
+    }
+  }, [
+    hasChanges,
+    isUpdating,
+    onboardingActive,
+    onboardingStep,
+    widgetData.components.length,
+  ])
 
   // Check if the current widget (including any loaded preview) is the latest version
   const isLatestVersion = React.useMemo(() => {

--- a/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
@@ -132,7 +132,7 @@ const WidgetEditor: React.FC<{
 
   const [onboardingStep, setOnboardingStep] =
     React.useState<OnboardingStep>('choose')
-  const [onboardingDismissed, setOnboardingDismissed] = React.useState(() => {
+  const [onboardingDismissed] = React.useState(() => {
     if (typeof window === 'undefined') {
       return false
     }
@@ -159,21 +159,6 @@ const WidgetEditor: React.FC<{
       setViewMode('edit')
     }
   }, [isPhone, setViewMode, viewMode])
-
-  const handleSkipOnboarding = React.useCallback(() => {
-    setOnboardingDismissed(true)
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(WIDGET_EDITOR_ONBOARDING_KEY, 'true')
-    }
-  }, [])
-
-  const handleRestartOnboarding = React.useCallback(() => {
-    setOnboardingDismissed(false)
-    setOnboardingStep(widgetData.components.length > 0 ? 'save' : 'choose')
-    if (typeof window !== 'undefined') {
-      window.localStorage.removeItem(WIDGET_EDITOR_ONBOARDING_KEY)
-    }
-  }, [widgetData.components.length])
 
   const handleGuidedDragStart = React.useCallback(
     (event: React.DragEvent<HTMLDivElement>, type: string) => {
@@ -712,8 +697,6 @@ const WidgetEditor: React.FC<{
               onUseTemplate={() => setShowTemplateDialog(true)}
               onboardingActive={onboardingActive}
               onboardingStep={onboardingStep}
-              onRestartOnboarding={handleRestartOnboarding}
-              onSkipOnboarding={handleSkipOnboarding}
             />
           </Box>
         )}

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
@@ -54,10 +54,12 @@ const PALETTE_GROUPS = [
   'Layout Containers',
   'Chart Components',
 ]
+const MOBILE_CONTENT_LAYOUT_GROUP = 'Content and layout'
 const PALETTE_GROUP_LABELS: Record<string, string> = {
   'UI Components': 'Content and Controls',
   'Layout Containers': 'Layout Helpers',
   'Chart Components': 'Charts',
+  [MOBILE_CONTENT_LAYOUT_GROUP]: 'Content and layout',
 }
 
 // Component palette component
@@ -92,7 +94,7 @@ const ComponentPalette = ({
         acc[category] = true
         return acc
       },
-      {} as Record<string, boolean>,
+      { [MOBILE_CONTENT_LAYOUT_GROUP]: true } as Record<string, boolean>,
     )
   })
 
@@ -299,8 +301,17 @@ const ComponentPalette = ({
           },
         }}
       >
-        {PALETTE_GROUPS.map((category) => {
-          const components = groupedComponents[category] || []
+        {(isPhone
+          ? [MOBILE_CONTENT_LAYOUT_GROUP, 'Chart Components']
+          : PALETTE_GROUPS
+        ).map((category) => {
+          const groupCategories =
+            isPhone && category === MOBILE_CONTENT_LAYOUT_GROUP
+              ? ['UI Components', 'Layout Containers']
+              : [category]
+          const components = groupCategories.flatMap(
+            (groupCategory) => groupedComponents[groupCategory] || [],
+          )
 
           if (components.length === 0) {
             return null
@@ -311,7 +322,11 @@ const ComponentPalette = ({
               key={category}
               sx={{
                 mb: isPhone ? 0 : 2,
-                flex: isPhone ? '1 1 0' : 'initial',
+                flex: isPhone
+                  ? category === MOBILE_CONTENT_LAYOUT_GROUP
+                    ? '1 0 100%'
+                    : '1 1 0'
+                  : 'initial',
                 minWidth: isPhone ? 0 : undefined,
                 border: isPhone ? 1 : 0,
                 borderColor: 'divider',
@@ -366,22 +381,45 @@ const ComponentPalette = ({
                     px: isPhone ? 0.5 : 1,
                     pt: isPhone ? 0.5 : 1,
                     pb: isPhone ? 0.5 : 0,
-                    display: isPhone ? 'flex' : 'block',
-                    gap: isPhone ? 0.75 : 0,
-                    overflowX: isPhone ? 'auto' : 'visible',
-                    scrollSnapType: isPhone ? 'x proximity' : 'none',
+                    display: 'block',
                     WebkitOverflowScrolling: 'touch',
                   }}
                 >
-                  {components.map((component) => (
-                    <ComponentPaletteItem
-                      key={component.type}
-                      component={component}
-                      showTooltips={showTooltips}
-                      handleDragStart={handleDragStart}
-                      onDirectAdd={onDirectAdd}
-                    />
-                  ))}
+                  {groupCategories.map((groupCategory, groupIndex) => {
+                    const groupComponents =
+                      groupedComponents[groupCategory] || []
+
+                    if (groupComponents.length === 0) {
+                      return null
+                    }
+
+                    return (
+                      <React.Fragment key={groupCategory}>
+                        {isPhone && groupIndex > 0 && (
+                          <Divider sx={{ my: 0.5, opacity: 0.65 }} />
+                        )}
+                        <Box
+                          sx={{
+                            display: isPhone ? 'flex' : 'block',
+                            gap: isPhone ? 0.75 : 0,
+                            overflowX: isPhone ? 'auto' : 'visible',
+                            scrollSnapType: isPhone ? 'x proximity' : 'none',
+                            WebkitOverflowScrolling: 'touch',
+                          }}
+                        >
+                          {groupComponents.map((component) => (
+                            <ComponentPaletteItem
+                              key={component.type}
+                              component={component}
+                              showTooltips={showTooltips}
+                              handleDragStart={handleDragStart}
+                              onDirectAdd={onDirectAdd}
+                            />
+                          ))}
+                        </Box>
+                      </React.Fragment>
+                    )
+                  })}
                 </Box>
               </Collapse>
             </Box>

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
@@ -9,7 +9,6 @@ import {
   useTheme,
   useMediaQuery,
   Chip,
-  Divider,
 } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
@@ -381,7 +380,10 @@ const ComponentPalette = ({
                     px: isPhone ? 0.5 : 1,
                     pt: isPhone ? 0.5 : 1,
                     pb: isPhone ? 0.5 : 0,
-                    display: 'block',
+                    display: isPhone ? 'flex' : 'block',
+                    gap: isPhone ? 0.75 : 0,
+                    overflowX: isPhone ? 'auto' : 'visible',
+                    scrollSnapType: isPhone ? 'x proximity' : 'none',
                     WebkitOverflowScrolling: 'touch',
                   }}
                 >
@@ -396,15 +398,21 @@ const ComponentPalette = ({
                     return (
                       <React.Fragment key={groupCategory}>
                         {isPhone && groupIndex > 0 && (
-                          <Divider sx={{ my: 0.5, opacity: 0.65 }} />
+                          <Box
+                            sx={{
+                              flex: '0 0 22px',
+                              alignSelf: 'center',
+                              borderTop: '1px solid',
+                              borderColor: 'divider',
+                              opacity: 0.8,
+                            }}
+                            aria-hidden="true"
+                          />
                         )}
                         <Box
                           sx={{
                             display: isPhone ? 'flex' : 'block',
                             gap: isPhone ? 0.75 : 0,
-                            overflowX: isPhone ? 'auto' : 'visible',
-                            scrollSnapType: isPhone ? 'x proximity' : 'none',
-                            WebkitOverflowScrolling: 'touch',
                           }}
                         >
                           {groupComponents.map((component) => (

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
@@ -163,7 +163,7 @@ const ComponentPalette = ({
         maxWidth: drawerWidth,
         flex: isPhone ? '0 0 auto' : `0 0 ${drawerWidth}px`,
         bgcolor: '#FFFFFF',
-        borderRight: { xs: 0, sm: 1 },
+        borderRight: 0,
         borderBottom: { xs: 1, sm: 0 },
         borderColor: 'divider',
         height: { xs: 'auto', sm: '100%' },

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
@@ -30,7 +30,7 @@ interface ComponentPaletteProps {
   setActiveContainerId?: (id: string | null) => void
   widgetData?: any // To lookup container name
   onboardingActive?: boolean
-  onboardingStep?: 'choose' | 'save' | null
+  onboardingStep?: 'choose' | 'save' | 'place' | null
 }
 
 // Helper function to group components by category
@@ -408,9 +408,7 @@ const ComponentPalette = ({
               fontSize: isPhone ? '0.5rem' : '0.65rem',
             }}
           >
-            {isPhone
-              ? 'Tap + to add an item'
-              : 'Drag items into your widget'}
+            {isPhone ? 'Tap + to add an item' : 'Drag items into your widget'}
           </Typography>
           <Typography
             variant="caption"

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
@@ -62,7 +62,7 @@ interface EditorCanvasProps {
   onStartOperationsWidget?: () => void
   onUseTemplate?: () => void
   onboardingActive?: boolean
-  onboardingStep?: 'choose' | 'save' | null
+  onboardingStep?: 'choose' | 'save' | 'place' | null
   onRestartOnboarding?: () => void
   onSkipOnboarding?: () => void
 }
@@ -113,6 +113,12 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
     onboardingActive &&
     widgetData.components.length > 0 &&
     onboardingStep === 'save'
+
+  const showOnboardingPlacePrompt =
+    editMode &&
+    onboardingActive &&
+    widgetData.components.length > 0 &&
+    onboardingStep === 'place'
 
   // Render the component hierarchy
   const renderComponents = (components: ComponentData[]) => {
@@ -211,7 +217,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
         </Typography>
       )}
 
-      {showOnboardingSavePrompt && (
+      {(showOnboardingSavePrompt || showOnboardingPlacePrompt) && (
         <Paper
           data-testid="widget-editor-save-coach"
           sx={{
@@ -238,7 +244,9 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                   mb: 0.25,
                 }}
               >
-                Step 2: tune it, then save it
+                {showOnboardingPlacePrompt
+                  ? 'Step 3: add it to your dashboard'
+                  : 'Step 2: tune it, then save it'}
               </Typography>
               <Typography
                 variant="body2"
@@ -247,9 +255,9 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                   fontSize: isPhone ? '0.78rem' : undefined,
                 }}
               >
-                Select the blue pen in a block to change its label, data, colors, or layout.
-                Save the Daily Operations widget when it is ready to be used in
-                dashboards.
+                {showOnboardingPlacePrompt
+                  ? `Open ${isPhone ? 'Add' : 'Add Widget'}, choose the widget you just saved, and click it to place it on the dashboard.`
+                  : 'Select the blue pen in a block to change its label, data, colors, or layout. Save the Daily Operations widget when it is ready to be used in dashboards.'}
               </Typography>
             </Box>
             <Stack direction="row" spacing={1}>

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
@@ -351,8 +351,9 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                         fontSize: isPhone ? '0.78rem' : undefined,
                       }}
                     >
-                      Track orders today, delayed tasks, support tickets, and
-                      system status without writing code.
+                      {isPhone
+                        ? 'Start fast, then add status text if you need it.'
+                        : 'Track orders today, delayed tasks, support tickets, and system status without writing code.'}
                     </Typography>
                   </Box>
 
@@ -379,6 +380,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                       onClick={() => onAddStarterComponent?.('Chart')}
                       disabled={!onAddStarterComponent}
                       sx={{
+                        display: { xs: 'none', sm: 'inline-flex' },
                         borderRadius: 1,
                         textTransform: 'none',
                         color: 'primary.dark',
@@ -409,6 +411,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                       onClick={() => onAddStarterComponent?.('TextField')}
                       disabled={!onAddStarterComponent}
                       sx={{
+                        display: { xs: 'none', sm: 'inline-flex' },
                         borderRadius: 1,
                         textTransform: 'none',
                         color: 'primary.dark',
@@ -424,6 +427,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                       onClick={onUseTemplate}
                       disabled={!onUseTemplate}
                       sx={{
+                        display: { xs: 'none', sm: 'inline-flex' },
                         borderRadius: 1,
                         textTransform: 'none',
                         color: 'primary.dark',

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
@@ -63,8 +63,6 @@ interface EditorCanvasProps {
   onUseTemplate?: () => void
   onboardingActive?: boolean
   onboardingStep?: 'choose' | 'save' | 'place' | null
-  onRestartOnboarding?: () => void
-  onSkipOnboarding?: () => void
 }
 
 const EditorCanvas: React.FC<EditorCanvasProps> = ({
@@ -96,8 +94,6 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
   onUseTemplate,
   onboardingActive = false,
   onboardingStep = null,
-  onRestartOnboarding,
-  onSkipOnboarding,
 }) => {
   const theme = useTheme()
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'))
@@ -260,18 +256,6 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                   : 'Select the blue pen in a block to change its label, data, colors, or layout. Save the Daily Operations widget when it is ready to be used in dashboards.'}
               </Typography>
             </Box>
-            <Stack direction="row" spacing={1}>
-              {onSkipOnboarding && (
-                <Button
-                  variant="contained"
-                  size="small"
-                  onClick={onSkipOnboarding}
-                  sx={{ borderRadius: 1, textTransform: 'none' }}
-                >
-                  Got it
-                </Button>
-              )}
-            </Stack>
           </Stack>
         </Paper>
       )}

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
@@ -252,7 +252,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                 }}
               >
                 {showOnboardingPlacePrompt
-                  ? `Open ${isPhone ? 'Add' : 'Add Widget'}, choose the widget you just saved, and click it to place it on the dashboard.`
+                  ? `Open ${isPhone ? 'Add' : 'Add Widget'}, choose the widget called ${widgetData.name || 'Daily Operations'}, and click it to place it on the dashboard.`
                   : 'Select the blue pen in a block to change its label, data, colors, or layout. Save the Daily Operations widget when it is ready to be used in dashboards.'}
               </Typography>
             </Box>

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/EditorToolbar.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/EditorToolbar.tsx
@@ -650,12 +650,16 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({
                       height: 30,
                       p: 0,
                       border: '1px solid',
+                      mr: 0.75,
                       borderColor:
                         !editMode || (!hasChanges && isUpdating) || isEmpty
                           ? alpha(theme.palette.action.disabled, 0.25)
-                          : alpha(theme.palette.divider, 0.6),
+                          : theme.palette.primary.main,
                       borderRadius: 1,
-                      bgcolor: alpha(theme.palette.background.paper, 0.35),
+                      bgcolor:
+                        !editMode || (!hasChanges && isUpdating) || isEmpty
+                          ? alpha(theme.palette.background.paper, 0.35)
+                          : alpha(theme.palette.primary.main, 0.1),
                       '&:hover': {
                         bgcolor: alpha(theme.palette.primary.main, 0.08),
                         borderColor: alpha(theme.palette.primary.main, 0.5),

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/EditorToolbar.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/EditorToolbar.tsx
@@ -646,7 +646,20 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({
                         !editMode || (!hasChanges && isUpdating) || isEmpty
                           ? 'action.disabled'
                           : 'primary.main',
-                      padding: isPhone ? '4px' : '8px',
+                      width: 30,
+                      height: 30,
+                      p: 0,
+                      border: '1px solid',
+                      borderColor:
+                        !editMode || (!hasChanges && isUpdating) || isEmpty
+                          ? alpha(theme.palette.action.disabled, 0.25)
+                          : alpha(theme.palette.divider, 0.6),
+                      borderRadius: 1,
+                      bgcolor: alpha(theme.palette.background.paper, 0.35),
+                      '&:hover': {
+                        bgcolor: alpha(theme.palette.primary.main, 0.08),
+                        borderColor: alpha(theme.palette.primary.main, 0.5),
+                      },
                     }}
                   >
                     <SaveIcon

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/EditorToolbar.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/EditorToolbar.tsx
@@ -161,7 +161,7 @@ const EditorToolbar: React.FC<EditorToolbarProps> = ({
               onClick={toggleSidebar}
               sx={{
                 mr: isPhone ? 0.25 : 2,
-                ml: isPhone ? 0.5 : 0,
+                ml: isPhone ? 0.5 : -1.5,
                 p: isPhone ? 0.5 : 1,
                 color: showSidebar
                   ? 'primary.main'

--- a/apps/aquamesh/src/components/WidgetEditor/hooks/useWidgetEditor.ts
+++ b/apps/aquamesh/src/components/WidgetEditor/hooks/useWidgetEditor.ts
@@ -137,7 +137,7 @@ export const useWidgetEditor = () => {
   const [requireNameEntryOnSave, setRequireNameEntryOnSave] = useState<boolean>(
     () => {
       const saved = localStorage.getItem('widget-editor-require-name-entry')
-      return saved ? JSON.parse(saved) : false
+      return saved ? JSON.parse(saved) : true
     },
   )
 

--- a/apps/aquamesh/src/components/WidgetEditor/hooks/useWidgetEditor.ts
+++ b/apps/aquamesh/src/components/WidgetEditor/hooks/useWidgetEditor.ts
@@ -960,9 +960,12 @@ export const useWidgetEditor = () => {
   }
 
   // Handle saving the widget
-  const handleSaveWidget = (isMajorUpdate: boolean = false) => {
+  const handleSaveWidget = (
+    isMajorUpdate: boolean = false,
+    requestedName?: string,
+  ) => {
     // Handle default or blank name according to setting
-    let nameToSave = widgetData.name.trim() || ''
+    let nameToSave = requestedName?.trim() || widgetData.name.trim() || ''
     const existingNames = savedWidgets.map((w) => w.name)
     if (!nameToSave || nameToSave === 'New Widget') {
       if (requireNameEntryOnSave) {
@@ -997,12 +1000,6 @@ export const useWidgetEditor = () => {
       // Update widgetData name for saving
       setWidgetData((prev) => ({ ...prev, name: nameToSave }))
     }
-    // Use nameToSave for saving
-    const widgetToSaveData = {
-      name: nameToSave,
-      components: [...widgetData.components],
-    }
-
     if (!nameToSave) {
       setNotification({
         open: true,
@@ -1026,13 +1023,11 @@ export const useWidgetEditor = () => {
       setIsUndoRedoAction(true)
 
       // Find if we already have a widget with this name to replace
-      const existingWidget = savedWidgets.find(
-        (w) => w.name === widgetData.name,
-      )
+      const existingWidget = savedWidgets.find((w) => w.name === nameToSave)
 
       // Prepare basic widget data for saving
       const widgetToSave = {
-        name: widgetData.name,
+        name: nameToSave,
         components: [...widgetData.components],
       }
 
@@ -1076,24 +1071,25 @@ export const useWidgetEditor = () => {
 
         setNotification({
           open: true,
-          message: `Widget "${widgetData.name}" updated successfully${isMajorUpdate ? ' with major version bump' : ''}`,
+          message: `Widget "${nameToSave}" updated successfully${isMajorUpdate ? ' with major version bump' : ''}`,
           severity: 'success',
         })
       }
       // Handle saving new widget
       else {
-        const savedWidget = WidgetStorage.saveWidget(widgetToSaveData)
+        const savedWidget = WidgetStorage.saveWidget(widgetToSave)
         savedWidgetId = savedWidget.id
         // Set new widgetData id and version
         setWidgetData((prev) => ({
           ...prev,
+          name: nameToSave,
           id: savedWidget.id,
           version: savedWidget.version,
         }))
 
         setNotification({
           open: true,
-          message: `Widget "${widgetData.name}" saved successfully`,
+          message: `Widget "${nameToSave}" saved successfully`,
           severity: 'success',
         })
       }

--- a/apps/aquamesh/tests/unit/components/WidgetEditor/EditorCanvas.test.tsx
+++ b/apps/aquamesh/tests/unit/components/WidgetEditor/EditorCanvas.test.tsx
@@ -67,8 +67,6 @@ const renderEditorCanvas = (
     onAddStarterComponent: vi.fn(),
     onStartOperationsWidget: vi.fn(),
     onUseTemplate: vi.fn(),
-    onRestartOnboarding: vi.fn(),
-    onSkipOnboarding: vi.fn(),
     ...overrides,
   }
 
@@ -183,7 +181,7 @@ describe('EditorCanvas first-widget guide', () => {
   })
 
   it('shows the edit and save guidance after the first component exists', () => {
-    const props = renderEditorCanvas({
+    renderEditorCanvas({
       onboardingActive: true,
       onboardingStep: 'save',
       widgetData: {
@@ -204,8 +202,8 @@ describe('EditorCanvas first-widget guide', () => {
     expect(
       screen.queryByRole('button', { name: /show again/i }),
     ).not.toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('button', { name: /got it/i }))
-    expect(props.onSkipOnboarding).toHaveBeenCalledTimes(1)
+    expect(
+      screen.queryByRole('button', { name: /got it/i }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/apps/aquamesh/tests/unit/components/dashboard/Dashboard.test.tsx
+++ b/apps/aquamesh/tests/unit/components/dashboard/Dashboard.test.tsx
@@ -103,7 +103,7 @@ describe('Dashboards', () => {
       }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /create daily operations widget/i }),
+      screen.getByRole('button', { name: /create your own widget/i }),
     ).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /view daily operations example/i }),
@@ -122,7 +122,7 @@ describe('Dashboards', () => {
     render(<Dashboards />)
 
     fireEvent.click(
-      screen.getByRole('button', { name: /create daily operations widget/i }),
+      screen.getByRole('button', { name: /create your own widget/i }),
     )
     fireEvent.click(
       screen.getByRole('button', { name: /view daily operations example/i }),


### PR DESCRIPTION
## Summary
- add dashboard onboarding steps for placing and saving widgets
- remove early “Got it” exits from widget editor steps 2 and 3
- make Require name entry on save default to enabled for new users
- fix named widget save flow so confirming the name in the save modal saves immediately in one click
- update widget editor step 3 copy to point to the saved widget by name
- style the mobile widget-editor save icon as a square button matching edit/preview controls
- make the mobile save button border/background green when it is ready to save and add right spacing from the green divider
- keep the mobile hamburger spacing scoped to phone so desktop Create Widget alignment stays normal
- keep the building-blocks/canvas separator on phone only; remove the desktop vertical separator
- add a final congratulations card after dashboard save; reaching it automatically marks onboarding done
- final congratulations card now has only a Got it close action, no Step 6 label, and mentions where to find the saved dashboard by name in Dash/Dashboards depending on screen size
- raise dashboard onboarding card z-index so component block controls do not appear over it
- move dashboard steps 4/5/final card to the bottom on phone so they do not block the widget area
- make step 4 complete after the user moves the widget/layout once, without requiring Add Widget or separator resizing
- remove the disabled “Split the dashboard first” step 4 button/text
- simplify step 4 copy and improve step 5 copy: “Save the dashboard using the disk icon on the Dashboard tab.”
- reduce the mobile empty-widget starter card to Daily Operations + status text while keeping desktop options unchanged
- combine mobile content/layout palette groups into a single horizontal row with a thin inline separator

## Verification
- npx prettier --check apps/aquamesh/src/components/WidgetEditor/components/core/EditorToolbar.tsx apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
- cd apps/aquamesh && npx vitest --run --config ./vitest.config.ts tests/unit/components/WidgetEditor/EditorCanvas.test.tsx tests/unit/components/WidgetEditor/WidgetEditor.test.tsx --reporter verbose
- npm --workspace apps/aquamesh run build