### PR TITLE
Simplify first user onboarding path

### DIFF
--- a/apps/aquamesh/public/images/widget_builder_overview.svg
+++ b/apps/aquamesh/public/images/widget_builder_overview.svg
@@ -1,0 +1,62 @@
+<svg width="1200" height="760" viewBox="0 0 1200 760" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="760" rx="32" fill="#F8FAFA"/>
+  <rect x="34" y="34" width="1132" height="692" rx="28" fill="#FFFFFF" stroke="#D9E8E4" stroke-width="2"/>
+  <rect x="34" y="34" width="1132" height="78" rx="28" fill="#FFFFFF"/>
+  <path d="M34 100H1166" stroke="#D9E8E4" stroke-width="2"/>
+  <rect x="72" y="64" width="28" height="4" rx="2" fill="#00BCA2"/>
+  <rect x="72" y="76" width="28" height="4" rx="2" fill="#00BCA2"/>
+  <rect x="72" y="88" width="28" height="4" rx="2" fill="#00BCA2"/>
+  <text x="130" y="85" fill="#12352F" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="800">Create Widget</text>
+  <rect x="848" y="54" width="74" height="38" rx="8" fill="#E8F7F4" stroke="#00BCA2"/>
+  <text x="875" y="79" fill="#007C66" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">✎</text>
+  <rect x="938" y="54" width="74" height="38" rx="8" fill="#FFFFFF" stroke="#D9E8E4"/>
+  <text x="965" y="79" fill="#60736F" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">◉</text>
+  <rect x="1048" y="54" width="72" height="38" rx="8" fill="#E8F7F4" stroke="#00BCA2"/>
+  <text x="1074" y="80" fill="#00BCA2" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="700">💾</text>
+
+  <rect x="64" y="144" width="300" height="538" rx="20" fill="#FFFFFF" stroke="#D9E8E4" stroke-width="2"/>
+  <text x="92" y="188" fill="#12352F" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="800">Building blocks</text>
+  <text x="92" y="222" fill="#60736F" font-family="Inter, Arial, sans-serif" font-size="16">Drag blocks into the widget canvas.</text>
+  <g>
+    <rect x="92" y="262" width="110" height="88" rx="14" fill="#F8FAFA" stroke="#D9E8E4"/>
+    <circle cx="147" cy="294" r="14" fill="#E8F7F4"/>
+    <text x="127" y="332" fill="#12352F" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Text</text>
+  </g>
+  <g>
+    <rect x="222" y="262" width="110" height="88" rx="14" fill="#F8FAFA" stroke="#D9E8E4"/>
+    <circle cx="277" cy="294" r="14" fill="#E8F7F4"/>
+    <text x="255" y="332" fill="#12352F" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Chart</text>
+  </g>
+  <g>
+    <rect x="92" y="370" width="110" height="88" rx="14" fill="#F8FAFA" stroke="#D9E8E4"/>
+    <circle cx="147" cy="402" r="14" fill="#E8F7F4"/>
+    <text x="123" y="440" fill="#12352F" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Input</text>
+  </g>
+  <g>
+    <rect x="222" y="370" width="110" height="88" rx="14" fill="#F8FAFA" stroke="#D9E8E4"/>
+    <circle cx="277" cy="402" r="14" fill="#E8F7F4"/>
+    <text x="244" y="440" fill="#12352F" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">Layout</text>
+  </g>
+  <rect x="92" y="506" width="240" height="116" rx="16" fill="#E8F7F4" stroke="#00BCA2" stroke-opacity="0.45"/>
+  <text x="116" y="546" fill="#005A49" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="800">Tip</text>
+  <text x="116" y="578" fill="#31524B" font-family="Inter, Arial, sans-serif" font-size="16">Start with one useful block,</text>
+  <text x="116" y="602" fill="#31524B" font-family="Inter, Arial, sans-serif" font-size="16">then save and reuse it.</text>
+
+  <rect x="400" y="144" width="736" height="538" rx="20" fill="#F8FAFA" stroke="#D9E8E4" stroke-width="2"/>
+  <text x="436" y="190" fill="#12352F" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="800">Daily Operations widget</text>
+  <text x="436" y="224" fill="#60736F" font-family="Inter, Arial, sans-serif" font-size="16">Orders, support, system status, and handoff notes in one reusable card.</text>
+  <rect x="436" y="270" width="300" height="124" rx="18" fill="#FFFFFF" stroke="#D9E8E4"/>
+  <text x="464" y="314" fill="#12352F" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="800">Orders today</text>
+  <rect x="464" y="338" width="220" height="14" rx="7" fill="#E8F7F4"/>
+  <rect x="464" y="362" width="160" height="14" rx="7" fill="#D9E8E4"/>
+  <rect x="772" y="270" width="328" height="124" rx="18" fill="#FFFFFF" stroke="#D9E8E4"/>
+  <text x="800" y="314" fill="#12352F" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="800">Support tickets</text>
+  <rect x="800" y="342" width="56" height="34" rx="8" fill="#00BCA2" opacity="0.88"/>
+  <rect x="866" y="324" width="56" height="52" rx="8" fill="#00BCA2" opacity="0.64"/>
+  <rect x="932" y="352" width="56" height="24" rx="8" fill="#00BCA2" opacity="0.4"/>
+  <rect x="436" y="430" width="664" height="170" rx="18" fill="#FFFFFF" stroke="#D9E8E4"/>
+  <text x="464" y="474" fill="#12352F" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="800">Team handoff</text>
+  <rect x="464" y="502" width="580" height="16" rx="8" fill="#E8F7F4"/>
+  <rect x="464" y="532" width="500" height="16" rx="8" fill="#D9E8E4"/>
+  <rect x="464" y="562" width="420" height="16" rx="8" fill="#D9E8E4"/>
+</svg>

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -24,11 +24,7 @@ import { ReactComponent as AddIcon } from '../../icons/add.svg'
 import { ReactComponent as CloseIcon } from '../../icons/close.svg'
 import SaveIcon from '@mui/icons-material/Save'
 import DashboardCustomizeIcon from '@mui/icons-material/DashboardCustomize'
-import WidgetsIcon from '@mui/icons-material/Widgets'
 import CreateIcon from '@mui/icons-material/Create'
-import ImportContactsIcon from '@mui/icons-material/ImportContacts'
-import { useNavigate } from 'react-router-dom'
-
 import DashboardLayoutView from '../Layout/Layout'
 import { DashboardLayout } from '../../state/store'
 import { useDashboards } from './DashboardProvider'
@@ -141,17 +137,11 @@ const DashboardStorage = {
 interface DashboardEmptyStateProps {
   isAdmin: boolean
   onCreateWidget: () => void
-  onOpenOperationsExample: () => void
-  onOpenWidgetMenu: () => void
-  onOpenQuickGuide: () => void
 }
 
 const DashboardEmptyState = ({
   isAdmin,
   onCreateWidget,
-  onOpenOperationsExample,
-  onOpenWidgetMenu,
-  onOpenQuickGuide,
 }: DashboardEmptyStateProps) => (
   <Box
     sx={{
@@ -193,7 +183,6 @@ const DashboardEmptyState = ({
         direction={{ xs: 'column', sm: 'row' }}
         spacing={1.5}
         justifyContent="center"
-        sx={{ mb: 2 }}
       >
         {isAdmin && (
           <Button
@@ -204,29 +193,7 @@ const DashboardEmptyState = ({
             Create your own widget
           </Button>
         )}
-        <Button
-          variant="outlined"
-          startIcon={<DashboardCustomizeIcon />}
-          onClick={onOpenOperationsExample}
-        >
-          View Daily Operations example
-        </Button>
-        <Button
-          variant="outlined"
-          startIcon={<WidgetsIcon />}
-          onClick={onOpenWidgetMenu}
-        >
-          Add saved widget
-        </Button>
       </Stack>
-      <Button
-        variant="text"
-        startIcon={<ImportContactsIcon />}
-        onClick={onOpenQuickGuide}
-        sx={{ color: 'foreground.contrastPrimary' }}
-      >
-        Open quick guide
-      </Button>
     </Paper>
   </Box>
 )
@@ -344,10 +311,7 @@ const Dashboards = () => {
       const savedStep = window.localStorage.getItem(DASHBOARD_ONBOARDING_KEY)
       return savedStep === 'save' || savedStep === 'done' ? savedStep : 'layout'
     })
-  const navigate = useNavigate()
-  const { openCreateWidget, openOperationsExample, openWidgetMenu } =
-    useWorkspaceActions()
-  const openQuickGuide = () => navigate('/')
+  const { openCreateWidget } = useWorkspaceActions()
 
   const completeDashboardOnboarding = () => {
     setDashboardOnboardingStep('done')
@@ -677,9 +641,6 @@ const Dashboards = () => {
                     <DashboardEmptyState
                       isAdmin={isAdmin}
                       onCreateWidget={openCreateWidget}
-                      onOpenOperationsExample={openOperationsExample}
-                      onOpenWidgetMenu={openWidgetMenu}
-                      onOpenQuickGuide={openQuickGuide}
                     />
                   ) : (
                     <DashboardLayoutView
@@ -705,9 +666,6 @@ const Dashboards = () => {
         <DashboardEmptyState
           isAdmin={isAdmin}
           onCreateWidget={openCreateWidget}
-          onOpenOperationsExample={openOperationsExample}
-          onOpenWidgetMenu={openWidgetMenu}
-          onOpenQuickGuide={openQuickGuide}
         />
       )}
 

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
@@ -326,7 +326,9 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                         mb: 0.5,
                       }}
                     >
-                      Build a Daily Operations widget
+                      {showOnboardingChoosePrompt
+                        ? 'Start with one block'
+                        : 'Build a Daily Operations widget'}
                     </Typography>
                     <Typography
                       variant="body2"
@@ -335,91 +337,95 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                         fontSize: isPhone ? '0.78rem' : undefined,
                       }}
                     >
-                      {isPhone
-                        ? 'Start fast, then add status text if you need it.'
-                        : 'Track orders today, delayed tasks, support tickets, and system status without writing code.'}
+                      {showOnboardingChoosePrompt
+                        ? 'Drag any block from Building Blocks into this canvas. You can experiment and adjust it after it lands here.'
+                        : isPhone
+                          ? 'Use a quick shortcut, then save it for dashboards.'
+                          : 'Use these shortcuts to create a reusable widget faster, or drag any block from the palette.'}
                     </Typography>
                   </Box>
 
-                  <Stack
-                    direction={isPhone ? 'column' : 'row'}
-                    spacing={1}
-                    useFlexGap
-                    flexWrap="wrap"
-                  >
-                    <Button
-                      variant="contained"
-                      size="small"
-                      startIcon={<DashboardCustomizeIcon />}
-                      onClick={onStartOperationsWidget}
-                      disabled={!onStartOperationsWidget}
-                      sx={{ borderRadius: 1, textTransform: 'none' }}
+                  {!showOnboardingChoosePrompt && (
+                    <Stack
+                      direction={isPhone ? 'column' : 'row'}
+                      spacing={1}
+                      useFlexGap
+                      flexWrap="wrap"
                     >
-                      Start from Daily Operations
-                    </Button>
-                    <Button
-                      variant="outlined"
-                      size="small"
-                      startIcon={<AutoGraphIcon />}
-                      onClick={() => onAddStarterComponent?.('Chart')}
-                      disabled={!onAddStarterComponent}
-                      sx={{
-                        display: { xs: 'none', sm: 'inline-flex' },
-                        borderRadius: 1,
-                        textTransform: 'none',
-                        color: 'primary.dark',
-                        borderColor: 'primary.dark',
-                      }}
-                    >
-                      Add tickets chart
-                    </Button>
-                    <Button
-                      variant="outlined"
-                      size="small"
-                      startIcon={<TextFieldsIcon />}
-                      onClick={() => onAddStarterComponent?.('Label')}
-                      disabled={!onAddStarterComponent}
-                      sx={{
-                        borderRadius: 1,
-                        textTransform: 'none',
-                        color: 'primary.dark',
-                        borderColor: 'primary.dark',
-                      }}
-                    >
-                      Add status text
-                    </Button>
-                    <Button
-                      variant="outlined"
-                      size="small"
-                      startIcon={<InputIcon />}
-                      onClick={() => onAddStarterComponent?.('TextField')}
-                      disabled={!onAddStarterComponent}
-                      sx={{
-                        display: { xs: 'none', sm: 'inline-flex' },
-                        borderRadius: 1,
-                        textTransform: 'none',
-                        color: 'primary.dark',
-                        borderColor: 'primary.dark',
-                      }}
-                    >
-                      Add team note
-                    </Button>
-                    <Button
-                      variant="text"
-                      size="small"
-                      startIcon={<ViewModuleIcon />}
-                      onClick={onUseTemplate}
-                      disabled={!onUseTemplate}
-                      sx={{
-                        display: { xs: 'none', sm: 'inline-flex' },
-                        borderRadius: 1,
-                        textTransform: 'none',
-                        color: 'primary.dark',
-                      }}
-                    >
-                      Browse templates
-                    </Button>
-                  </Stack>
+                      <Button
+                        variant="contained"
+                        size="small"
+                        startIcon={<DashboardCustomizeIcon />}
+                        onClick={onStartOperationsWidget}
+                        disabled={!onStartOperationsWidget}
+                        sx={{ borderRadius: 1, textTransform: 'none' }}
+                      >
+                        Daily Operations template
+                      </Button>
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        startIcon={<AutoGraphIcon />}
+                        onClick={() => onAddStarterComponent?.('Chart')}
+                        disabled={!onAddStarterComponent}
+                        sx={{
+                          display: { xs: 'none', sm: 'inline-flex' },
+                          borderRadius: 1,
+                          textTransform: 'none',
+                          color: 'primary.dark',
+                          borderColor: 'primary.dark',
+                        }}
+                      >
+                        Tickets chart
+                      </Button>
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        startIcon={<TextFieldsIcon />}
+                        onClick={() => onAddStarterComponent?.('Label')}
+                        disabled={!onAddStarterComponent}
+                        sx={{
+                          borderRadius: 1,
+                          textTransform: 'none',
+                          color: 'primary.dark',
+                          borderColor: 'primary.dark',
+                        }}
+                      >
+                        Status text
+                      </Button>
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        startIcon={<InputIcon />}
+                        onClick={() => onAddStarterComponent?.('TextField')}
+                        disabled={!onAddStarterComponent}
+                        sx={{
+                          display: { xs: 'none', sm: 'inline-flex' },
+                          borderRadius: 1,
+                          textTransform: 'none',
+                          color: 'primary.dark',
+                          borderColor: 'primary.dark',
+                        }}
+                      >
+                        Team note
+                      </Button>
+                      <Button
+                        variant="text"
+                        size="small"
+                        startIcon={<ViewModuleIcon />}
+                        onClick={onUseTemplate}
+                        disabled={!onUseTemplate}
+                        sx={{
+                          display: { xs: 'none', sm: 'inline-flex' },
+                          borderRadius: 1,
+                          textTransform: 'none',
+                          color: 'primary.dark',
+                        }}
+                      >
+                        Browse templates
+                      </Button>
+                    </Stack>
+                  )}
                 </Stack>
               </Box>
             ) : (

--- a/apps/aquamesh/src/components/landing/AquaMeshLanding.tsx
+++ b/apps/aquamesh/src/components/landing/AquaMeshLanding.tsx
@@ -169,26 +169,18 @@ const AquaMeshLanding = () => {
               Create operational dashboard widgets without code.
             </Typography>
             <Typography variant="body1" sx={{ color: '#425c57', mb: 3 }}>
-              Build reusable widgets for orders, delayed tasks, support
-              tickets, system status, team notes, and handoff actions, then
-              place them into dashboards.
+              Build reusable widgets for orders, delayed tasks, support tickets,
+              system status, team notes, and handoff actions, then place them
+              into dashboards.
             </Typography>
             <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
               <Button
                 variant="contained"
                 size="large"
-                onClick={() => openWorkspace('create-widget')}
+                onClick={() => openWorkspace()}
                 sx={{ borderRadius: 1, textTransform: 'none' }}
               >
-                Create your own widget
-              </Button>
-              <Button
-                variant="outlined"
-                size="large"
-                onClick={() => openWorkspace('open-operations-example')}
-                sx={{ borderRadius: 1, textTransform: 'none' }}
-              >
-                Open operations example
+                Enter workspace
               </Button>
             </Stack>
           </Grid>
@@ -205,7 +197,7 @@ const AquaMeshLanding = () => {
             >
               <Box
                 component="img"
-                src="/images/widget_editor.png"
+                src="/images/widget_builder_overview.svg"
                 alt="AquaMesh widget editor"
                 sx={{
                   display: 'block',
@@ -288,7 +280,7 @@ const AquaMeshLanding = () => {
           </Grid>
         </Box>
 
-        <Box sx={{ py: 5, pb: 8 }}>
+        <Box sx={{ py: 5 }}>
           <Typography variant="h4" component="h2" fontWeight={850} mb={3}>
             Quick answers
           </Typography>
@@ -316,6 +308,39 @@ const AquaMeshLanding = () => {
             ))}
           </Grid>
         </Box>
+
+        <Paper
+          elevation={0}
+          sx={{
+            mb: 8,
+            p: { xs: 3, sm: 4 },
+            borderRadius: 2,
+            bgcolor: '#005A49',
+            color: '#ffffff',
+            textAlign: 'center',
+          }}
+        >
+          <Typography variant="h4" component="h2" fontWeight={850} mb={1}>
+            Ready to build your first dashboard?
+          </Typography>
+          <Typography sx={{ color: 'rgba(255,255,255,0.82)', mb: 3 }}>
+            Enter the workspace, create one reusable widget, and place it on a
+            dashboard.
+          </Typography>
+          <Button
+            variant="contained"
+            size="large"
+            onClick={() => openWorkspace()}
+            sx={{
+              borderRadius: 1,
+              textTransform: 'none',
+              bgcolor: '#00BCA2',
+              '&:hover': { bgcolor: '#00A891' },
+            }}
+          >
+            Enter workspace
+          </Button>
+        </Paper>
       </Container>
     </Box>
   )

--- a/apps/aquamesh/src/components/tutorial/TutorialModal.tsx
+++ b/apps/aquamesh/src/components/tutorial/TutorialModal.tsx
@@ -34,7 +34,7 @@ const placeholderImages = {
   dashboardWidgetExplanation: '/images/understanding_dashboards.png',
   predefinedDashboards: `/images/dashboards_topnavbar.png`,
   predefinedWidgets: `/images/widgets_topnavbar.png`,
-  customWidgetCreation: `/images/widget_editor.png`,
+  customWidgetCreation: `/images/widget_builder_overview.svg`,
 }
 
 // Define interfaces for the tutorial options
@@ -132,29 +132,17 @@ const TutorialModal: React.FC<TutorialModalProps> = ({
       description:
         'Open Create Widget and build a reusable summary for orders today, delayed tasks, support tickets, and system status.',
       icon: <CreateIcon fontSize="large" color="primary" />,
-      buttonText: 'Open Create Widget',
+      buttonText: 'Start building',
       image: placeholderImages.customWidgetCreation,
-      hasMultipleButtons: true,
-      buttons: [
-        {
-          text: 'Quick Start',
-          action: () => {
-            setWidgetEditorModalOpen(true)
-          },
-        },
-        {
-          text: 'Open Create Widget',
-          action: () => {
-            onClose()
-            const createWidgetButton = document.querySelector(
-              '[data-tutorial-id="create-widget-button"]',
-            )
-            if (createWidgetButton) {
-              ;(createWidgetButton as HTMLElement).click()
-            }
-          },
-        },
-      ],
+      action: () => {
+        onClose()
+        const createWidgetButton = document.querySelector(
+          '[data-tutorial-id="create-widget-button"]',
+        )
+        if (createWidgetButton) {
+          ;(createWidgetButton as HTMLElement).click()
+        }
+      },
     })
   } else {
     options.push({
@@ -240,16 +228,7 @@ const TutorialModal: React.FC<TutorialModalProps> = ({
   )
 
   // Determine which slides to display based on device and user role
-  let displayOptions = options
-  if (isMobile) {
-    if (isAdmin) {
-      // On mobile for admin: show only the first and last slides
-      displayOptions = [options[0], options[options.length - 1]]
-    } else {
-      // On mobile for non-admin: show only the first slide
-      displayOptions = [options[0]]
-    }
-  }
+  const displayOptions = [options[0]]
 
   // Keyboard navigation handler
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {

--- a/apps/aquamesh/tests/unit/components/WidgetEditor/EditorCanvas.test.tsx
+++ b/apps/aquamesh/tests/unit/components/WidgetEditor/EditorCanvas.test.tsx
@@ -91,16 +91,16 @@ describe('EditorCanvas first-widget guide', () => {
       screen.getByText('Build a Daily Operations widget'),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /start from daily operations/i }),
+      screen.getByRole('button', { name: /daily operations template/i }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /add tickets chart/i }),
+      screen.getByRole('button', { name: /tickets chart/i }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /add status text/i }),
+      screen.getByRole('button', { name: /status text/i }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /add team note/i }),
+      screen.getByRole('button', { name: /team note/i }),
     ).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /browse templates/i }),
@@ -111,11 +111,11 @@ describe('EditorCanvas first-widget guide', () => {
     const props = renderEditorCanvas()
 
     fireEvent.click(
-      screen.getByRole('button', { name: /start from daily operations/i }),
+      screen.getByRole('button', { name: /daily operations template/i }),
     )
-    fireEvent.click(screen.getByRole('button', { name: /add tickets chart/i }))
-    fireEvent.click(screen.getByRole('button', { name: /add status text/i }))
-    fireEvent.click(screen.getByRole('button', { name: /add team note/i }))
+    fireEvent.click(screen.getByRole('button', { name: /tickets chart/i }))
+    fireEvent.click(screen.getByRole('button', { name: /status text/i }))
+    fireEvent.click(screen.getByRole('button', { name: /team note/i }))
     fireEvent.click(screen.getByRole('button', { name: /browse templates/i }))
 
     expect(props.onStartOperationsWidget).toHaveBeenCalledTimes(1)

--- a/apps/aquamesh/tests/unit/components/dashboard/Dashboard.test.tsx
+++ b/apps/aquamesh/tests/unit/components/dashboard/Dashboard.test.tsx
@@ -106,14 +106,14 @@ describe('Dashboards', () => {
       screen.getByRole('button', { name: /create your own widget/i }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /view daily operations example/i }),
-    ).toBeInTheDocument()
+      screen.queryByRole('button', { name: /view daily operations example/i }),
+    ).not.toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /add saved widget/i }),
-    ).toBeInTheDocument()
+      screen.queryByRole('button', { name: /add saved widget/i }),
+    ).not.toBeInTheDocument()
   })
 
-  it('shows the same Daily Operations actions when no dashboard is open', () => {
+  it('opens Create Widget when the empty workspace action is used', () => {
     mockDashboardProvider({
       openDashboards: [],
       selectedDashboard: -1,
@@ -124,15 +124,10 @@ describe('Dashboards', () => {
     fireEvent.click(
       screen.getByRole('button', { name: /create your own widget/i }),
     )
-    fireEvent.click(
-      screen.getByRole('button', { name: /view daily operations example/i }),
-    )
-    fireEvent.click(screen.getByRole('button', { name: /add saved widget/i }))
-    fireEvent.click(screen.getByRole('button', { name: /open quick guide/i }))
 
     expect(openCreateWidgetMock).toHaveBeenCalledTimes(1)
-    expect(openOperationsExampleMock).toHaveBeenCalledTimes(1)
-    expect(openWidgetMenuMock).toHaveBeenCalledTimes(1)
-    expect(navigateMock).toHaveBeenCalledWith('/')
+    expect(openOperationsExampleMock).not.toHaveBeenCalled()
+    expect(openWidgetMenuMock).not.toHaveBeenCalled()
+    expect(navigateMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- replace the stale landing/tutorial widget screenshot with a new neutral AquaMesh builder illustration
- simplify the landing hero to one primary Enter workspace path and add a large bottom CTA
- simplify the in-workspace welcome/tutorial modal to one first action: Start building
- simplify the empty dashboard state to one primary Create your own widget action
- reduce the empty widget canvas during active onboarding to a lightweight instruction instead of showing shortcut buttons next to onboarding guidance
- keep post-onboarding widget shortcuts, with lighter labels that work better as reusable shortcuts
- make Widget Editor help/onboarding copy phone-aware: phone says tap blocks, desktop keeps drag/drop language
- rename user-facing “component” wording to “block” across delete/search/toast/help copy

## Notes
- I left the widget name field in place for now. Moving it needs a slightly larger save/rename design pass so we do not remove an obvious way to rename existing widgets.

## Verification
- npx prettier --check apps/aquamesh/src/components/landing/AquaMeshLanding.tsx apps/aquamesh/src/components/tutorial/TutorialModal.tsx apps/aquamesh/src/components/Dasboard/Dashboard.tsx apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx apps/aquamesh/tests/unit/components/dashboard/Dashboard.test.tsx apps/aquamesh/tests/unit/components/WidgetEditor/EditorCanvas.test.tsx
- cd apps/aquamesh && npx vitest --run --config ./vitest.config.ts tests/unit/components/dashboard/Dashboard.test.tsx tests/unit/components/WidgetEditor/EditorCanvas.test.tsx tests/unit/components/WidgetEditor/WidgetEditor.test.tsx --reporter verbose
- npx prettier --check apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx apps/aquamesh/src/components/WidgetEditor/components/dialogs/ComponentSearchDialog.tsx apps/aquamesh/src/components/WidgetEditor/components/dialogs/SettingsDialog.tsx apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx apps/aquamesh/src/components/WidgetEditor/hooks/useWidgetEditor.ts apps/aquamesh/src/components/WidgetEditor/CustomWidget.tsx apps/aquamesh/src/components/tutorial/FAQDialog.tsx apps/aquamesh/src/components/tutorial/WidgetEditorExplanationModal.tsx apps/aquamesh/src/components/landing/AquaMeshLanding.tsx apps/aquamesh/tests/unit/components/WidgetEditor/CustomWidget.test.tsx
- cd apps/aquamesh && npx vitest --run --config ./vitest.config.ts tests/unit/components/WidgetEditor/EditorCanvas.test.tsx tests/unit/components/WidgetEditor/WidgetEditor.test.tsx tests/unit/components/WidgetEditor/CustomWidget.test.tsx --reporter verbose
- npm --workspace apps/aquamesh run build