### PR TITLE
Clarify mobile block builder copy

### DIFF
--- a/apps/aquamesh/src/components/WidgetEditor/CustomWidget.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/CustomWidget.tsx
@@ -939,7 +939,7 @@ const CustomWidget: React.FC<CustomWidgetProps> = ({
             variant="body2"
             sx={{ opacity: 0.7, fontStyle: 'italic' }}
           >
-            No components found for this widget.
+            No blocks found for this widget.
           </Typography>
         </Paper>
       )
@@ -968,7 +968,7 @@ const CustomWidget: React.FC<CustomWidgetProps> = ({
         }}
       >
         <Typography color="text.secondary">
-          This widget has no components
+          This widget has no blocks
         </Typography>
         {widgetId && (
           <Typography variant="caption" sx={{ mt: 1 }}>

--- a/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
@@ -468,8 +468,7 @@ const WidgetEditor: React.FC<{
       // Show a message if there are no components to search
       setComponentToast({
         open: true,
-        message:
-          'No components to search. Add components to your widget first.',
+        message: 'No blocks to search. Add blocks to your widget first.',
         severity: 'info',
       })
       return
@@ -486,7 +485,7 @@ const WidgetEditor: React.FC<{
     // Show a success message
     setComponentToast({
       open: true,
-      message: 'Component found and selected for editing',
+      message: 'Block found and selected for editing',
       severity: 'success',
     })
   }
@@ -551,8 +550,8 @@ const WidgetEditor: React.FC<{
   const getDeleteConfirmationProps = () => {
     if (componentToDelete) {
       return {
-        title: 'Delete Component?',
-        content: 'Are you sure you want to delete this component?',
+        title: 'Delete Block?',
+        content: 'Are you sure you want to delete this block?',
         onConfirm: confirmDeleteComponent,
         onCancel: cancelDeleteComponent,
       }

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
@@ -222,7 +222,7 @@ const ComponentPalette = ({
             }}
           >
             {isPhone
-              ? 'Tap the + button on any block below to add it to your widget.'
+              ? 'Tap any block below to add it to your widget.'
               : 'Grab a block below and drag it into the Daily Operations widget canvas.'}
           </Typography>
         </Box>
@@ -454,7 +454,7 @@ const ComponentPalette = ({
               fontSize: isPhone ? '0.5rem' : '0.65rem',
             }}
           >
-            {isPhone ? 'Tap + to add an item' : 'Drag items into your widget'}
+            {isPhone ? 'Tap a block to add it' : 'Drag blocks into your widget'}
           </Typography>
           <Typography
             variant="caption"
@@ -467,8 +467,8 @@ const ComponentPalette = ({
             {!showTooltips
               ? 'Turn on helpful tips in settings for short explanations'
               : isPhone
-                ? 'Long press items for short explanations'
-                : 'Hover over items for short explanations'}
+                ? 'Long press blocks for short explanations'
+                : 'Hover over blocks for short explanations'}
           </Typography>
         </Box>
       )}

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
@@ -338,7 +338,9 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                       }}
                     >
                       {showOnboardingChoosePrompt
-                        ? 'Drag any block from Building Blocks into this canvas. You can experiment and adjust it after it lands here.'
+                        ? isPhone
+                          ? 'Tap any block in Building Blocks to add it here. You can experiment and adjust it after it lands here.'
+                          : 'Drag any block from Building Blocks into this canvas. You can experiment and adjust it after it lands here.'
                         : isPhone
                           ? 'Use a quick shortcut, then save it for dashboards.'
                           : 'Use these shortcuts to create a reusable widget faster, or drag any block from the palette.'}

--- a/apps/aquamesh/src/components/WidgetEditor/components/dialogs/ComponentSearchDialog.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/dialogs/ComponentSearchDialog.tsx
@@ -199,7 +199,7 @@ const ComponentSearchDialog: React.FC<ComponentSearchDialogProps> = ({
               fontSize: isMobile ? '1.1rem' : undefined,
             }}
           >
-            Search Components
+            Search Blocks
           </Typography>
         </Box>
       </DialogTitle>
@@ -250,7 +250,7 @@ const ComponentSearchDialog: React.FC<ComponentSearchDialogProps> = ({
               color="text.secondary"
               sx={{ fontSize: isMobile ? '0.75rem' : undefined }}
             >
-              Found {searchResults.length} component
+              Found {searchResults.length} block
               {searchResults.length !== 1 ? 's' : ''} matching "{searchTerm}"
             </Typography>
           )}
@@ -268,7 +268,7 @@ const ComponentSearchDialog: React.FC<ComponentSearchDialogProps> = ({
               },
             }}
           >
-            No components found matching your search.
+            No blocks found matching your search.
           </Alert>
         ) : (
           <List

--- a/apps/aquamesh/src/components/WidgetEditor/components/dialogs/SettingsDialog.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/dialogs/SettingsDialog.tsx
@@ -246,8 +246,8 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
                   color="text.secondary"
                   sx={{ ml: 5, mb: 1 }}
                 >
-                  Show short explanations when hovering over building blocks in the
-                  palette.
+                  Show short explanations when hovering over building blocks in
+                  the palette.
                 </Typography>
               </Box>
             </Box>
@@ -264,7 +264,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                   <HelpOutlineIcon sx={{ mr: 1.5, color: 'primary.main' }} />
                   <Typography fontWeight="medium" color="text.primary">
-                    Show Component Palette Help
+                    Show Building Blocks Help
                   </Typography>
                   <Box sx={{ flexGrow: 1 }} />
                   <Switch
@@ -280,7 +280,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
                   color="text.secondary"
                   sx={{ ml: 5, mb: 1 }}
                 >
-                  Show the help text at the bottom of the component palette.
+                  Show the help text at the bottom of the Building Blocks panel.
                 </Typography>
               </Box>
             </Box>

--- a/apps/aquamesh/src/components/WidgetEditor/components/dialogs/SettingsDialog.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/dialogs/SettingsDialog.tsx
@@ -485,7 +485,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
                   <DeleteOutlineIcon sx={{ mr: 1.5, color: 'error.main' }} />
                   <Typography fontWeight="medium" color="text.primary">
-                    Confirm Component Deletion
+                    Confirm Block Deletion
                   </Typography>
                   <Box sx={{ flexGrow: 1 }} />
                   <Switch
@@ -501,7 +501,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
                   color="text.secondary"
                   sx={{ ml: 5, mb: 1 }}
                 >
-                  Show a confirmation dialog when deleting components.
+                  Show a confirmation dialog when deleting blocks.
                 </Typography>
               </Box>
             </Box>

--- a/apps/aquamesh/src/components/WidgetEditor/components/dialogs/WidgetVersioningDialog.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/dialogs/WidgetVersioningDialog.tsx
@@ -365,7 +365,7 @@ const WidgetVersioningDialog: React.FC<WidgetVersioningDialogProps> = ({
                               )}
                               <Chip
                                 size="small"
-                                label={`${version.components.length} items`}
+                                label={`${version.components.length} ${version.components.length === 1 ? 'block' : 'blocks'}`}
                                 variant="outlined"
                                 sx={{ height: 20, fontSize: '0.7rem', borderColor: alpha(theme.palette.divider, 0.6), color: 'text.secondary' }}
                               />
@@ -434,7 +434,7 @@ const WidgetVersioningDialog: React.FC<WidgetVersioningDialogProps> = ({
                       )}
                     </Box>
                     <Typography variant={isPhone ? 'subtitle2' : 'h6'} fontWeight="medium" sx={{mb: 1.5, color: theme.palette.text.primary, fontSize: isPhone ? '1rem' : undefined}}>
-                      Component Summary
+                      Block Summary
                     </Typography>
                     <Paper variant="outlined" sx={{ 
                         p: '16px 20px', borderRadius: 2.5, 
@@ -443,7 +443,7 @@ const WidgetVersioningDialog: React.FC<WidgetVersioningDialogProps> = ({
                         mb: 3, flexGrow: 1, overflow: 'auto' 
                       }}>
                       <Typography variant="subtitle1" fontWeight="bold" gutterBottom color="text.primary">
-                        {selectedVersion.components.length} component{selectedVersion.components.length !== 1 ? 's' : ''}
+                        {selectedVersion.components.length} block{selectedVersion.components.length !== 1 ? 's' : ''}
                       </Typography>
                       {selectedVersion.components.length > 0 ? (
                         <Box component="ul" sx={{ pl: 2.5, m: 0, maxHeight: '220px', overflowY: 'auto' }}>
@@ -477,7 +477,7 @@ const WidgetVersioningDialog: React.FC<WidgetVersioningDialogProps> = ({
                         }}
                       >
                         <Typography variant="subtitle2" gutterBottom fontWeight="medium">
-                          Component Count Comparison
+                          Block Count Comparison
                         </Typography>
                         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-around' }}>
                           <Box sx={{ textAlign: 'center' }}>

--- a/apps/aquamesh/src/components/WidgetEditor/components/preview/ComponentPreview.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/preview/ComponentPreview.tsx
@@ -258,7 +258,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
                     minHeight: editMode ? '60px' : 'auto'
                   }}
                 >
-                  {isDragging ? 'Drop component here' : (editMode ? 'Drag and drop components here' : 'Content will appear here')}
+                  {isDragging ? 'Drop block here' : (editMode ? (isPhone ? 'Tap blocks in Building Blocks to add them here' : 'Drag and drop blocks here') : 'Content will appear here')}
                 </Box>
               )}
             </Collapse>
@@ -498,7 +498,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
                 alignItems: 'center',
                 minHeight: '40px'
               }}>
-                {isDragging ? 'Drop component here' : 'Empty Flex Container'}
+                {isDragging ? 'Drop block here' : 'Empty Flex Container'}
               </Box>
             )}
           </Box>
@@ -576,7 +576,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
                 gridColumn: `span ${columns}`,
                 minHeight: '40px'
               }}>
-                {isDragging ? 'Drop component here' : 'Empty Grid Container'}
+                {isDragging ? 'Drop block here' : 'Empty Grid Container'}
               </Box>
             )}
           </Box>
@@ -742,7 +742,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
           }}
         >
           {/* Visibility toggle button */}
-          <TooltipStyled title={isHidden ? "Show component" : "Hide component"}>
+          <TooltipStyled title={isHidden ? "Show block" : "Hide block"}>
             <IconButton
               size="small"
               onClick={() => onToggleVisibility && onToggleVisibility(component.id)}

--- a/apps/aquamesh/src/components/WidgetEditor/hooks/useWidgetEditor.ts
+++ b/apps/aquamesh/src/components/WidgetEditor/hooks/useWidgetEditor.ts
@@ -525,7 +525,7 @@ export const useWidgetEditor = () => {
           // Show success notification
           setNotification({
             open: true,
-            message: `Added ${componentConfig.label} component`,
+            message: `Added ${componentConfig.label} block`,
             severity: 'success',
           })
         }
@@ -825,7 +825,7 @@ export const useWidgetEditor = () => {
 
     setNotification({
       open: true,
-      message: `Added ${componentConfig.label} component`,
+      message: `Added ${componentConfig.label} block`,
       severity: 'success',
     })
 
@@ -849,7 +849,7 @@ export const useWidgetEditor = () => {
 
       setNotification({
         open: true,
-        message: 'Component deleted',
+        message: 'Block deleted',
         severity: 'success',
       })
       return
@@ -870,7 +870,7 @@ export const useWidgetEditor = () => {
 
       setNotification({
         open: true,
-        message: 'Component deleted',
+        message: 'Block deleted',
         severity: 'error',
       })
 
@@ -1318,7 +1318,7 @@ export const useWidgetEditor = () => {
       // Show success notification
       setNotification({
         open: true,
-        message: `Added ${componentConfig.label} component`,
+        message: `Added ${componentConfig.label} block`,
         severity: 'success',
       })
     }

--- a/apps/aquamesh/src/components/landing/AquaMeshLanding.tsx
+++ b/apps/aquamesh/src/components/landing/AquaMeshLanding.tsx
@@ -29,7 +29,7 @@ const workflow = [
   },
   {
     title: 'Add Blocks',
-    body: 'Drag in text, inputs, buttons, charts, and layout sections.',
+    body: 'Add text, inputs, buttons, charts, and layout sections.',
     icon: <AddchartIcon />,
   },
   {

--- a/apps/aquamesh/src/components/tutorial/FAQDialog.tsx
+++ b/apps/aquamesh/src/components/tutorial/FAQDialog.tsx
@@ -60,8 +60,8 @@ const FAQDialog: React.FC<FAQDialogProps> = ({ open, onClose }) => {
       answer: (
         <>
           Click <span style={accentText}>Create Widget</span> in the top bar,
-          name the widget, drag building blocks onto the canvas, preview it,
-          then save it as a reusable Daily Operations widget.
+          name the widget, add building blocks to the canvas, preview it, then
+          save it as a reusable Daily Operations widget.
         </>
       ),
     },

--- a/apps/aquamesh/src/components/tutorial/WidgetEditorExplanationModal.tsx
+++ b/apps/aquamesh/src/components/tutorial/WidgetEditorExplanationModal.tsx
@@ -130,7 +130,7 @@ const WidgetEditorExplanationModal: React.FC<
           title: 'Add Building Blocks',
           icon: <WidgetsIcon />,
           content: isMobile
-            ? 'Tap the + button on text, answer boxes, buttons, charts, and groups to add them to your widget.'
+            ? 'Tap text, answer boxes, buttons, charts, and groups to add them to your widget.'
             : 'Drag text, answer boxes, buttons, charts, and groups from the left panel into your widget.',
         },
         {

--- a/apps/aquamesh/tests/unit/components/WidgetEditor/CustomWidget.test.tsx
+++ b/apps/aquamesh/tests/unit/components/WidgetEditor/CustomWidget.test.tsx
@@ -108,9 +108,7 @@ describe('CustomWidget live storage refresh', () => {
     })
 
     await waitFor(() => {
-      expect(
-        screen.getByText('This widget has no components'),
-      ).toBeInTheDocument()
+      expect(screen.getByText('This widget has no blocks')).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## Summary
- make Widget Editor help/onboarding copy phone-aware: phone says tap blocks, desktop keeps drag/drop language
- rename user-facing “component” wording to “block” in delete/search/toast/help/empty-widget copy
- update landing/tutorial FAQ copy to avoid desktop-only drag wording where the flow is shared with phone

## Verification
- npx prettier --check apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx apps/aquamesh/src/components/WidgetEditor/components/dialogs/ComponentSearchDialog.tsx apps/aquamesh/src/components/WidgetEditor/components/dialogs/SettingsDialog.tsx apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx apps/aquamesh/src/components/WidgetEditor/hooks/useWidgetEditor.ts apps/aquamesh/src/components/WidgetEditor/CustomWidget.tsx apps/aquamesh/src/components/tutorial/FAQDialog.tsx apps/aquamesh/src/components/tutorial/WidgetEditorExplanationModal.tsx apps/aquamesh/src/components/landing/AquaMeshLanding.tsx apps/aquamesh/tests/unit/components/WidgetEditor/CustomWidget.test.tsx
- cd apps/aquamesh && npx vitest --run --config ./vitest.config.ts tests/unit/components/WidgetEditor/EditorCanvas.test.tsx tests/unit/components/WidgetEditor/WidgetEditor.test.tsx tests/unit/components/WidgetEditor/CustomWidget.test.tsx --reporter verbose
- npm --workspace apps/aquamesh run build