### PR TITLE
Clarify onboarding and starter examples

### DIFF
--- a/apps/aquamesh/README.md
+++ b/apps/aquamesh/README.md
@@ -1,6 +1,6 @@
 # AquaMesh app
 
-AquaMesh is the main no-code custom widget builder in this monorepo. It gives non-programmers a visual workspace for creating reusable dashboard widgets, arranging them into dashboards, and saving layouts without writing UI code.
+AquaMesh is the main no-code custom widget builder in this monorepo. It gives non-programmers a visual workspace for creating reusable widgets from text, inputs, buttons, charts, images, and layout blocks, then arranging them into dashboards or focused workspaces without writing UI code.
 
 ## Product workflow
 
@@ -10,7 +10,7 @@ AquaMesh is the main no-code custom widget builder in this monorepo. It gives no
 4. Save dashboard layouts for reuse.
 5. Import, export, or restore widget versions when work needs to move or be recovered.
 
-For demo and portfolio use, the recommended scenario is a **Daily Operations Dashboard** with orders today, delayed tasks, support ticket mix, system status, team notes, and a handoff action. It gives the app a concrete user story: an operations user can assemble an internal dashboard without waiting for custom code.
+For demo and portfolio use, **Daily Operations** remains one concrete example: orders today, delayed tasks, support ticket mix, system status, team notes, and a handoff action. AquaMesh is broader than that single dashboard: architects can organize site-review notes, biologists can collect observation logs, and teams can build task or research workspaces without waiting for custom code.
 
 ## User-facing capabilities
 

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -169,15 +169,15 @@ const DashboardEmptyState = ({
         sx={{ fontSize: 48, color: 'primary.main', mb: 1 }}
       />
       <Typography variant="h5" fontWeight="bold" gutterBottom>
-        Build your Daily Operations dashboard
+        Start a workspace dashboard
       </Typography>
       <Typography
         variant="body1"
         sx={{ color: 'foreground.contrastSecondary', mb: 3 }}
       >
-        Imagine a small operations team tracking orders, delayed tasks, support
-        tickets, and system status. Start by creating one reusable Daily
-        Operations widget, then place it on this dashboard.
+        Pick one real workflow: daily operations, architecture review notes, lab
+        observations, project tasks, or image-rich research. Create one reusable
+        widget first, then place it on this dashboard.
       </Typography>
       <Stack
         direction={{ xs: 'column', sm: 'row' }}

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
@@ -223,7 +223,7 @@ const ComponentPalette = ({
           >
             {isPhone
               ? 'Tap any block below to add it to your widget.'
-              : 'Grab a block below and drag it into the Daily Operations widget canvas.'}
+              : 'Grab a block below and drag it into your widget canvas.'}
           </Typography>
         </Box>
       )}

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
@@ -252,8 +252,8 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                 }}
               >
                 {showOnboardingPlacePrompt
-                  ? `Open ${isPhone ? 'Add' : 'Add Widget'}, choose the widget called ${widgetData.name || 'Daily Operations'}, and click it to place it on the dashboard.`
-                  : 'Select the blue pen in a block to change its label, data, colors, or layout. Save the Daily Operations widget when it is ready to be used in dashboards.'}
+                  ? `Open ${isPhone ? 'Add' : 'Add Widget'}, choose the widget called ${widgetData.name || 'My First Widget'}, and click it to place it on the dashboard.`
+                  : 'Select the blue pen in a block to change its label, data, colors, or layout. Save the widget when it is ready to be reused.'}
               </Typography>
             </Box>
           </Stack>
@@ -328,7 +328,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                     >
                       {showOnboardingChoosePrompt
                         ? 'Start with one block'
-                        : 'Build a Daily Operations widget'}
+                        : 'Build your first reusable widget'}
                     </Typography>
                     <Typography
                       variant="body2"
@@ -343,7 +343,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                           : 'Drag any block from Building Blocks into this canvas. You can experiment and adjust it after it lands here.'
                         : isPhone
                           ? 'Use a quick shortcut, then save it for dashboards.'
-                          : 'Use these shortcuts to create a reusable widget faster, or drag any block from the palette.'}
+                          : 'Use a shortcut for a concrete example, or drag any block from the palette.'}
                     </Typography>
                   </Box>
 
@@ -362,7 +362,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                         disabled={!onStartOperationsWidget}
                         sx={{ borderRadius: 1, textTransform: 'none' }}
                       >
-                        Daily Operations template
+                        Example operations template
                       </Button>
                       <Button
                         variant="outlined"
@@ -378,7 +378,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                           borderColor: 'primary.dark',
                         }}
                       >
-                        Tickets chart
+                        Chart block
                       </Button>
                       <Button
                         variant="outlined"
@@ -409,7 +409,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                           borderColor: 'primary.dark',
                         }}
                       >
-                        Team note
+                        Notes field
                       </Button>
                       <Button
                         variant="text"

--- a/apps/aquamesh/src/components/WidgetEditor/components/dialogs/WidgetLibrary.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/dialogs/WidgetLibrary.tsx
@@ -445,7 +445,7 @@ const WidgetManagementModal: React.FC<WidgetManagementModalProps> = ({
               <Typography variant="body2" sx={{ maxWidth: 400 }}>
                 {searchTerm
                   ? `No saved widgets match your search for "${searchTerm}"`
-                  : 'Create a Daily Operations widget, save it here, then reuse it in any dashboard.'}
+                  : 'Create a widget for a real use case, save it here, then reuse it in any dashboard.'}
               </Typography>
             </Box>
           ) : (

--- a/apps/aquamesh/src/components/WidgetEditor/constants/templateWidgets.ts
+++ b/apps/aquamesh/src/components/WidgetEditor/constants/templateWidgets.ts
@@ -264,9 +264,9 @@ export const WIDGET_TEMPLATES: CustomWidget[] = [
   },
   {
     id: 'template-operations-dashboard',
-    name: 'Daily Operations Dashboard Template',
+    name: 'Daily Operations Example Template',
     description:
-      'A ready-made daily operations dashboard for tracking orders, delayed tasks, support tickets, system status, team notes, and handoff actions.',
+      'One concrete starter example for tracking orders, delayed tasks, support tickets, system status, team notes, and handoff actions. Use it as inspiration, then adapt AquaMesh to your own domain.',
     category: 'Dashboard',
     components: [
       {

--- a/apps/aquamesh/src/components/landing/AquaMeshLanding.tsx
+++ b/apps/aquamesh/src/components/landing/AquaMeshLanding.tsx
@@ -15,8 +15,9 @@ import SaveAltIcon from '@mui/icons-material/SaveAlt'
 import WidgetsIcon from '@mui/icons-material/Widgets'
 import TaskAltIcon from '@mui/icons-material/TaskAlt'
 import SupportAgentIcon from '@mui/icons-material/SupportAgent'
-import LocalShippingIcon from '@mui/icons-material/LocalShipping'
-import SettingsSuggestIcon from '@mui/icons-material/SettingsSuggest'
+import ArchitectureIcon from '@mui/icons-material/Architecture'
+import BiotechIcon from '@mui/icons-material/Biotech'
+import ImageIcon from '@mui/icons-material/Image'
 import NotesIcon from '@mui/icons-material/Notes'
 
 import { ReactComponent as Logo } from '../../../public/logo.svg'
@@ -24,7 +25,7 @@ import { ReactComponent as Logo } from '../../../public/logo.svg'
 const workflow = [
   {
     title: 'Create Widget',
-    body: 'Name a Daily Operations widget and start from visual building blocks.',
+    body: 'Name a widget for your work: an operations snapshot, site review, lab log, or task tracker.',
     icon: <WidgetsIcon />,
   },
   {
@@ -46,24 +47,29 @@ const workflow = [
 
 const useCases = [
   {
-    title: 'Orders today',
-    body: 'Track intake, fulfillment, and handoff status.',
-    icon: <LocalShippingIcon />,
-  },
-  {
-    title: 'Delayed tasks',
-    body: 'Surface blocked work before it misses the day.',
-    icon: <TaskAltIcon />,
-  },
-  {
-    title: 'Support tickets',
-    body: 'Show ticket mix, priority, and follow-up notes.',
+    title: 'Operations hub',
+    body: 'Track orders, delayed work, tickets, status, and handoffs.',
     icon: <SupportAgentIcon />,
   },
   {
-    title: 'System status',
-    body: 'Keep health indicators visible beside team actions.',
-    icon: <SettingsSuggestIcon />,
+    title: 'Architecture review',
+    body: 'Collect site notes, material choices, images, and decisions.',
+    icon: <ArchitectureIcon />,
+  },
+  {
+    title: 'Biology field log',
+    body: 'Record observations, sample counts, charts, and next steps.',
+    icon: <BiotechIcon />,
+  },
+  {
+    title: 'Task workspace',
+    body: 'Organize priorities, blockers, owners, and follow-up actions.',
+    icon: <TaskAltIcon />,
+  },
+  {
+    title: 'Image and notes board',
+    body: 'Pair visual references with structured text and controls.',
+    icon: <ImageIcon />,
   },
   {
     title: 'Team handoff',
@@ -76,17 +82,17 @@ const quickAnswers = [
   {
     question: 'What should I do first?',
     answer:
-      'Start with Create Widget. Build one reusable Daily Operations widget first, then add it to a dashboard.',
+      'Start with Create Widget. Pick one concrete use case, such as an operations summary, architecture site review, lab observation log, or task tracker. Save it, then reuse it in a dashboard.',
   },
   {
     question: 'Which blocks should I start with?',
     answer:
-      'Use a chart for support tickets, a status label for system health, or a note field for team handoff.',
+      'Use a chart for trends, a label for status, an image for visual context, or a note field for follow-up.',
   },
   {
     question: 'Where does my saved widget go?',
     answer:
-      'Saved widgets appear in Add Widget so you can reuse them in dashboards.',
+      'Saved widgets appear in Add Widget so you can reuse them across dashboards and workspaces.',
   },
 ]
 
@@ -166,12 +172,13 @@ const AquaMeshLanding = () => {
               component="p"
               sx={{ fontWeight: 700, color: '#005A49', mb: 2 }}
             >
-              Create operational dashboard widgets without code.
+              Create reusable workspace widgets without code.
             </Typography>
             <Typography variant="body1" sx={{ color: '#425c57', mb: 3 }}>
-              Build reusable widgets for orders, delayed tasks, support tickets,
-              system status, team notes, and handoff actions, then place them
-              into dashboards.
+              Build reusable widgets from text, inputs, buttons, charts, images,
+              and layout blocks. Use them for operations, architecture reviews,
+              biology notes, project planning, or any workspace you need to
+              organize.
             </Typography>
             <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
               <Button
@@ -250,7 +257,7 @@ const AquaMeshLanding = () => {
 
         <Box sx={{ py: 5 }}>
           <Typography variant="h4" component="h2" fontWeight={850} mb={3}>
-            Made for daily operations
+            Use AquaMesh for real work
           </Typography>
           <Grid container spacing={2}>
             {useCases.map((useCase) => (
@@ -321,11 +328,12 @@ const AquaMeshLanding = () => {
           }}
         >
           <Typography variant="h4" component="h2" fontWeight={850} mb={1}>
-            Ready to build your first dashboard?
+            Ready to build your first workspace?
           </Typography>
           <Typography sx={{ color: 'rgba(255,255,255,0.82)', mb: 3 }}>
-            Enter the workspace, create one reusable widget, and place it on a
-            dashboard.
+            Enter the workspace, create one reusable widget, and place it
+            wherever it helps: a dashboard, review board, lab log, or task
+            space.
           </Typography>
           <Button
             variant="contained"

--- a/apps/aquamesh/src/components/topnavbar/TopNavBar.tsx
+++ b/apps/aquamesh/src/components/topnavbar/TopNavBar.tsx
@@ -337,7 +337,7 @@ const TopNavBar: React.FC<TopNavBarProps> = () => {
                       }}
                     >
                       {userData.role === 'ADMIN_ROLE'
-                        ? 'No saved widgets yet. Create a Daily Operations widget, then add it to this dashboard.'
+                        ? 'No saved widgets yet. Create a widget for your work, then add it to this dashboard.'
                         : 'Switch to Builder mode to create your own reusable widgets.'}
                     </Typography>
                   </MenuItem>
@@ -353,7 +353,7 @@ const TopNavBar: React.FC<TopNavBarProps> = () => {
                       color: 'text.primary',
                     }}
                   >
-                    Example Operations Widgets
+                    Example Starter Widgets
                   </Typography>
                   <Divider sx={{ borderColor: 'divider' }} />
                   {topNavBarWidgets

--- a/apps/aquamesh/src/components/tutorial/FAQDialog.tsx
+++ b/apps/aquamesh/src/components/tutorial/FAQDialog.tsx
@@ -39,7 +39,7 @@ const FAQDialog: React.FC<FAQDialogProps> = ({ open, onClose }) => {
       category: 'Start Here',
       question: 'What should I do first?',
       answer:
-        'Start with Create Widget. Build one reusable Daily Operations widget first, then add it to a dashboard.',
+        'Start with Create Widget. Pick one concrete use case, such as an operations summary, architecture site review, lab observation log, or task tracker. Save it, then reuse it in a dashboard.',
     },
     {
       category: 'Start Here',
@@ -47,8 +47,8 @@ const FAQDialog: React.FC<FAQDialogProps> = ({ open, onClose }) => {
       answer: (
         <>
           1. Open <span style={accentText}>Create Widget</span>. 2. Build a
-          Daily Operations summary for orders today, delayed tasks, support
-          tickets, and system status. 3. Click Save. 4. Open{' '}
+          focused widget for your work: operations status, site-review notes,
+          lab observations, or a task board. 3. Click Save. 4. Open{' '}
           <span style={accentText}>Add Widget</span> and place the saved widget
           on a dashboard.
         </>
@@ -61,7 +61,7 @@ const FAQDialog: React.FC<FAQDialogProps> = ({ open, onClose }) => {
         <>
           Click <span style={accentText}>Create Widget</span> in the top bar,
           name the widget, add building blocks to the canvas, preview it, then
-          save it as a reusable Daily Operations widget.
+          save it as a reusable widget.
         </>
       ),
     },
@@ -69,7 +69,7 @@ const FAQDialog: React.FC<FAQDialogProps> = ({ open, onClose }) => {
       category: 'Create Widget',
       question: 'Which building blocks should I start with?',
       answer:
-        'Start with one concrete operations need: a chart for support tickets, a status label for system health, or a note field for team handoff.',
+        'Start with one concrete need: a chart for trends, a status label, an image for context, or a note field for follow-up.',
     },
     {
       category: 'Create Widget',

--- a/apps/aquamesh/src/components/tutorial/TutorialModal.tsx
+++ b/apps/aquamesh/src/components/tutorial/TutorialModal.tsx
@@ -128,9 +128,9 @@ const TutorialModal: React.FC<TutorialModalProps> = ({
   // Create Widget is the primary path for builder users.
   if (isAdmin) {
     options.push({
-      title: 'Create a Daily Operations widget',
+      title: 'Create your first reusable widget',
       description:
-        'Open Create Widget and build a reusable summary for orders today, delayed tasks, support tickets, and system status.',
+        'Open Create Widget and build something concrete: an operations summary, architecture site review, lab observation log, or task tracker.',
       icon: <CreateIcon fontSize="large" color="primary" />,
       buttonText: 'Start building',
       image: placeholderImages.customWidgetCreation,
@@ -146,9 +146,9 @@ const TutorialModal: React.FC<TutorialModalProps> = ({
     })
   } else {
     options.push({
-      title: 'Create a Daily Operations widget',
+      title: 'Create your first reusable widget',
       description:
-        'The recommended path is to create a reusable Daily Operations widget first, then add it to a dashboard. Builder mode is required to save widgets.',
+        'The recommended path is to create one reusable widget for a real use case, then add it to a dashboard. Builder mode is required to save widgets.',
       icon: <CreateIcon fontSize="large" color="primary" />,
       buttonText: 'View Quick Start',
       image: placeholderImages.customWidgetCreation,
@@ -162,7 +162,7 @@ const TutorialModal: React.FC<TutorialModalProps> = ({
     {
       title: 'Use the widget in a dashboard',
       description:
-        'After saving, open Add Widget, choose the saved Daily Operations widget, and place it into the current dashboard.',
+        'After saving, open Add Widget, choose your saved widget, and place it into the current dashboard.',
       icon: <DashboardIcon fontSize="large" color="primary" />,
       image: placeholderImages.predefinedWidgets,
       hasMultipleButtons: true,
@@ -190,7 +190,7 @@ const TutorialModal: React.FC<TutorialModalProps> = ({
     {
       title: 'View an example dashboard',
       description:
-        'Use the dashboard menu only when you want inspiration from a finished layout. The recommended first step is still Create Widget.',
+        'Use the dashboard menu when you want inspiration from a finished layout. Daily Operations is one example, not the only kind of workspace AquaMesh can organize.',
       icon: <InfoIcon fontSize="large" color="primary" />,
       hasMultipleImages: true,
       images: [

--- a/apps/aquamesh/src/components/tutorial/WidgetEditorExplanationModal.tsx
+++ b/apps/aquamesh/src/components/tutorial/WidgetEditorExplanationModal.tsx
@@ -376,8 +376,8 @@ const WidgetEditorExplanationModal: React.FC<
               </Typography>
             </Box>
             <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-              Add blocks that match the Daily Operations story: orders today,
-              delayed tasks, support tickets, system status, and team notes.
+              Add blocks that match your chosen workflow: status labels, charts,
+              notes, images, controls, or layout sections.
             </Typography>
           </Paper>
         </Grid>

--- a/apps/aquamesh/tests/e2e/support.spec.ts
+++ b/apps/aquamesh/tests/e2e/support.spec.ts
@@ -10,18 +10,18 @@ test.describe('Landing tutorial page', () => {
       page.getByRole('heading', { name: 'AquaMesh' }).first(),
     ).toBeVisible()
     await expect(
-      page.getByText('Create operational dashboard widgets without code.'),
+      page.getByText('Create reusable workspace widgets without code.'),
     ).toBeVisible()
-    await expect(page.getByText('Build one widget, then reuse it')).toBeVisible()
-    await expect(page.getByText('Made for daily operations')).toBeVisible()
+    await expect(
+      page.getByText('Build one widget, then reuse it'),
+    ).toBeVisible()
+    await expect(page.getByText('Use AquaMesh for real work')).toBeVisible()
 
     await expect(page.getByText('What should I do first?')).toBeVisible()
   })
 
   test('should open the workspace from the landing CTA', async ({ page }) => {
-    await page
-      .getByRole('button', { name: 'Create Daily Operations widget' })
-      .click()
+    await page.getByRole('button', { name: 'Enter workspace' }).first().click()
 
     await page.waitForURL('http://localhost:3000/workspace')
     await expect(page.getByText('Building Blocks')).toBeVisible({

--- a/apps/aquamesh/tests/unit/components/WidgetEditor/EditorCanvas.test.tsx
+++ b/apps/aquamesh/tests/unit/components/WidgetEditor/EditorCanvas.test.tsx
@@ -88,19 +88,19 @@ describe('EditorCanvas first-widget guide', () => {
     renderEditorCanvas()
 
     expect(
-      screen.getByText('Build a Daily Operations widget'),
+      screen.getByText('Build your first reusable widget'),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /daily operations template/i }),
+      screen.getByRole('button', { name: /example operations template/i }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /tickets chart/i }),
+      screen.getByRole('button', { name: /chart block/i }),
     ).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /status text/i }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /team note/i }),
+      screen.getByRole('button', { name: /notes field/i }),
     ).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /browse templates/i }),
@@ -111,11 +111,11 @@ describe('EditorCanvas first-widget guide', () => {
     const props = renderEditorCanvas()
 
     fireEvent.click(
-      screen.getByRole('button', { name: /daily operations template/i }),
+      screen.getByRole('button', { name: /example operations template/i }),
     )
-    fireEvent.click(screen.getByRole('button', { name: /tickets chart/i }))
+    fireEvent.click(screen.getByRole('button', { name: /chart block/i }))
     fireEvent.click(screen.getByRole('button', { name: /status text/i }))
-    fireEvent.click(screen.getByRole('button', { name: /team note/i }))
+    fireEvent.click(screen.getByRole('button', { name: /notes field/i }))
     fireEvent.click(screen.getByRole('button', { name: /browse templates/i }))
 
     expect(props.onStartOperationsWidget).toHaveBeenCalledTimes(1)
@@ -140,7 +140,7 @@ describe('EditorCanvas first-widget guide', () => {
     })
 
     expect(
-      screen.queryByText('Build a Daily Operations widget'),
+      screen.queryByText('Build your first reusable widget'),
     ).not.toBeInTheDocument()
     expect(screen.getByTestId('component-preview')).toHaveTextContent('Label')
   })
@@ -149,7 +149,7 @@ describe('EditorCanvas first-widget guide', () => {
     renderEditorCanvas({ isDragging: true })
 
     expect(
-      screen.queryByText('Build a Daily Operations widget'),
+      screen.queryByText('Build your first reusable widget'),
     ).not.toBeInTheDocument()
     expect(screen.getByText('Drop it into your widget')).toBeInTheDocument()
   })

--- a/apps/aquamesh/tests/unit/components/dashboard/Dashboard.test.tsx
+++ b/apps/aquamesh/tests/unit/components/dashboard/Dashboard.test.tsx
@@ -92,14 +92,14 @@ describe('Dashboards', () => {
     })
   })
 
-  it('shows Daily Operations actions when the selected dashboard is empty', () => {
+  it('shows workspace actions when the selected dashboard is empty', () => {
     mockDashboardProvider({})
 
     render(<Dashboards />)
 
     expect(
       screen.getByRole('heading', {
-        name: /build your daily operations dashboard/i,
+        name: /start a workspace dashboard/i,
       }),
     ).toBeInTheDocument()
     expect(

--- a/apps/aquamesh/tests/unit/components/topnavbar/TopNavBar.test.tsx
+++ b/apps/aquamesh/tests/unit/components/topnavbar/TopNavBar.test.tsx
@@ -182,7 +182,9 @@ describe('TopNavBar Component', () => {
       screen.getByRole('button', { name: /create widget/i }),
     ).toBeInTheDocument()
     expect(screen.queryByTitle('Open tutorial')).not.toBeInTheDocument()
-    expect(screen.queryByTitle('Frequently Asked Questions')).not.toBeInTheDocument()
+    expect(
+      screen.queryByTitle('Frequently Asked Questions'),
+    ).not.toBeInTheDocument()
   })
 
   it('navigates home when the logo is clicked', () => {
@@ -210,7 +212,7 @@ describe('TopNavBar Component', () => {
     // Check if the menu items appear
     await waitFor(() => {
       expect(screen.getByText('Saved Widgets')).toBeInTheDocument()
-      expect(screen.getByText('Example Operations Widgets')).toBeInTheDocument()
+      expect(screen.getByText('Example Starter Widgets')).toBeInTheDocument()
     })
   })
 
@@ -227,7 +229,7 @@ describe('TopNavBar Component', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Saved Widgets')).toBeInTheDocument()
-      expect(screen.getByText('Example Operations Widgets')).toBeInTheDocument()
+      expect(screen.getByText('Example Starter Widgets')).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## Summary
- Broaden AquaMesh onboarding copy beyond the Daily Operations example
- Keep Daily Operations as one concrete starter widget while highlighting reusable workspaces/widgets
- Update landing, dashboard empty state, editor guidance, FAQ/tutorial copy, README, and related tests

## Verification
- npx prettier --check on changed files
- git diff --check

## Notes
- Full Vitest/build could not run locally because the existing dependency install/lockfile is incomplete/out of sync in this workspace.