### PR TITLE
Add persisted dark mode toggle

### DIFF
--- a/apps/aquamesh/src/App.tsx
+++ b/apps/aquamesh/src/App.tsx
@@ -27,6 +27,7 @@ import {
   readStoredAccentColorId,
   writeStoredAccentColorId,
 } from './theme/accentColors'
+import { ThemeModeProvider, useThemeMode } from './theme/ThemeModeContext'
 import { PrimeReactProvider } from 'primereact/api'
 import 'primeflex/primeflex.css'
 import 'primeicons/primeicons.css'
@@ -98,15 +99,16 @@ const WorkspacePage = () => {
   )
 }
 
-const App = () => {
+const AppShell = () => {
+  const { mode } = useThemeMode()
   const [accentColorId, setAccentColorId] = useState(readStoredAccentColorId)
   const accentColor = useMemo(
     () => getAccentColorById(accentColorId),
     [accentColorId],
   )
   const theme = useMemo(
-    () => createAquaMeshTheme(accentColorId),
-    [accentColorId],
+    () => createAquaMeshTheme(mode, accentColorId),
+    [accentColorId, mode],
   )
 
   useEffect(() => {
@@ -125,33 +127,41 @@ const App = () => {
   )
 
   return (
+    <AccentColorProvider value={accentColorContextValue}>
+      <ThemeProvider theme={theme}>
+        <PrimeReactProvider value={{ ripple: true }}>
+          <CssBaseline />
+          <DashboardProvider>
+            <LayoutProvider>
+              <Routes>
+                <Route path="/login" element={<Login />} />
+                <Route path="/" element={<AquaMeshLanding />} />
+                <Route
+                  path="/workspace"
+                  element={
+                    <ProtectedRoute>
+                      <WorkspacePage />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route path="*" element={<Navigate to="/" replace />} />
+              </Routes>
+            </LayoutProvider>
+          </DashboardProvider>
+        </PrimeReactProvider>
+      </ThemeProvider>
+    </AccentColorProvider>
+  )
+}
+
+const App = () => {
+  return (
     <BrowserRouter>
-      <AccentColorProvider value={accentColorContextValue}>
-        <ThemeProvider theme={theme}>
-          <PrimeReactProvider value={{ ripple: true }}>
-            <CssBaseline />
-            <DashboardProvider>
-              <LayoutProvider>
-                <CssBaseline />
-                <Routes>
-                  <Route path="/login" element={<Login />} />
-                  <Route path="/" element={<AquaMeshLanding />} />
-                  <Route
-                    path="/workspace"
-                    element={
-                      <ProtectedRoute>
-                        <WorkspacePage />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route path="*" element={<Navigate to="/" replace />} />
-                </Routes>
-              </LayoutProvider>
-            </DashboardProvider>
-          </PrimeReactProvider>
-        </ThemeProvider>
-      </AccentColorProvider>
+      <ThemeModeProvider>
+        <AppShell />
+      </ThemeModeProvider>
     </BrowserRouter>
   )
 }
+
 export default App

--- a/apps/aquamesh/src/components/Dasboard/tabs.scss
+++ b/apps/aquamesh/src/components/Dasboard/tabs.scss
@@ -12,16 +12,20 @@
     padding: 0;
     margin: 0;
     overflow-x: auto;
-    
+
     &::-webkit-scrollbar {
       height: 4px; /* Controls the scrollbar thickness */
     }
 
     & .react-tabs__tab {
       background-color: var(--background-paper);
+      border: 1px solid var(--surface-border, var(--other-divider));
+      border-bottom: 0;
 
-      & .react-tabs__tab--selected {
-        background-color: var(--primary-main);
+      &.react-tabs__tab--selected {
+        background-color: var(--background-bar-medium);
+        color: var(--foreground-primary);
+        border-color: var(--primary-main);
       }
     }
   }
@@ -47,8 +51,8 @@
     &:not(&--selected) {
       // REVIEW does not match design (set Y offset to -16px instead of -8px and
       // spread to 0px instead of -16px to actually see the shadow)
-      box-shadow: inset 0 -8px 8px rgba(0, 0, 0, 0.07);
-      opacity: 0.6;
+      box-shadow: inset 0 -8px 8px rgba(0, 0, 0, 0.12);
+      opacity: 0.78;
 
       &:hover {
         opacity: 0.7;
@@ -72,7 +76,7 @@
 
   &__tab-panel {
     position: relative;
-    background: var(--background-bar-medium, #F4F7F8);
+    background: var(--background-bar-medium, #f4f7f8);
     // NOTE use the whole viewport and substract (1) header's height, (2) main
     // content's top padding, (3) tab bar height, and (4) main content's bottom
     // padding

--- a/apps/aquamesh/src/components/Layout/layout.scss
+++ b/apps/aquamesh/src/components/Layout/layout.scss
@@ -50,9 +50,11 @@
 .flexlayout__tabset {
   border-radius: 8px;
   background-color: var(--background-paper);
-  border: 1px solid var(--grey-200);
+  border: 1px solid var(--surface-border, var(--grey-200));
 
-  & .flexlayout__tabset-selected .flexlayout__tabset_tabbar_inner_tab_container  {
+  &
+    .flexlayout__tabset-selected
+    .flexlayout__tabset_tabbar_inner_tab_container {
     background-color: var(--background-paper);
   }
 
@@ -95,7 +97,7 @@
 }
 
 .flexlayout__tab_button {
-  background-color: transparent;
+  background-color: var(--background-paper);
   height: 32px;
   line-height: 1;
   min-width: 132px;
@@ -116,7 +118,8 @@
 
     &.flexlayout__tab_button--selected {
       color: var(--foreground-primary);
-      background-color: var(--action-selected);
+      background-color: var(--background-bar-medium);
+      border: 1px solid var(--primary-main);
       border-bottom: 1px solid var(--primary-main);
     }
 
@@ -146,7 +149,7 @@
     width: 24px;
     height: 24px;
     cursor: pointer;
-    
+
     & > svg {
       color: var(--foreground-primary);
     }
@@ -154,7 +157,8 @@
 }
 
 /* Hide the entire toolbar when tab container is empty */
-.flexlayout__tabset:has(.flexlayout__tabset_tabbar_inner_tab_container:empty) .flexlayout__tab_toolbar {
+.flexlayout__tabset:has(.flexlayout__tabset_tabbar_inner_tab_container:empty)
+  .flexlayout__tab_toolbar {
   display: none !important;
 }
 

--- a/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/WidgetEditor.tsx
@@ -697,7 +697,7 @@ const WidgetEditor: React.FC<{
               borderLeft: { xs: 0, md: viewMode === 'both' ? 1 : 0 },
               borderTop: { xs: viewMode === 'both' ? 1 : 0, md: 0 },
               borderColor: 'divider',
-              bgcolor: '#F8FAFA',
+              bgcolor: 'background.default',
               display: 'flex',
               flexDirection: 'column',
               overflow: 'hidden',
@@ -709,7 +709,7 @@ const WidgetEditor: React.FC<{
                 py: 1,
                 borderBottom: 1,
                 borderColor: 'divider',
-                bgcolor: '#FFFFFF',
+                bgcolor: 'background.paper',
               }}
             >
               <Typography variant="subtitle2" color="text.primary">
@@ -722,7 +722,7 @@ const WidgetEditor: React.FC<{
                 minHeight: 0,
                 overflow: 'auto',
                 p: { xs: 1.5, md: 2 },
-                bgcolor: '#FAFBFB',
+                bgcolor: 'background.default',
               }}
             >
               <CustomWidgetPreview components={widgetData.components} />

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
@@ -162,7 +162,7 @@ const ComponentPalette = ({
         minWidth: isPhone ? 0 : drawerWidth,
         maxWidth: drawerWidth,
         flex: isPhone ? '0 0 auto' : `0 0 ${drawerWidth}px`,
-        bgcolor: '#FFFFFF',
+        bgcolor: 'background.paper',
         borderRight: 0,
         borderBottom: { xs: 1, sm: 0 },
         borderColor: 'divider',
@@ -180,7 +180,7 @@ const ComponentPalette = ({
         sx={{
           px: isPhone ? 1 : 2,
           py: isPhone ? 0.75 : 1,
-          color: 'foreground.contrastPrimary',
+          color: 'text.primary',
           fontWeight: 'bold',
           borderBottom: 1,
           borderColor: 'divider',
@@ -217,7 +217,7 @@ const ComponentPalette = ({
           <Typography
             variant="body2"
             sx={{
-              color: 'foreground.contrastPrimary',
+              color: 'text.primary',
               fontSize: isPhone ? '0.72rem' : '0.82rem',
               lineHeight: 1.35,
             }}

--- a/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/EditorCanvas.tsx
@@ -154,7 +154,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
         display: 'flex',
         flexDirection: 'column',
         overflowY: 'auto',
-        bgcolor: '#F8FAFA',
+        bgcolor: 'background.default',
         transition: 'width 0.3s ease',
         width: '100%',
       }}
@@ -304,7 +304,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
               <Typography
                 variant="subtitle2"
                 sx={{
-                  color: 'foreground.contrastPrimary',
+                  color: 'text.primary',
                   fontWeight: 700,
                   mb: 0.25,
                 }}
@@ -316,7 +316,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
               <Typography
                 variant="body2"
                 sx={{
-                  color: 'foreground.contrastSecondary',
+                  color: 'text.secondary',
                   fontSize: isPhone ? '0.78rem' : undefined,
                 }}
               >
@@ -349,7 +349,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
           borderRadius: 1,
           minHeight: isPhone ? 150 : 200,
           overflowY: 'auto',
-          color: 'foreground.contrastPrimary',
+          color: 'text.primary',
           boxShadow: 'none',
           transition: 'background-color 0.2s',
         }}
@@ -365,7 +365,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
               flexDirection: 'column',
               justifyContent: 'center',
               alignItems: 'center',
-              color: 'foreground.contrastPrimary',
+              color: 'text.primary',
               pt: isPhone ? 2 : 4,
               pb: isPhone ? 2 : 4,
               px: isPhone ? 0.5 : 2,
@@ -390,7 +390,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                       variant={isPhone ? 'subtitle1' : 'h6'}
                       sx={{
                         fontWeight: 700,
-                        color: 'foreground.contrastPrimary',
+                        color: 'text.primary',
                         mb: 0.5,
                       }}
                     >
@@ -401,7 +401,7 @@ const EditorCanvas: React.FC<EditorCanvasProps> = ({
                     <Typography
                       variant="body2"
                       sx={{
-                        color: 'foreground.contrastSecondary',
+                        color: 'text.secondary',
                         fontSize: isPhone ? '0.78rem' : undefined,
                       }}
                     >

--- a/apps/aquamesh/src/components/landing/AquaMeshLanding.tsx
+++ b/apps/aquamesh/src/components/landing/AquaMeshLanding.tsx
@@ -7,7 +7,9 @@ import {
   Paper,
   Stack,
   Typography,
+  useTheme,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import { useNavigate } from 'react-router-dom'
 import AddchartIcon from '@mui/icons-material/Addchart'
 import DashboardCustomizeIcon from '@mui/icons-material/DashboardCustomize'
@@ -21,6 +23,7 @@ import ImageIcon from '@mui/icons-material/Image'
 import NotesIcon from '@mui/icons-material/Notes'
 
 import { ReactComponent as Logo } from '../../../public/logo.svg'
+import ThemeModeToggle from '../shared/ThemeModeToggle'
 
 const workflow = [
   {
@@ -98,6 +101,7 @@ const quickAnswers = [
 
 const AquaMeshLanding = () => {
   const navigate = useNavigate()
+  const theme = useTheme()
 
   const openWorkspace = (action?: string) => {
     navigate(action ? `/workspace?action=${action}` : '/workspace')
@@ -107,16 +111,18 @@ const AquaMeshLanding = () => {
     <Box
       sx={{
         minHeight: '100dvh',
-        bgcolor: '#f6fbf9',
-        color: '#12352f',
+        bgcolor: 'background.default',
+        color: 'text.primary',
         overflowX: 'hidden',
       }}
     >
       <Box
         component="header"
         sx={{
-          borderBottom: '1px solid rgba(0, 90, 73, 0.12)',
-          bgcolor: 'rgba(246, 251, 249, 0.92)',
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+          bgcolor: alpha(theme.palette.background.default, 0.92),
+          backdropFilter: 'blur(14px)',
           position: 'sticky',
           top: 0,
           zIndex: 10,
@@ -137,13 +143,16 @@ const AquaMeshLanding = () => {
               AquaMesh
             </Typography>
           </Stack>
-          <Button
-            variant="outlined"
-            onClick={() => openWorkspace()}
-            sx={{ borderRadius: 1, textTransform: 'none' }}
-          >
-            Enter workspace
-          </Button>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <ThemeModeToggle />
+            <Button
+              variant="outlined"
+              onClick={() => openWorkspace()}
+              sx={{ borderRadius: 1, textTransform: 'none' }}
+            >
+              Enter workspace
+            </Button>
+          </Stack>
         </Container>
       </Box>
 
@@ -174,7 +183,7 @@ const AquaMeshLanding = () => {
             >
               Create reusable workspace widgets without code.
             </Typography>
-            <Typography variant="body1" sx={{ color: '#425c57', mb: 3 }}>
+            <Typography variant="body1" sx={{ color: 'text.secondary', mb: 3 }}>
               Build reusable widgets from text, inputs, buttons, charts, images,
               and layout blocks. Use them for operations, architecture reviews,
               biology notes, project planning, or any workspace you need to
@@ -196,10 +205,14 @@ const AquaMeshLanding = () => {
               elevation={0}
               sx={{
                 borderRadius: 2,
-                border: '1px solid rgba(0, 90, 73, 0.16)',
+                border: '1px solid',
+                borderColor: 'divider',
                 overflow: 'hidden',
-                bgcolor: '#ffffff',
-                boxShadow: '0 22px 60px rgba(0, 61, 49, 0.14)',
+                bgcolor: 'background.paper',
+                boxShadow:
+                  theme.palette.mode === 'dark'
+                    ? `0 22px 60px ${alpha(theme.palette.common.black, 0.42)}`
+                    : `0 22px 60px ${alpha(theme.palette.primary.dark, 0.14)}`,
               }}
             >
               <Box
@@ -231,22 +244,23 @@ const AquaMeshLanding = () => {
                     height: '100%',
                     p: 2.5,
                     borderRadius: 1,
-                    border: '1px solid rgba(0, 90, 73, 0.14)',
-                    bgcolor: '#ffffff',
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    bgcolor: 'background.paper',
                   }}
                 >
                   <Stack direction="row" spacing={1} alignItems="center" mb={1}>
                     <Box sx={{ color: 'primary.main', display: 'flex' }}>
                       {step.icon}
                     </Box>
-                    <Typography variant="caption" color="#667c78">
+                    <Typography variant="caption" color="text.secondary">
                       Step {index + 1}
                     </Typography>
                   </Stack>
                   <Typography variant="h6" fontWeight={800} mb={1}>
                     {step.title}
                   </Typography>
-                  <Typography variant="body2" color="#425c57">
+                  <Typography variant="body2" color="text.secondary">
                     {step.body}
                   </Typography>
                 </Paper>
@@ -268,8 +282,9 @@ const AquaMeshLanding = () => {
                     height: '100%',
                     p: 2.5,
                     borderRadius: 1,
-                    border: '1px solid rgba(0, 90, 73, 0.14)',
-                    bgcolor: '#ffffff',
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    bgcolor: 'background.paper',
                   }}
                 >
                   <Box sx={{ color: 'primary.main', display: 'flex', mb: 1 }}>
@@ -278,7 +293,7 @@ const AquaMeshLanding = () => {
                   <Typography variant="h6" fontWeight={800} mb={0.5}>
                     {useCase.title}
                   </Typography>
-                  <Typography variant="body2" color="#425c57">
+                  <Typography variant="body2" color="text.secondary">
                     {useCase.body}
                   </Typography>
                 </Paper>
@@ -300,14 +315,15 @@ const AquaMeshLanding = () => {
                     height: '100%',
                     p: 2.5,
                     borderRadius: 1,
-                    border: '1px solid rgba(0, 90, 73, 0.14)',
-                    bgcolor: '#ffffff',
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    bgcolor: 'background.paper',
                   }}
                 >
                   <Typography variant="h6" fontWeight={800} mb={1}>
                     {item.question}
                   </Typography>
-                  <Typography variant="body2" color="#425c57">
+                  <Typography variant="body2" color="text.secondary">
                     {item.answer}
                   </Typography>
                 </Paper>
@@ -323,14 +339,19 @@ const AquaMeshLanding = () => {
             p: { xs: 3, sm: 4 },
             borderRadius: 2,
             bgcolor: 'primary.dark',
-            color: '#ffffff',
+            color: 'primary.contrastText',
             textAlign: 'center',
           }}
         >
           <Typography variant="h4" component="h2" fontWeight={850} mb={1}>
             Ready to build your first workspace?
           </Typography>
-          <Typography sx={{ color: 'rgba(255,255,255,0.82)', mb: 3 }}>
+          <Typography
+            sx={{
+              color: alpha(theme.palette.primary.contrastText, 0.82),
+              mb: 3,
+            }}
+          >
             Enter the workspace, create one reusable widget, and place it
             wherever it helps: a dashboard, review board, lab log, or task
             space.
@@ -343,7 +364,8 @@ const AquaMeshLanding = () => {
               borderRadius: 1,
               textTransform: 'none',
               bgcolor: 'primary.main',
-              '&:hover': { bgcolor: 'primary.dark' },
+              color: 'primary.contrastText',
+              '&:hover': { bgcolor: 'primary.light' },
             }}
           >
             Enter workspace

--- a/apps/aquamesh/src/components/shared/ThemeModeToggle.tsx
+++ b/apps/aquamesh/src/components/shared/ThemeModeToggle.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { IconButton, Tooltip, useTheme } from '@mui/material'
+import DarkModeIcon from '@mui/icons-material/DarkMode'
+import LightModeIcon from '@mui/icons-material/LightMode'
+
+import { useThemeMode } from '../../theme/ThemeModeContext'
+
+interface ThemeModeToggleProps {
+  compact?: boolean
+}
+
+const ThemeModeToggle: React.FC<ThemeModeToggleProps> = ({
+  compact = false,
+}) => {
+  const theme = useTheme()
+  const { mode, toggleMode } = useThemeMode()
+  const isDark = mode === 'dark'
+
+  return (
+    <Tooltip title={`Switch to ${isDark ? 'light' : 'dark'} mode`}>
+      <IconButton
+        aria-label={`Switch to ${isDark ? 'light' : 'dark'} mode`}
+        onClick={toggleMode}
+        size={compact ? 'small' : 'medium'}
+        sx={{
+          border: '1px solid',
+          borderColor: 'divider',
+          color: 'text.primary',
+          bgcolor:
+            theme.palette.mode === 'dark'
+              ? 'rgba(255,255,255,0.06)'
+              : 'rgba(255,255,255,0.72)',
+          '&:hover': {
+            bgcolor: 'action.hover',
+          },
+        }}
+      >
+        {isDark ? (
+          <LightModeIcon fontSize="small" />
+        ) : (
+          <DarkModeIcon fontSize="small" />
+        )}
+      </IconButton>
+    </Tooltip>
+  )
+}
+
+export default ThemeModeToggle

--- a/apps/aquamesh/src/components/topnavbar/TopNavBar.tsx
+++ b/apps/aquamesh/src/components/topnavbar/TopNavBar.tsx
@@ -32,6 +32,7 @@ import {
   OPEN_WIDGET_MENU_EVENT,
   useWorkspaceActions,
 } from '../../customHooks/useWorkspaceActions'
+import ThemeModeToggle from '../shared/ThemeModeToggle'
 
 // Define user data type
 interface UserData {
@@ -465,7 +466,8 @@ const TopNavBar: React.FC<TopNavBarProps> = () => {
           </Box>
 
           {/* Right Side Elements */}
-          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <ThemeModeToggle compact={isPhone} />
             <Divider
               orientation="vertical"
               flexItem

--- a/apps/aquamesh/src/theme/ThemeModeContext.tsx
+++ b/apps/aquamesh/src/theme/ThemeModeContext.tsx
@@ -1,0 +1,109 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+
+import { THEME_STORAGE_KEY } from './index'
+
+export type ThemeMode = 'light' | 'dark'
+
+interface ThemeModeContextValue {
+  mode: ThemeMode
+  setMode: (mode: ThemeMode) => void
+  toggleMode: () => void
+}
+
+const ThemeModeContext = createContext<ThemeModeContextValue | undefined>(
+  undefined,
+)
+
+const getSystemThemeMode = (): ThemeMode => {
+  if (typeof window === 'undefined') {
+    return 'light'
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light'
+}
+
+const getInitialThemeMode = (): ThemeMode => {
+  if (typeof window === 'undefined') {
+    return 'light'
+  }
+
+  const savedMode = window.localStorage.getItem(THEME_STORAGE_KEY)
+
+  if (savedMode === 'light' || savedMode === 'dark') {
+    return savedMode
+  }
+
+  return getSystemThemeMode()
+}
+
+export const ThemeModeProvider = ({
+  children,
+}: {
+  children: React.ReactNode
+}) => {
+  const [mode, setModeState] = useState<ThemeMode>(getInitialThemeMode)
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+
+    const handleSystemPreferenceChange = (event: MediaQueryListEvent) => {
+      const savedMode = window.localStorage.getItem(THEME_STORAGE_KEY)
+
+      if (!savedMode) {
+        setModeState(event.matches ? 'dark' : 'light')
+      }
+    }
+
+    mediaQuery.addEventListener('change', handleSystemPreferenceChange)
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleSystemPreferenceChange)
+    }
+  }, [])
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = mode
+  }, [mode])
+
+  const value = useMemo(
+    () => ({
+      mode,
+      setMode: (nextMode: ThemeMode) => {
+        window.localStorage.setItem(THEME_STORAGE_KEY, nextMode)
+        setModeState(nextMode)
+      },
+      toggleMode: () => {
+        setModeState((currentMode) => {
+          const nextMode = currentMode === 'dark' ? 'light' : 'dark'
+          window.localStorage.setItem(THEME_STORAGE_KEY, nextMode)
+          return nextMode
+        })
+      },
+    }),
+    [mode],
+  )
+
+  return (
+    <ThemeModeContext.Provider value={value}>
+      {children}
+    </ThemeModeContext.Provider>
+  )
+}
+
+export const useThemeMode = () => {
+  const context = useContext(ThemeModeContext)
+
+  if (!context) {
+    throw new Error('useThemeMode must be used within ThemeModeProvider')
+  }
+
+  return context
+}

--- a/apps/aquamesh/src/theme/index.js
+++ b/apps/aquamesh/src/theme/index.js
@@ -1,27 +1,176 @@
-import { createTheme } from '@mui/material/styles'
+import { alpha, createTheme } from '@mui/material/styles'
 
 import createPalette from './palette'
-import { getAccentColorById } from './accentColors'
+import { defaultAccentColorId, getAccentColorById } from './accentColors'
 import typography from './typography'
 
-export const createAquaMeshTheme = (accentColorId) => {
-  const palette = createPalette(getAccentColorById(accentColorId))
+export const THEME_STORAGE_KEY = 'aquamesh-theme-mode'
+
+const createCssVariables = (themePalette, mode) => ({
+  colorScheme: mode,
+  '--common-black': themePalette.common.black,
+  '--common-white': themePalette.common.white,
+  '--common-clear': themePalette.common.clear,
+  '--foreground-primary': themePalette.foreground.primary,
+  '--foreground-contrast-primary': themePalette.foreground.contrastPrimary,
+  '--foreground-secondary': themePalette.foreground.secondary,
+  '--foreground-contrast-secondary': themePalette.foreground.contrastSecondary,
+  '--foreground-disabled': themePalette.foreground.disabled,
+  '--foreground-contrast-disabled': themePalette.foreground.contrastDisabled,
+  '--background-default': themePalette.background.default,
+  '--background-paper': themePalette.background.paper,
+  '--background-header': themePalette.background.header,
+  '--background-bar-dark': themePalette.background.barDark,
+  '--background-bar-medium': themePalette.background.barMedium,
+  '--background-light': themePalette.background.light,
+  '--background-accent-soft': themePalette.background.accentSoft,
+  '--background-accent-surface': themePalette.background.accentSurface,
+  '--surface-ground': themePalette.background.default,
+  '--surface-section': themePalette.background.barMedium,
+  '--surface-card': themePalette.background.paper,
+  '--surface-overlay': themePalette.background.paper,
+  '--surface-border': themePalette.divider,
+  '--surface-hover': themePalette.action.hover,
+  '--surface-0': themePalette.background.paper,
+  '--surface-50': themePalette.background.default,
+  '--surface-100': themePalette.background.barMedium,
+  '--surface-200': themePalette.background.barDark,
+  '--surface-700': themePalette.grey[700],
+  '--surface-800': themePalette.grey[800],
+  '--surface-900': themePalette.grey[900],
+  '--text-color': themePalette.text.primary,
+  '--text-color-secondary': themePalette.text.secondary,
+  '--primary-main': themePalette.primary.main,
+  '--primary-light': themePalette.primary.light,
+  '--primary-dark': themePalette.primary.dark,
+  '--primary-color': themePalette.primary.main,
+  '--primary-color-text': themePalette.primary.contrastText,
+  '--secondary-main': themePalette.secondary.main,
+  '--secondary-light': themePalette.secondary.light,
+  '--secondary-dark': themePalette.secondary.dark,
+  '--accent-soft': themePalette.background.accentSoft,
+  '--accent-surface': themePalette.background.accentSurface,
+  '--grey-50': themePalette.grey[50],
+  '--grey-100': themePalette.grey[100],
+  '--grey-200': themePalette.grey[200],
+  '--grey-300': themePalette.grey[300],
+  '--grey-400': themePalette.grey[400],
+  '--grey-500': themePalette.grey[500],
+  '--grey-600': themePalette.grey[600],
+  '--grey-700': themePalette.grey[700],
+  '--grey-800': themePalette.grey[800],
+  '--grey-900': themePalette.grey[900],
+  '--action-active': themePalette.action.active,
+  '--action-contrast-active': themePalette.action.contrastActive,
+  '--action-hover': themePalette.action.hover,
+  '--action-contrast-hover': themePalette.action.contrastHover,
+  '--action-selected': themePalette.action.selected,
+  '--action-contrast-selected': themePalette.action.contrastSelected,
+  '--action-disabled': themePalette.action.disabled,
+  '--action-contrast-disabled': themePalette.action.contrastDisabled,
+  '--tabs-background': themePalette.tabs.background,
+  '--other-divider': themePalette.other.divider,
+  '--other-outlined-border': themePalette.other.outlinedBorder,
+  '--other-backdrop-overlay': themePalette.other.backdropOverlay,
+  '--other-filled-input-background': themePalette.other.filledInputBackground,
+  '--other-standard-input-line': themePalette.other.standardInputLine,
+  '--other-snackbar': themePalette.other.snackbar,
+})
+
+export const createAquaMeshTheme = (
+  mode = 'light',
+  accentColorId = defaultAccentColorId,
+) => {
+  const themePalette = createPalette(getAccentColorById(accentColorId), mode)
+  const isDark = mode === 'dark'
+  const cssVariables = createCssVariables(themePalette, mode)
 
   return createTheme({
-    palette,
+    palette: themePalette,
     typography,
     components: {
       MuiCssBaseline: {
         styleOverrides: {
+          ':root': cssVariables,
           body: {
-            backgroundColor: palette.background.barMedium,
+            ...cssVariables,
+            backgroundColor: themePalette.background.default,
+            color: themePalette.text.primary,
+            transition: 'background-color 180ms ease, color 180ms ease',
+          },
+          '#root': {
+            minHeight: '100dvh',
+            backgroundColor: themePalette.background.default,
+          },
+          '::selection': {
+            backgroundColor: alpha(themePalette.primary.main, 0.35),
           },
         },
       },
       MuiTooltip: {
         styleOverrides: {
-          tooltip: { backgroundColor: palette.common.black },
-          arrow: { color: palette.common.black },
+          tooltip: { backgroundColor: themePalette.common.black },
+          arrow: { color: themePalette.common.black },
+        },
+      },
+      MuiPaper: {
+        styleOverrides: {
+          root: {
+            backgroundImage: 'none',
+          },
+        },
+      },
+      MuiAppBar: {
+        defaultProps: {
+          color: 'default',
+        },
+      },
+      MuiDialog: {
+        styleOverrides: {
+          paper: {
+            backgroundImage: 'none',
+            backgroundColor: themePalette.background.dialog,
+            color: themePalette.text.primary,
+          },
+        },
+      },
+      MuiDrawer: {
+        styleOverrides: {
+          paper: {
+            backgroundImage: 'none',
+            backgroundColor: themePalette.background.paper,
+            color: themePalette.text.primary,
+          },
+        },
+      },
+      MuiMenu: {
+        styleOverrides: {
+          paper: {
+            backgroundImage: 'none',
+          },
+        },
+      },
+      MuiButton: {
+        styleOverrides: {
+          root: {
+            borderRadius: 8,
+            textTransform: 'none',
+          },
+          containedPrimary: {
+            color: themePalette.primary.contrastText,
+            boxShadow: isDark
+              ? `0 10px 24px ${alpha(themePalette.primary.main, 0.22)}`
+              : undefined,
+          },
+        },
+      },
+      MuiOutlinedInput: {
+        styleOverrides: {
+          root: {
+            backgroundColor: isDark
+              ? alpha(themePalette.common.white, 0.03)
+              : undefined,
+          },
         },
       },
     },

--- a/apps/aquamesh/src/theme/palette.js
+++ b/apps/aquamesh/src/theme/palette.js
@@ -1,24 +1,9 @@
-// IDEA (re-)use css variables here
-const createPalette = (accent) => ({
-  brand: {
-    primary: accent.main,
-  },
+const lightBase = {
+  mode: 'light',
   common: {
     black: '#000000',
     white: '#FFFFFF',
     clear: '#FFFFFF0',
-  },
-  primary: {
-    main: accent.main,
-    light: accent.light,
-    dark: accent.dark,
-    contrastText: accent.contrastText,
-  },
-  secondary: {
-    main: accent.soft,
-    light: accent.surface,
-    dark: accent.light,
-    contrastText: accent.dark,
   },
   grey: {
     50: '#F9FAFA',
@@ -36,39 +21,6 @@ const createPalette = (accent) => ({
     A400: '#596569',
     A700: '#2D3334',
   },
-  critical: {
-    main: '#E31B0C',
-    light: '#F88078',
-    dark: '#BA1408',
-  },
-  serious: {
-    main: '#ED6C02',
-    light: '#FFB547',
-    dark: '#BB5A00',
-  },
-  caution: {
-    main: '#FBE20E',
-    light: '#FDF082',
-    dark: '#B4A203',
-    contrastText: '#00000099',
-  },
-  normal: {
-    main: '#299E2E',
-    light: '#7BC67E',
-    dark: '#3B873E',
-  },
-  standby: {
-    main: accent.main,
-    light: accent.light,
-    dark: accent.dark,
-  },
-  off: {
-    main: '#9EA7AD',
-    light: '#D6D9DC',
-    dark: '#6A7177',
-  },
-  // REVIEW add these colors after creating the theme, so we can reference
-  // their bases
   foreground: {
     primary: '#102A2DDE',
     contrastPrimary: '#102A2DDE',
@@ -76,6 +28,11 @@ const createPalette = (accent) => ({
     contrastSecondary: '#3D575CDE',
     disabled: '#00102661',
     contrastDisabled: '#00102661',
+  },
+  text: {
+    primary: '#102A2DDE',
+    secondary: '#3D575CDE',
+    disabled: '#00102661',
   },
   background: {
     header: '#FFFFFF',
@@ -86,22 +43,8 @@ const createPalette = (accent) => ({
     paper: '#FFFFFF',
     dialog: '#FFFFFF',
     modal: '#FFFFFF',
-    accentSoft: accent.soft,
-    accentSurface: accent.surface,
   },
-  action: {
-    active: `${accent.light}33`,
-    contrastActive: '#FFFFFF7a',
-    hover: `${accent.light}24`,
-    contrastHover: '#FFFFFF14',
-    selected: `${accent.light}33`,
-    contrastSelected: '#FFFFFF29',
-    disabled: '#00000042',
-    contrastDisabled: '#FFFFFF42',
-  },
-  tabs: {
-    background: '#FFFFFF14',
-  },
+  divider: '#0000001F',
   other: {
     divider: '#0000001F',
     outlinedBorder: '#0000003B',
@@ -110,6 +53,133 @@ const createPalette = (accent) => ({
     standardInputLine: '#0000006B',
     snackbar: '#2D3334',
   },
-})
+}
+
+const darkBase = {
+  ...lightBase,
+  mode: 'dark',
+  grey: {
+    ...lightBase.grey,
+    50: '#071414',
+    100: '#0A1A1C',
+    200: '#102326',
+    300: '#183236',
+    400: '#304B50',
+    500: '#6D858A',
+    600: '#90A3A7',
+    700: '#B5C4C7',
+    800: '#D7E0E2',
+    900: '#F4FAFA',
+  },
+  foreground: {
+    primary: '#E8F4F2DE',
+    contrastPrimary: '#E8F4F2DE',
+    secondary: '#B6CAC6DE',
+    contrastSecondary: '#B6CAC6DE',
+    disabled: '#E8F4F261',
+    contrastDisabled: '#E8F4F261',
+  },
+  text: {
+    primary: '#E8F4F2DE',
+    secondary: '#B6CAC6DE',
+    disabled: '#E8F4F261',
+  },
+  background: {
+    header: '#081718',
+    barDark: '#061213',
+    barMedium: '#0B1A1C',
+    default: '#071414',
+    light: '#102326',
+    paper: '#0D2022',
+    dialog: '#102326',
+    modal: '#102326',
+  },
+  divider: '#D7E0E21F',
+  other: {
+    divider: '#D7E0E21F',
+    outlinedBorder: '#D7E0E23B',
+    backdropOverlay: '#000000B3',
+    filledInputBackground: '#FFFFFF14',
+    standardInputLine: '#FFFFFF70',
+    snackbar: '#E8F4F2',
+  },
+}
+
+const createSeverityPalette = (mode) =>
+  mode === 'dark'
+    ? {
+        critical: { main: '#FF8A80', light: '#FFDAD6', dark: '#E35D52' },
+        serious: { main: '#FFB46A', light: '#FFD8AD', dark: '#F28A2A' },
+        caution: {
+          main: '#FBE86A',
+          light: '#FFF3A8',
+          dark: '#DCC02B',
+          contrastText: '#211C00',
+        },
+        normal: { main: '#7DDB85', light: '#BDF1C1', dark: '#44AF4E' },
+        off: { main: '#87979B', light: '#BAC6C9', dark: '#5D6C70' },
+      }
+    : {
+        critical: { main: '#E31B0C', light: '#F88078', dark: '#BA1408' },
+        serious: { main: '#ED6C02', light: '#FFB547', dark: '#BB5A00' },
+        caution: {
+          main: '#FBE20E',
+          light: '#FDF082',
+          dark: '#B4A203',
+          contrastText: '#00000099',
+        },
+        normal: { main: '#299E2E', light: '#7BC67E', dark: '#3B873E' },
+        off: { main: '#9EA7AD', light: '#D6D9DC', dark: '#6A7177' },
+      }
+
+const createPalette = (accent, mode = 'light') => {
+  const isDark = mode === 'dark'
+  const base = isDark ? darkBase : lightBase
+  const accentSoft = isDark ? `${accent.main}2E` : accent.soft
+  const accentSurface = isDark ? `${accent.main}1A` : accent.surface
+
+  return {
+    ...base,
+    brand: {
+      primary: accent.main,
+    },
+    primary: {
+      main: isDark ? accent.light : accent.main,
+      light: isDark ? accent.surface : accent.light,
+      dark: isDark ? accent.main : accent.dark,
+      contrastText: isDark ? '#04211D' : accent.contrastText,
+    },
+    secondary: {
+      main: accentSoft,
+      light: accentSurface,
+      dark: isDark ? accent.light : accent.light,
+      contrastText: isDark ? '#E8F4F2DE' : accent.dark,
+    },
+    ...createSeverityPalette(mode),
+    standby: {
+      main: isDark ? accent.light : accent.main,
+      light: isDark ? accent.surface : accent.light,
+      dark: isDark ? accent.main : accent.dark,
+    },
+    background: {
+      ...base.background,
+      accentSoft,
+      accentSurface,
+    },
+    action: {
+      active: isDark ? `${accent.main}3D` : `${accent.light}33`,
+      contrastActive: isDark ? `${accent.main}3D` : '#FFFFFF7a',
+      hover: isDark ? `${accent.main}26` : `${accent.light}24`,
+      contrastHover: '#FFFFFF14',
+      selected: isDark ? `${accent.main}33` : `${accent.light}33`,
+      contrastSelected: isDark ? `${accent.main}33` : '#FFFFFF29',
+      disabled: isDark ? '#FFFFFF3D' : '#00000042',
+      contrastDisabled: '#FFFFFF42',
+    },
+    tabs: {
+      background: isDark ? `${accent.main}1F` : '#FFFFFF14',
+    },
+  }
+}
 
 export default createPalette

--- a/apps/aquamesh/tests/unit/theme/ThemeModeContext.test.tsx
+++ b/apps/aquamesh/tests/unit/theme/ThemeModeContext.test.tsx
@@ -1,0 +1,70 @@
+/// <reference types="@testing-library/jest-dom" />
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ThemeProvider } from '@mui/material/styles'
+
+import ThemeModeToggle from '../../../src/components/shared/ThemeModeToggle'
+import { createAquaMeshTheme, THEME_STORAGE_KEY } from '../../../src/theme'
+import {
+  ThemeModeProvider,
+  useThemeMode,
+} from '../../../src/theme/ThemeModeContext'
+
+const Probe = () => {
+  const { mode } = useThemeMode()
+  const theme = React.useMemo(() => createAquaMeshTheme(mode), [mode])
+
+  return (
+    <ThemeProvider theme={theme}>
+      <span data-testid="theme-mode">{mode}</span>
+      <ThemeModeToggle />
+    </ThemeProvider>
+  )
+}
+
+describe('ThemeModeProvider', () => {
+  it('uses the saved user preference and persists toggles', () => {
+    vi.mocked(window.localStorage.getItem).mockImplementation((key) =>
+      key === THEME_STORAGE_KEY ? 'dark' : null,
+    )
+
+    render(
+      <ThemeModeProvider>
+        <Probe />
+      </ThemeModeProvider>,
+    )
+
+    expect(screen.getByTestId('theme-mode')).toHaveTextContent('dark')
+
+    fireEvent.click(screen.getByRole('button', { name: /switch to light/i }))
+
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      THEME_STORAGE_KEY,
+      'light',
+    )
+    expect(screen.getByTestId('theme-mode')).toHaveTextContent('light')
+  })
+
+  it('falls back to the system preference when no user preference exists', () => {
+    vi.mocked(window.localStorage.getItem).mockReturnValue(null)
+    vi.mocked(window.matchMedia).mockImplementation((query) => ({
+      matches: query === '(prefers-color-scheme: dark)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+
+    render(
+      <ThemeModeProvider>
+        <Probe />
+      </ThemeModeProvider>,
+    )
+
+    expect(screen.getByTestId('theme-mode')).toHaveTextContent('dark')
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       ],
       "dependencies": {
         "@types/uuid": "^10.0.0",
+        "bashunit": "^0.35.0",
         "date-fns": "^4.1.0",
         "uuid": "^11.1.0"
       },
@@ -10361,6 +10362,23 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bashunit": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/bashunit/-/bashunit-0.35.0.tgz",
+      "integrity": "sha512-QR3RsMEyCZ4Ncf4zZSif8cTf3dkpQtT/vGRYYfyKTPyeRruGioVOFAJtoi+5azniKBbHCvXdNzhwO2mt5iDufQ==",
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "chart.js": "^4.4.9",
+        "vanilla-tilt": "^1.8.1"
+      },
+      "bin": {
+        "bashunit": "bin/bashunit"
+      }
     },
     "node_modules/basic-ftp": {
       "version": "5.0.5",
@@ -25480,6 +25498,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/vanilla-tilt": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/vanilla-tilt/-/vanilla-tilt-1.8.1.tgz",
+      "integrity": "sha512-hPB1XUsnh+SIeVSW2beb5RnuFxz4ZNgxjGD78o52F49gS4xaoLeEMh9qrQnJrnEn/vjjBI7IlxrrXmz4tGV0Kw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",


### PR DESCRIPTION
## Summary
- Add light/dark AquaMesh theme generation and CSS variable updates
- Persist the selected theme mode and fall back to system preference
- Add a theme toggle on the landing page and top navbar
- Update landing/top-level surfaces to use theme palette tokens
- Add unit coverage for saved/system theme mode behavior

## Verification
- npx prettier --check on changed files
- git diff --check

## Notes
- Targeted Vitest/build are blocked locally by the existing incomplete node_modules/optional dependency state.