### PR TITLE
Reframe onboarding around knowledge workspaces

### DIFF
--- a/apps/aquamesh/src/App.tsx
+++ b/apps/aquamesh/src/App.tsx
@@ -59,8 +59,13 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
 const WorkspacePage = () => {
   const [menuOpen, setMenuOpen] = useState(false)
   const [searchParams, setSearchParams] = useSearchParams()
-  const { openCreateWidget, openOperationsExample, openWidgetMenu } =
-    useWorkspaceActions()
+  const {
+    openCreateWidget,
+    openOperationsExample,
+    openMathExample,
+    openTutorialExample,
+    openWidgetMenu,
+  } = useWorkspaceActions()
   const handledActionRef = useRef<string | null>(null)
 
   useEffect(() => {
@@ -76,6 +81,10 @@ const WorkspacePage = () => {
       openCreateWidget()
     } else if (action === 'open-operations-example') {
       openOperationsExample()
+    } else if (action === 'open-math-example') {
+      openMathExample()
+    } else if (action === 'open-tutorial-example') {
+      openTutorialExample()
     } else if (action === 'add-widget') {
       openWidgetMenu()
     }
@@ -84,6 +93,8 @@ const WorkspacePage = () => {
   }, [
     openCreateWidget,
     openOperationsExample,
+    openMathExample,
+    openTutorialExample,
     openWidgetMenu,
     searchParams,
     setSearchParams,

--- a/apps/aquamesh/src/App.tsx
+++ b/apps/aquamesh/src/App.tsx
@@ -101,9 +101,15 @@ const WorkspacePage = () => {
   ])
 
   return (
-    <Box sx={{ overflowX: 'hidden', height: '100dvh' }}>
+    <Box sx={{ overflow: 'hidden', height: '100dvh' }}>
       <TopNavBar open={menuOpen} setOpen={setMenuOpen} />
-      <Main mt={8} sx={{ position: 'relative' }}>
+      <Main
+        sx={{
+          position: 'relative',
+          marginTop: 0,
+          height: { xs: 'calc(100dvh - 72px)', sm: 'calc(100dvh - 64px)' },
+        }}
+      >
         <Dashboards />
       </Main>
     </Box>

--- a/apps/aquamesh/src/App.tsx
+++ b/apps/aquamesh/src/App.tsx
@@ -101,15 +101,9 @@ const WorkspacePage = () => {
   ])
 
   return (
-    <Box sx={{ overflow: 'hidden', height: '100dvh' }}>
+    <Box sx={{ overflowX: 'hidden', height: '100dvh' }}>
       <TopNavBar open={menuOpen} setOpen={setMenuOpen} />
-      <Main
-        sx={{
-          position: 'relative',
-          marginTop: 0,
-          height: { xs: 'calc(100dvh - 72px)', sm: 'calc(100dvh - 64px)' },
-        }}
-      >
+      <Main mt={8} sx={{ position: 'relative' }}>
         <Dashboards />
       </Main>
     </Box>

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -35,6 +35,7 @@ import './tabs.scss'
 interface SavedDashboard {
   id: string
   name: string
+  folder?: string
   layout: DashboardLayout
   description?: string
   tags?: string[]
@@ -170,15 +171,15 @@ const DashboardEmptyState = ({
         sx={{ fontSize: 48, color: 'primary.main', mb: 1 }}
       />
       <Typography variant="h5" fontWeight="bold" gutterBottom>
-        Start a workspace dashboard
+        Start a knowledge dashboard
       </Typography>
       <Typography
         variant="body1"
         sx={{ color: 'foreground.contrastSecondary', mb: 3 }}
       >
-        Pick one real workflow: daily operations, architecture review notes, lab
-        observations, project tasks, or image-rich research. Create one reusable
-        widget first, then place it on this dashboard.
+        Open a starter example from Dashboards, or create one reusable block for
+        your notes: formulas, study questions, charts, images, project tasks, or
+        research observations.
       </Typography>
       <Stack
         direction={{ xs: 'column', sm: 'row' }}
@@ -293,6 +294,7 @@ const Dashboards = () => {
 
   const [saveDialogOpen, setSaveDialogOpen] = useState(false)
   const [dashboardName, setDashboardName] = useState('')
+  const [dashboardFolder, setDashboardFolder] = useState('Default')
   const [dashboardDescription, setDashboardDescription] = useState('')
   const [dashboardTags, setDashboardTags] = useState<string[]>([])
   const [isPublic, setIsPublic] = useState(false)
@@ -435,6 +437,7 @@ const Dashboards = () => {
       // Show enhanced save dialog for new dashboards
       setCurrentTabIndex(index)
       setDashboardName(currentDashboard.name || '')
+      setDashboardFolder('Default')
       setDashboardDescription('')
       setDashboardTags(['dashboard'])
       setIsPublic(false)
@@ -446,6 +449,7 @@ const Dashboards = () => {
   const handleSaveDialogClose = () => {
     setSaveDialogOpen(false)
     setDashboardName('')
+    setDashboardFolder('Default')
     setDashboardDescription('')
     setDashboardTags([])
     setIsPublic(false)
@@ -479,6 +483,7 @@ const Dashboards = () => {
           const newDashboard: SavedDashboard = {
             id: `dashboard-${Date.now()}`,
             name: dashboardName.trim(),
+            folder: dashboardFolder.trim() || 'Default',
             layout: currentDashboard.layout,
             description: dashboardDescription.trim() || undefined,
             tags: dashboardTags.length > 0 ? dashboardTags : ['dashboard'],
@@ -770,6 +775,37 @@ const Dashboards = () => {
                   <CloseIcon width={16} height={16} />
                 </IconButton>
               ),
+            }}
+          />
+
+          <TextField
+            margin="normal"
+            id="folder"
+            label="Folder"
+            type="text"
+            fullWidth
+            variant="outlined"
+            value={dashboardFolder}
+            onChange={(e) => setDashboardFolder(e.target.value)}
+            helperText="Dashboards with the same folder name are grouped together."
+            InputLabelProps={{
+              shrink: true,
+              sx: { color: 'text.secondary' },
+            }}
+            InputProps={{
+              sx: {
+                bgcolor: 'background.paper',
+                color: 'text.primary',
+                '& .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'divider',
+                },
+                '&:hover .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'primary.main',
+                },
+                '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'primary.main',
+                },
+              },
             }}
           />
 

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -316,6 +316,9 @@ const Dashboards = () => {
       return savedStep === 'save' || savedStep === 'done' ? savedStep : 'layout'
     })
   const { openCreateWidget } = useWorkspaceActions()
+  const selectedDashboardIsEmpty =
+    !openDashboards[selectedDashboard]?.layout?.children ||
+    openDashboards[selectedDashboard]?.layout?.children?.length === 0
 
   const completeDashboardOnboarding = () => {
     setDashboardOnboardingStep('done')
@@ -514,6 +517,7 @@ const Dashboards = () => {
   return (
     <Box>
       <Tabs
+        className={selectedDashboardIsEmpty ? 'react-tabs--empty-selected' : ''}
         selectedIndex={selectedDashboard}
         onSelect={(index) => setSelectedDashboard(index)}
         style={{ position: 'relative' }}

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -146,7 +146,7 @@ const DashboardEmptyState = ({
 }: DashboardEmptyStateProps) => (
   <Box
     sx={{
-      height: '100%',
+      minHeight: 'calc(100dvh - 130px)',
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
@@ -517,7 +517,7 @@ const Dashboards = () => {
   return (
     <Box>
       <Tabs
-        className={selectedDashboardIsEmpty ? 'react-tabs--empty-selected' : ''}
+        className={`react-tabs ${selectedDashboardIsEmpty ? 'react-tabs--empty-selected' : ''}`.trim()}
         selectedIndex={selectedDashboard}
         onSelect={(index) => setSelectedDashboard(index)}
         style={{ position: 'relative' }}

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -146,7 +146,7 @@ const DashboardEmptyState = ({
 }: DashboardEmptyStateProps) => (
   <Box
     sx={{
-      minHeight: 'calc(100dvh - 130px)',
+      height: '100%',
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',

--- a/apps/aquamesh/src/components/Dasboard/DashboardLibrary.tsx
+++ b/apps/aquamesh/src/components/Dasboard/DashboardLibrary.tsx
@@ -39,6 +39,7 @@ import LockIcon from '@mui/icons-material/Lock'
 import { Layout } from '../../types/types'
 import { useDashboards } from './DashboardProvider'
 import { DefaultDashboard } from './fixture'
+import { ensureStarterDashboards } from '../../customHooks/useWorkspaceActions'
 import DeleteConfirmationDialog from '../WidgetEditor/components/dialogs/DeleteConfirmationDialog'
 
 interface SavedDashboard {
@@ -160,6 +161,7 @@ const SavedDashboardsDialog: React.FC<SavedDashboardsDialogProps> = ({
   // Function to load dashboards from localStorage
   const loadDashboards = () => {
     try {
+      ensureStarterDashboards()
       const savedDashboards = localStorage.getItem('customDashboards')
       if (savedDashboards) {
         const parsedDashboards = JSON.parse(savedDashboards)

--- a/apps/aquamesh/src/components/Dasboard/DashboardLibrary.tsx
+++ b/apps/aquamesh/src/components/Dasboard/DashboardLibrary.tsx
@@ -44,6 +44,7 @@ import DeleteConfirmationDialog from '../WidgetEditor/components/dialogs/DeleteC
 interface SavedDashboard {
   id: string
   name: string
+  folder?: string
   layout: Layout
   description?: string
   tags?: string[]
@@ -168,6 +169,7 @@ const SavedDashboardsDialog: React.FC<SavedDashboardsDialogProps> = ({
           (dashboard: {
             id: string
             name: string
+            folder?: string
             layout: Layout
             description?: string
             tags?: string[]
@@ -177,6 +179,7 @@ const SavedDashboardsDialog: React.FC<SavedDashboardsDialogProps> = ({
           }) => ({
             id: dashboard.id,
             name: dashboard.name,
+            folder: dashboard.folder?.trim() || 'Default',
             layout: dashboard.layout,
             description: dashboard.description || 'No description',
             tags: dashboard.tags || ['dashboard'],
@@ -358,6 +361,7 @@ const SavedDashboardsDialog: React.FC<SavedDashboardsDialogProps> = ({
       filtered = filtered.filter(
         (dashboard) =>
           dashboard.name.toLowerCase().includes(term) ||
+          dashboard.folder?.toLowerCase().includes(term) ||
           dashboard.description?.toLowerCase().includes(term) ||
           dashboard.tags?.some((tag) => tag.toLowerCase().includes(term)),
       )
@@ -787,6 +791,17 @@ const SavedDashboardsDialog: React.FC<SavedDashboardsDialogProps> = ({
                                     color: 'primary.dark',
                                   }}
                                 />
+                                <Chip
+                                  size="small"
+                                  label={dashboard.folder || 'Default'}
+                                  sx={{
+                                    ml: 1,
+                                    height: 20,
+                                    fontSize: '0.7rem',
+                                    bgcolor: 'action.hover',
+                                    color: 'text.secondary',
+                                  }}
+                                />
                                 {dashboard.isPublic && (
                                   <Chip
                                     size="small"
@@ -1056,6 +1071,7 @@ const EditDashboardDialog: React.FC<EditDashboardDialogProps> = ({
   onSave,
 }) => {
   const [name, setName] = useState('')
+  const [folder, setFolder] = useState('Default')
   const [description, setDescription] = useState('')
   const [tags, setTags] = useState<string[]>([])
   const [isPublic, setIsPublic] = useState(false)
@@ -1065,6 +1081,7 @@ const EditDashboardDialog: React.FC<EditDashboardDialogProps> = ({
   useEffect(() => {
     if (dashboard) {
       setName(dashboard.name)
+      setFolder(dashboard.folder || 'Default')
       setDescription(dashboard.description || '')
       setTags(dashboard.tags || [])
       setIsPublic(dashboard.isPublic || false)
@@ -1077,6 +1094,7 @@ const EditDashboardDialog: React.FC<EditDashboardDialogProps> = ({
       const updatedDashboard: SavedDashboard = {
         ...dashboard,
         name: name.trim(),
+        folder: folder.trim() || 'Default',
         description: description.trim() || 'No description',
         tags: tags.length > 0 ? tags : ['dashboard'],
         isPublic,
@@ -1162,6 +1180,31 @@ const EditDashboardDialog: React.FC<EditDashboardDialogProps> = ({
             }}
             margin="normal"
             required
+            InputLabelProps={{ shrink: true, sx: { color: 'text.secondary' } }}
+            InputProps={{
+              sx: {
+                bgcolor: 'background.paper',
+                color: 'text.primary',
+                '& .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'divider',
+                },
+                '&:hover .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'primary.main',
+                },
+                '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'primary.main',
+                },
+              },
+            }}
+          />
+
+          <TextField
+            fullWidth
+            label="Folder"
+            value={folder}
+            onChange={(e) => setFolder(e.target.value)}
+            margin="normal"
+            helperText="Dashboards with the same folder name are grouped in the dashboard menu."
             InputLabelProps={{ shrink: true, sx: { color: 'text.secondary' } }}
             InputProps={{
               sx: {

--- a/apps/aquamesh/src/components/Dasboard/DashboardOptionsMenu.tsx
+++ b/apps/aquamesh/src/components/Dasboard/DashboardOptionsMenu.tsx
@@ -15,7 +15,7 @@ import FolderIcon from '@mui/icons-material/Folder'
 import { useDashboards } from './DashboardProvider'
 import SavedDashboardsDialog from './DashboardLibrary'
 import { Layout } from '../../types/types'
-import { useWorkspaceActions } from '../../customHooks/useWorkspaceActions'
+import { ensureStarterDashboards } from '../../customHooks/useWorkspaceActions'
 
 // Define saved dashboard type
 interface SavedDashboard {
@@ -80,7 +80,6 @@ const DashboardOptionsMenu: React.FC = () => {
   const [isAdmin, setIsAdmin] = useState(false)
 
   const { addDashboard } = useDashboards()
-  const { openMathExample, openTutorialExample } = useWorkspaceActions()
 
   const theme = useTheme()
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'))
@@ -109,6 +108,7 @@ const DashboardOptionsMenu: React.FC = () => {
 
   const loadSavedDashboards = () => {
     try {
+      ensureStarterDashboards()
       const dashboards = localStorage.getItem('customDashboards')
       if (dashboards) {
         setCustomDashboards(JSON.parse(dashboards))
@@ -126,7 +126,13 @@ const DashboardOptionsMenu: React.FC = () => {
   const dashboardsByFolder = visibleCustomDashboards.reduce<
     Record<string, SavedDashboard[]>
   >((folders, dashboard) => {
-    const folderName = dashboard.folder?.trim() || 'Default'
+    const rawFolderName = dashboard.folder?.trim() || 'Default'
+    const folderName =
+      rawFolderName.toLowerCase() === 'mathematics'
+        ? 'Mathematics'
+        : rawFolderName.toLowerCase() === 'tutorial'
+          ? 'Tutorial'
+          : rawFolderName
     folders[folderName] = folders[folderName] || []
     folders[folderName].push(dashboard)
     return folders
@@ -221,52 +227,7 @@ const DashboardOptionsMenu: React.FC = () => {
 
         <Divider sx={{ my: 1, borderColor: 'divider' }} />
 
-        {/* Starter folders */}
-        <Typography
-          sx={{
-            px: 2,
-            py: 1,
-            fontWeight: 'bold',
-            mt: 1,
-            color: 'text.primary',
-          }}
-        >
-          Mathematics
-        </Typography>
-        <Divider sx={{ borderColor: 'divider' }} />
-        <MenuItem
-          onClick={() => {
-            openMathExample()
-            handleClose()
-          }}
-          sx={{ p: 1.5 }}
-        >
-          Mathematics Study Example
-        </MenuItem>
-
-        <Typography
-          sx={{
-            px: 2,
-            py: 1,
-            fontWeight: 'bold',
-            mt: 1,
-            color: 'text.primary',
-          }}
-        >
-          Tutorial
-        </Typography>
-        <Divider sx={{ borderColor: 'divider' }} />
-        <MenuItem
-          onClick={() => {
-            openTutorialExample()
-            handleClose()
-          }}
-          sx={{ p: 1.5 }}
-        >
-          AquaMesh Tutorial
-        </MenuItem>
-
-        {/* Custom Dashboards Section */}
+        {/* Dashboard folders */}
         {visibleCustomDashboards.length > 0 && (
           <>
             {Object.entries(dashboardsByFolder).map(

--- a/apps/aquamesh/src/components/Dasboard/DashboardOptionsMenu.tsx
+++ b/apps/aquamesh/src/components/Dasboard/DashboardOptionsMenu.tsx
@@ -21,6 +21,7 @@ import { useWorkspaceActions } from '../../customHooks/useWorkspaceActions'
 interface SavedDashboard {
   id: string
   name: string
+  folder?: string
   layout: Layout
   description?: string
   tags?: string[]
@@ -79,7 +80,7 @@ const DashboardOptionsMenu: React.FC = () => {
   const [isAdmin, setIsAdmin] = useState(false)
 
   const { addDashboard } = useDashboards()
-  const { openOperationsExample } = useWorkspaceActions()
+  const { openMathExample, openTutorialExample } = useWorkspaceActions()
 
   const theme = useTheme()
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'))
@@ -121,6 +122,15 @@ const DashboardOptionsMenu: React.FC = () => {
   const visibleCustomDashboards = isAdmin
     ? customDashboards
     : customDashboards.filter((d) => d.isPublic)
+
+  const dashboardsByFolder = visibleCustomDashboards.reduce<
+    Record<string, SavedDashboard[]>
+  >((folders, dashboard) => {
+    const folderName = dashboard.folder?.trim() || 'Default'
+    folders[folderName] = folders[folderName] || []
+    folders[folderName].push(dashboard)
+    return folders
+  }, {})
 
   // Handle opening and closing dropdown
   const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -211,57 +221,81 @@ const DashboardOptionsMenu: React.FC = () => {
 
         <Divider sx={{ my: 1, borderColor: 'divider' }} />
 
-        {!isPhone && (
-          <>
-            {/* Predefined Dashboards Section */}
-            <Typography
-              sx={{
-                px: 2,
-                py: 1,
-                fontWeight: 'bold',
-                mt: 1,
-                color: 'text.primary',
-              }}
-            >
-              Demo Scenarios
-            </Typography>
-            <Divider sx={{ borderColor: 'divider' }} />
-            <MenuItem
-              onClick={() => {
-                openOperationsExample()
-                handleClose()
-              }}
-              sx={{ p: 1.5 }}
-            >
-              Daily Operations Example
-            </MenuItem>
-          </>
-        )}
+        {/* Starter folders */}
+        <Typography
+          sx={{
+            px: 2,
+            py: 1,
+            fontWeight: 'bold',
+            mt: 1,
+            color: 'text.primary',
+          }}
+        >
+          Mathematics
+        </Typography>
+        <Divider sx={{ borderColor: 'divider' }} />
+        <MenuItem
+          onClick={() => {
+            openMathExample()
+            handleClose()
+          }}
+          sx={{ p: 1.5 }}
+        >
+          Mathematics Study Example
+        </MenuItem>
+
+        <Typography
+          sx={{
+            px: 2,
+            py: 1,
+            fontWeight: 'bold',
+            mt: 1,
+            color: 'text.primary',
+          }}
+        >
+          Tutorial
+        </Typography>
+        <Divider sx={{ borderColor: 'divider' }} />
+        <MenuItem
+          onClick={() => {
+            openTutorialExample()
+            handleClose()
+          }}
+          sx={{ p: 1.5 }}
+        >
+          AquaMesh Tutorial
+        </MenuItem>
 
         {/* Custom Dashboards Section */}
         {visibleCustomDashboards.length > 0 && (
           <>
-            <Typography
-              sx={{
-                px: 2,
-                py: 1,
-                fontWeight: 'bold',
-                mt: 1,
-                color: 'text.primary',
-              }}
-            >
-              My Dashboards
-            </Typography>
-            <Divider sx={{ borderColor: 'divider' }} />
-            {[...visibleCustomDashboards].reverse().map((dashboard) => (
-              <MenuItem
-                key={dashboard.id}
-                onClick={() => loadCustomDashboard(dashboard)}
-                sx={{ p: 1.5 }}
-              >
-                {dashboard.name}
-              </MenuItem>
-            ))}
+            {Object.entries(dashboardsByFolder).map(
+              ([folderName, dashboards]) => (
+                <React.Fragment key={folderName}>
+                  <Typography
+                    sx={{
+                      px: 2,
+                      py: 1,
+                      fontWeight: 'bold',
+                      mt: 1,
+                      color: 'text.primary',
+                    }}
+                  >
+                    {folderName}
+                  </Typography>
+                  <Divider sx={{ borderColor: 'divider' }} />
+                  {[...dashboards].reverse().map((dashboard) => (
+                    <MenuItem
+                      key={dashboard.id}
+                      onClick={() => loadCustomDashboard(dashboard)}
+                      sx={{ p: 1.5 }}
+                    >
+                      {dashboard.name}
+                    </MenuItem>
+                  ))}
+                </React.Fragment>
+              ),
+            )}
           </>
         )}
         {isPhone && visibleCustomDashboards.length === 0 && (
@@ -275,7 +309,7 @@ const DashboardOptionsMenu: React.FC = () => {
               textAlign: 'center',
             }}
           >
-            No Dashboards
+            No saved dashboards yet
           </MenuItem>
         )}
       </Menu>

--- a/apps/aquamesh/src/components/Dasboard/tabs.scss
+++ b/apps/aquamesh/src/components/Dasboard/tabs.scss
@@ -1,7 +1,6 @@
 .react-tabs {
   -webkit-tap-highlight-color: transparent;
-  height: 100%;
-  margin: 0 6px;
+  margin: -56px 6px 0 6px;
   background-color: var(--background-bar-medium);
 
   &__tab-list {
@@ -31,7 +30,7 @@
     }
 
     .react-tabs--empty-selected & .react-tabs__tab--selected {
-      border-bottom: 1px solid var(--primary-main);
+      box-shadow: inset 0 -1px 0 var(--primary-main);
     }
   }
 
@@ -82,8 +81,23 @@
   &__tab-panel {
     position: relative;
     background: var(--background-bar-medium, #f4f7f8);
-    height: calc(100% - 36px);
+    // NOTE use the whole viewport and substract (1) header's height, (2) main
+    // content's top padding, (3) tab bar height, and (4) main content's bottom
+    // padding
+
+    // Desktop default.
+    height: calc(100dvh - 36px - 16px - 36px - 24px);
     display: none;
+
+    // Tablet: -2px extra height.
+    @media (min-width: 576px) and (max-width: 992px) {
+      height: calc(100dvh - 36px - 16px - 36px - 24px - 2px);
+    }
+
+    // Phone: -8px extra height.
+    @media (max-width: 576.99px) {
+      height: calc(100dvh - 36px - 16px - 36px - 24px - 8px);
+    }
 
     &--selected {
       display: block;

--- a/apps/aquamesh/src/components/Dasboard/tabs.scss
+++ b/apps/aquamesh/src/components/Dasboard/tabs.scss
@@ -28,6 +28,10 @@
         border-color: var(--primary-main);
       }
     }
+
+    .react-tabs--empty-selected & .react-tabs__tab--selected {
+      border-bottom: 1px solid var(--primary-main);
+    }
   }
 
   &__tab {

--- a/apps/aquamesh/src/components/Dasboard/tabs.scss
+++ b/apps/aquamesh/src/components/Dasboard/tabs.scss
@@ -1,6 +1,7 @@
 .react-tabs {
   -webkit-tap-highlight-color: transparent;
-  margin: -56px 6px 0 6px;
+  height: 100%;
+  margin: 0 6px;
   background-color: var(--background-bar-medium);
 
   &__tab-list {
@@ -81,23 +82,8 @@
   &__tab-panel {
     position: relative;
     background: var(--background-bar-medium, #f4f7f8);
-    // NOTE use the whole viewport and substract (1) header's height, (2) main
-    // content's top padding, (3) tab bar height, and (4) main content's bottom
-    // padding
-
-    // Desktop default.
-    height: calc(100dvh - 36px - 16px - 36px - 24px);
+    height: calc(100% - 36px);
     display: none;
-
-    // Tablet: -2px extra height.
-    @media (min-width: 576px) and (max-width: 992px) {
-      height: calc(100dvh - 36px - 16px - 36px - 24px - 2px);
-    }
-
-    // Phone: -8px extra height.
-    @media (max-width: 576.99px) {
-      height: calc(100dvh - 36px - 16px - 36px - 24px - 8px);
-    }
 
     &--selected {
       display: block;

--- a/apps/aquamesh/src/components/WidgetEditor/CustomWidget.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/CustomWidget.tsx
@@ -986,7 +986,13 @@ const CustomWidget: React.FC<CustomWidgetProps> = ({
 
   return (
     <Paper
-      sx={{ p: 2, height: '100%', overflow: 'auto', position: 'relative' }}
+      sx={{
+        p: 2,
+        height: '100%',
+        boxSizing: 'border-box',
+        overflow: 'auto',
+        position: 'relative',
+      }}
     >
       {showWidgetName && widgetName && (
         <Typography variant="subtitle1" sx={{ mb: 2 }}>

--- a/apps/aquamesh/src/components/WidgetEditor/WidgetStorage.ts
+++ b/apps/aquamesh/src/components/WidgetEditor/WidgetStorage.ts
@@ -59,6 +59,9 @@ export const WIDGET_CATEGORIES = [
 const STORAGE_KEY = 'aquamesh_custom_widgets'
 const VERSION_STORAGE_KEY = 'aquamesh_widget_versions'
 
+const createWidgetId = () =>
+  `widget-${Date.now()}-${Math.floor(Math.random() * 1000000)}`
+
 /**
  * Storage utility for custom widgets
  */
@@ -86,7 +89,7 @@ class WidgetStorage {
     // Create a new widget with ID and timestamps
     const now = new Date().toISOString()
     const newWidget: CustomWidget = {
-      id: `widget-${Date.now()}`,
+      id: createWidgetId(),
       name: widget.name,
       components:
         widget.components && Array.isArray(widget.components)

--- a/apps/aquamesh/src/components/WidgetEditor/constants/templateWidgets.ts
+++ b/apps/aquamesh/src/components/WidgetEditor/constants/templateWidgets.ts
@@ -815,7 +815,7 @@ export const WIDGET_TEMPLATES: CustomWidget[] = [
                   fullWidth: true,
                   variant: 'outlined',
                   helperText:
-                    'Future idea: turn notes/questions into dashboard blocks automatically.',
+                    'Use this block for questions, doubts, or short study notes.',
                 },
               },
             ],
@@ -944,7 +944,7 @@ export const WIDGET_TEMPLATES: CustomWidget[] = [
                   fullWidth: true,
                   variant: 'outlined',
                   helperText:
-                    'Future idea: paste notes and generate a dashboard from them.',
+                    'Use this block for experiment notes and observations.',
                 },
               },
             ],
@@ -1009,8 +1009,8 @@ export const WIDGET_TEMPLATES: CustomWidget[] = [
             "datasets": [{
               "label": "Confidence",
               "data": [85, 55, 65, 35],
-              "backgroundColor": "rgba(25, 118, 210, 0.75)",
-              "borderColor": "rgba(25, 118, 210, 1)",
+              "backgroundColor": ["rgba(25, 118, 210, 0.75)", "rgba(239, 108, 0, 0.75)", "rgba(123, 31, 162, 0.75)", "rgba(0, 124, 102, 0.75)"],
+              "borderColor": ["rgba(25, 118, 210, 1)", "rgba(239, 108, 0, 1)", "rgba(123, 31, 162, 1)", "rgba(0, 124, 102, 1)"],
               "borderWidth": 2
             }]
           }`,
@@ -1020,7 +1020,7 @@ export const WIDGET_TEMPLATES: CustomWidget[] = [
         id: 'template-math-chart-note',
         type: 'Label',
         props: {
-          text: 'This is a chart block. Later it could react to answers, checks, or note data.',
+          text: 'This is a chart block. Use it to visualize progress, scores, or categories.',
           variant: 'body2',
         },
       },

--- a/apps/aquamesh/src/components/WidgetEditor/constants/templateWidgets.ts
+++ b/apps/aquamesh/src/components/WidgetEditor/constants/templateWidgets.ts
@@ -717,6 +717,552 @@ export const WIDGET_TEMPLATES: CustomWidget[] = [
     updatedAt: new Date().toISOString(),
     tags: ['report', 'status', 'system', 'monitoring'],
   },
+  {
+    id: 'template-knowledge-math',
+    name: 'Mathematics Knowledge Wiki Template',
+    description:
+      'A visual study page for formulas, worked examples, practice progress, and questions to review later.',
+    category: 'Knowledge Workspace',
+    components: [
+      {
+        id: 'template-math-title',
+        type: 'Label',
+        props: {
+          text: 'Mathematics 1 — Derivatives',
+          variant: 'h4',
+          gutterBottom: true,
+          useCustomColor: true,
+          customColor: '#1976D2',
+          fontWeight: 700,
+        },
+      },
+      {
+        id: 'template-math-overview',
+        type: 'FieldSet',
+        props: {
+          legend: 'What this dashboard teaches',
+          collapsed: false,
+          borderStyle: 'solid',
+          useCustomBorderColor: true,
+          useCustomLegendColor: true,
+          borderColor: '#1976D2',
+          legendColor: '#1976D2',
+          backgroundColor: 'rgba(25, 118, 210, 0.08)',
+          padding: 2,
+          borderRadius: 8,
+        },
+        children: [
+          {
+            id: 'template-math-goal',
+            type: 'Label',
+            props: {
+              text: 'Use this as a wiki page: collect the concept, formulas, examples, practice questions, and a progress chart in one reusable dashboard.',
+              variant: 'body1',
+            },
+          },
+        ],
+      },
+      {
+        id: 'template-math-grid',
+        type: 'GridBox',
+        props: { columns: 2, spacing: 2, responsive: true },
+        children: [
+          {
+            id: 'template-math-formulas',
+            type: 'FieldSet',
+            props: {
+              legend: 'Core formulas',
+              borderStyle: 'solid',
+              useCustomBorderColor: true,
+              useCustomLegendColor: true,
+              borderColor: '#7B1FA2',
+              legendColor: '#7B1FA2',
+              padding: 2,
+              borderRadius: 8,
+            },
+            children: [
+              {
+                id: 'template-math-formula-label',
+                type: 'Label',
+                props: {
+                  text: 'Power rule: d/dx xⁿ = n·xⁿ⁻¹\nChain rule: d/dx f(g(x)) = f′(g(x))·g′(x)\nProduct rule: (fg)′ = f′g + fg′',
+                  variant: 'body1',
+                  whiteSpace: 'pre-line',
+                },
+              },
+            ],
+          },
+          {
+            id: 'template-math-questions',
+            type: 'FieldSet',
+            props: {
+              legend: 'Questions to resolve',
+              borderStyle: 'solid',
+              useCustomBorderColor: true,
+              useCustomLegendColor: true,
+              borderColor: '#EF6C00',
+              legendColor: '#EF6C00',
+              padding: 2,
+              borderRadius: 8,
+            },
+            children: [
+              {
+                id: 'template-math-question-input',
+                type: 'TextField',
+                props: {
+                  label: 'Add a doubt or exam question',
+                  placeholder: 'Example: when should I use chain rule?',
+                  fullWidth: true,
+                  variant: 'outlined',
+                  helperText:
+                    'Future idea: turn notes/questions into dashboard blocks automatically.',
+                },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'template-math-progress',
+        type: 'Chart',
+        props: {
+          title: 'Study progress',
+          chartType: 'pie',
+          height: 260,
+          description: 'Example of using charts as visual study feedback.',
+          data: `{
+            "labels": ["Understood", "Needs practice", "Ask teacher"],
+            "datasets": [{
+              "data": [55, 35, 10],
+              "backgroundColor": ["rgba(25, 118, 210, 0.85)", "rgba(239, 108, 0, 0.85)", "rgba(194, 24, 91, 0.85)"],
+              "borderWidth": 2
+            }]
+          }`,
+        },
+      },
+    ],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    tags: ['knowledge wiki', 'math', 'study', 'formulas', 'chart'],
+  },
+  {
+    id: 'template-knowledge-physics',
+    name: 'Physics Knowledge Wiki Template',
+    description:
+      'A visual physics study page for formulas, experiment notes, diagrams, and revision status.',
+    category: 'Knowledge Workspace',
+    components: [
+      {
+        id: 'template-physics-title',
+        type: 'Label',
+        props: {
+          text: 'Physics 1 — Motion',
+          variant: 'h4',
+          gutterBottom: true,
+          useCustomColor: true,
+          customColor: '#007C66',
+          fontWeight: 700,
+        },
+      },
+      {
+        id: 'template-physics-overview',
+        type: 'FieldSet',
+        props: {
+          legend: 'Knowledge page structure',
+          collapsed: false,
+          borderStyle: 'solid',
+          useCustomBorderColor: true,
+          useCustomLegendColor: true,
+          borderColor: '#007C66',
+          legendColor: '#007C66',
+          backgroundColor: 'rgba(0, 124, 102, 0.08)',
+          padding: 2,
+          borderRadius: 8,
+        },
+        children: [
+          {
+            id: 'template-physics-overview-label',
+            type: 'Label',
+            props: {
+              text: 'This example shows how AquaMesh can behave like a visual wiki: formulas, notes, questions, and charts live in the same dashboard.',
+              variant: 'body1',
+            },
+          },
+        ],
+      },
+      {
+        id: 'template-physics-grid',
+        type: 'GridBox',
+        props: { columns: 2, spacing: 2, responsive: true },
+        children: [
+          {
+            id: 'template-physics-formulas',
+            type: 'FieldSet',
+            props: {
+              legend: 'Motion formulas',
+              borderStyle: 'solid',
+              useCustomBorderColor: true,
+              useCustomLegendColor: true,
+              borderColor: '#455A64',
+              legendColor: '#455A64',
+              padding: 2,
+              borderRadius: 8,
+            },
+            children: [
+              {
+                id: 'template-physics-formula-label',
+                type: 'Label',
+                props: {
+                  text: 'Velocity: v = Δx / Δt\nAcceleration: a = Δv / Δt\nPosition: x = x₀ + vt + ½at²',
+                  variant: 'body1',
+                  whiteSpace: 'pre-line',
+                },
+              },
+            ],
+          },
+          {
+            id: 'template-physics-lab-notes',
+            type: 'FieldSet',
+            props: {
+              legend: 'Experiment notes',
+              borderStyle: 'solid',
+              useCustomBorderColor: true,
+              useCustomLegendColor: true,
+              borderColor: '#C2185B',
+              legendColor: '#C2185B',
+              padding: 2,
+              borderRadius: 8,
+            },
+            children: [
+              {
+                id: 'template-physics-note-input',
+                type: 'TextField',
+                props: {
+                  label: 'Observation',
+                  placeholder:
+                    'Example: slope of position/time graph gives velocity',
+                  fullWidth: true,
+                  variant: 'outlined',
+                  helperText:
+                    'Future idea: paste notes and generate a dashboard from them.',
+                },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'template-physics-chart',
+        type: 'Chart',
+        props: {
+          title: 'Revision status',
+          chartType: 'bar',
+          height: 280,
+          description: 'Track what needs review before the exam.',
+          data: `{
+            "labels": ["Formulas", "Graphs", "Problems", "Lab notes"],
+            "datasets": [{
+              "label": "Confidence",
+              "data": [80, 55, 45, 70],
+              "backgroundColor": "rgba(0, 124, 102, 0.75)",
+              "borderColor": "rgba(0, 124, 102, 1)",
+              "borderWidth": 2
+            }]
+          }`,
+        },
+      },
+    ],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    tags: ['knowledge wiki', 'physics', 'study', 'formulas', 'notes'],
+  },
+
+  {
+    id: 'template-math-derivatives-chart',
+    name: 'Mathematics Derivatives Chart Template',
+    description: 'A chart widget for derivative practice progress.',
+    category: 'Knowledge Workspace',
+    components: [
+      {
+        id: 'template-math-chart-title',
+        type: 'Label',
+        props: {
+          text: 'Mathematics 1 — Chart',
+          variant: 'h5',
+          gutterBottom: true,
+          useCustomColor: true,
+          customColor: '#1976D2',
+          fontWeight: 700,
+        },
+      },
+      {
+        id: 'template-math-progress-chart',
+        type: 'Chart',
+        props: {
+          title: 'Derivative practice progress',
+          chartType: 'bar',
+          height: 280,
+          description:
+            'Example chart: what is understood, what needs practice, and what needs help.',
+          data: `{
+            "labels": ["Power rule", "Chain rule", "Product rule", "Word problems"],
+            "datasets": [{
+              "label": "Confidence",
+              "data": [85, 55, 65, 35],
+              "backgroundColor": "rgba(25, 118, 210, 0.75)",
+              "borderColor": "rgba(25, 118, 210, 1)",
+              "borderWidth": 2
+            }]
+          }`,
+        },
+      },
+      {
+        id: 'template-math-chart-note',
+        type: 'Label',
+        props: {
+          text: 'This is a chart block. Later it could react to answers, checks, or note data.',
+          variant: 'body2',
+        },
+      },
+    ],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    tags: ['mathematics', 'derivatives', 'chart'],
+  },
+  {
+    id: 'template-math-derivatives-example',
+    name: 'Mathematics Derivatives Example Template',
+    description:
+      'A widget with worked derivative examples and a question input.',
+    category: 'Knowledge Workspace',
+    components: [
+      {
+        id: 'template-math-example-title',
+        type: 'Label',
+        props: {
+          text: 'Mathematics 1 — Derivatives Example',
+          variant: 'h5',
+          gutterBottom: true,
+          useCustomColor: true,
+          customColor: '#EF6C00',
+          fontWeight: 700,
+        },
+      },
+      {
+        id: 'template-math-example-section',
+        type: 'FieldSet',
+        props: {
+          legend: 'Worked example',
+          borderStyle: 'solid',
+          borderColor: '#EF6C00',
+          legendColor: '#EF6C00',
+          useCustomBorderColor: true,
+          useCustomLegendColor: true,
+          padding: 2,
+          borderRadius: 8,
+        },
+        children: [
+          {
+            id: 'template-math-example-text',
+            type: 'Label',
+            props: {
+              text: 'Example: f(x)=3x⁴ - 2x² + 7\nf′(x)=12x³ - 4x\n\nWhy: apply the power rule to each term.',
+              variant: 'body1',
+              whiteSpace: 'pre-line',
+            },
+          },
+          {
+            id: 'template-math-example-input',
+            type: 'TextField',
+            props: {
+              label: 'Try one yourself',
+              placeholder: 'Derivative of x³ + 5x?',
+              fullWidth: true,
+              variant: 'outlined',
+              helperText:
+                'This is an input block for answers, doubts, or notes.',
+            },
+          },
+        ],
+      },
+    ],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    tags: ['mathematics', 'derivatives', 'example', 'input'],
+  },
+  {
+    id: 'template-math-derivatives-theory',
+    name: 'Mathematics Derivatives Theory Template',
+    description: 'A widget with derivative theory and formulas.',
+    category: 'Knowledge Workspace',
+    components: [
+      {
+        id: 'template-math-theory-title',
+        type: 'Label',
+        props: {
+          text: 'Mathematics 1 — Theory Derivatives',
+          variant: 'h5',
+          gutterBottom: true,
+          useCustomColor: true,
+          customColor: '#7B1FA2',
+          fontWeight: 700,
+        },
+      },
+      {
+        id: 'template-math-theory-fieldset',
+        type: 'FieldSet',
+        props: {
+          legend: 'Core theory',
+          borderStyle: 'solid',
+          borderColor: '#7B1FA2',
+          legendColor: '#7B1FA2',
+          useCustomBorderColor: true,
+          useCustomLegendColor: true,
+          padding: 2,
+          borderRadius: 8,
+        },
+        children: [
+          {
+            id: 'template-math-theory-text',
+            type: 'Label',
+            props: {
+              text: 'A derivative measures the rate of change of a function.\n\nPower rule: d/dx xⁿ = n·xⁿ⁻¹\nChain rule: d/dx f(g(x)) = f′(g(x))·g′(x)\nProduct rule: (fg)′ = f′g + fg′',
+              variant: 'body1',
+              whiteSpace: 'pre-line',
+            },
+          },
+        ],
+      },
+    ],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    tags: ['mathematics', 'derivatives', 'theory', 'formulas'],
+  },
+  {
+    id: 'template-knowledge-tutorial',
+    name: 'AquaMesh Tutorial Template',
+    description: 'A dashboard that explains widgets, dashboards, and blocks.',
+    category: 'Knowledge Workspace',
+    components: [
+      {
+        id: 'template-tutorial-title',
+        type: 'Label',
+        props: {
+          text: 'AquaMesh Tutorial',
+          variant: 'h4',
+          gutterBottom: true,
+          useCustomColor: true,
+          customColor: '#007C66',
+          fontWeight: 700,
+        },
+      },
+      {
+        id: 'template-tutorial-intro',
+        type: 'FieldSet',
+        props: {
+          legend: 'The three ideas',
+          borderStyle: 'solid',
+          borderColor: '#007C66',
+          legendColor: '#007C66',
+          useCustomBorderColor: true,
+          useCustomLegendColor: true,
+          padding: 2,
+          borderRadius: 8,
+        },
+        children: [
+          {
+            id: 'template-tutorial-text',
+            type: 'Label',
+            props: {
+              text: 'Widgets are reusable pieces of knowledge.\nDashboards are pages where widgets live together.\nBlocks are the small parts inside a widget: labels, inputs, buttons, charts, and groups.',
+              variant: 'body1',
+              whiteSpace: 'pre-line',
+            },
+          },
+        ],
+      },
+      {
+        id: 'template-tutorial-blocks',
+        type: 'GridBox',
+        props: { columns: 2, spacing: 2, responsive: true },
+        children: [
+          {
+            id: 'template-tutorial-label-section',
+            type: 'FieldSet',
+            props: { legend: 'Label block', padding: 2, borderRadius: 8 },
+            children: [
+              {
+                id: 'template-tutorial-label-example',
+                type: 'Label',
+                props: {
+                  text: 'This is a label: text, theory, explanations, or titles.',
+                  variant: 'body1',
+                },
+              },
+            ],
+          },
+          {
+            id: 'template-tutorial-input-section',
+            type: 'FieldSet',
+            props: { legend: 'Input block', padding: 2, borderRadius: 8 },
+            children: [
+              {
+                id: 'template-tutorial-input-example',
+                type: 'TextField',
+                props: {
+                  label: 'This is an input',
+                  placeholder: 'Write a note or answer',
+                  fullWidth: true,
+                },
+              },
+            ],
+          },
+          {
+            id: 'template-tutorial-button-section',
+            type: 'FieldSet',
+            props: { legend: 'Button block', padding: 2, borderRadius: 8 },
+            children: [
+              {
+                id: 'template-tutorial-button-example',
+                type: 'Button',
+                props: {
+                  text: 'This is a button',
+                  variant: 'contained',
+                  showToast: true,
+                  toastMessage: 'Button clicked',
+                  toastSeverity: 'info',
+                },
+              },
+            ],
+          },
+          {
+            id: 'template-tutorial-chart-section',
+            type: 'FieldSet',
+            props: {
+              legend: 'Chart / graph block',
+              padding: 2,
+              borderRadius: 8,
+            },
+            children: [
+              {
+                id: 'template-tutorial-chart-example',
+                type: 'Chart',
+                props: {
+                  title: 'This is a chart',
+                  chartType: 'pie',
+                  height: 220,
+                  data: `{"labels":["Labels","Inputs","Charts"],"datasets":[{"data":[35,30,35],"backgroundColor":["rgba(0,124,102,0.8)","rgba(25,118,210,0.8)","rgba(239,108,0,0.8)"]}]}`,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    tags: ['tutorial', 'widgets', 'dashboards', 'blocks'],
+  },
 ]
 
 // Function to clone a template and generate new IDs

--- a/apps/aquamesh/src/components/WidgetEditor/constants/templateWidgets.ts
+++ b/apps/aquamesh/src/components/WidgetEditor/constants/templateWidgets.ts
@@ -1118,7 +1118,7 @@ export const WIDGET_TEMPLATES: CustomWidget[] = [
           legendColor: '#7B1FA2',
           useCustomBorderColor: true,
           useCustomLegendColor: true,
-          padding: 2,
+          padding: 1.5,
           borderRadius: 8,
         },
         children: [
@@ -1126,8 +1126,8 @@ export const WIDGET_TEMPLATES: CustomWidget[] = [
             id: 'template-math-theory-text',
             type: 'Label',
             props: {
-              text: 'A derivative measures the rate of change of a function.\n\nPower rule: d/dx xⁿ = n·xⁿ⁻¹\nChain rule: d/dx f(g(x)) = f′(g(x))·g′(x)\nProduct rule: (fg)′ = f′g + fg′',
-              variant: 'body1',
+              text: 'Derivative = rate of change.\nPower: d/dx xⁿ = n·xⁿ⁻¹\nChain: d/dx f(g(x)) = f′(g(x))·g′(x)\nProduct: (fg)′ = f′g + fg′',
+              variant: 'body2',
               whiteSpace: 'pre-line',
             },
           },

--- a/apps/aquamesh/src/components/landing/AquaMeshLanding.tsx
+++ b/apps/aquamesh/src/components/landing/AquaMeshLanding.tsx
@@ -26,8 +26,8 @@ import ThemeModeToggle from '../shared/ThemeModeToggle'
 
 const workflow = [
   {
-    title: 'Open an example',
-    body: 'Start from a Mathematics or Tutorial dashboard so the app explains itself before you build anything.',
+    title: 'Enter the workspace',
+    body: 'Start with a clean workspace, then open saved dashboards or create your own widgets when you need them.',
     icon: <SchoolIcon />,
   },
   {
@@ -84,17 +84,17 @@ const quickAnswers = [
   {
     question: 'What is AquaMesh for?',
     answer:
-      'AquaMesh is becoming a visual knowledge wiki: notes, formulas, charts, images, and reusable widgets organized into dashboards.',
+      'AquaMesh is a visual knowledge wiki: notes, formulas, charts, images, and reusable widgets organized into dashboards.',
   },
   {
-    question: 'What should I open first?',
+    question: 'What should I do first?',
     answer:
-      'Open the Mathematics or Tutorial example from the dashboard menu. They are starter pages and mini tutorials.',
+      'Enter the workspace. From there you can create a dashboard, save it to a folder, or open existing dashboards.',
   },
   {
-    question: 'Can notes become dashboards?',
+    question: 'How are dashboards organized?',
     answer:
-      'That is the direction: paste or write notes, then turn them into structured dashboard blocks. This PR prepares the product around that workflow.',
+      'When you save a dashboard, choose a folder name. Dashboards with the same folder name appear together.',
   },
 ]
 
@@ -191,18 +191,10 @@ const AquaMeshLanding = () => {
               <Button
                 variant="contained"
                 size="large"
-                onClick={() => openWorkspace('open-math-example')}
-                sx={{ borderRadius: 1, textTransform: 'none' }}
-              >
-                Open math example
-              </Button>
-              <Button
-                variant="outlined"
-                size="large"
                 onClick={() => openWorkspace()}
                 sx={{ borderRadius: 1, textTransform: 'none' }}
               >
-                Start blank
+                Enter workspace
               </Button>
             </Stack>
           </Grid>
@@ -350,7 +342,7 @@ const AquaMeshLanding = () => {
           }}
         >
           <Typography variant="h4" component="h2" fontWeight={850} mb={1}>
-            Ready to open your first study dashboard?
+            Ready to build your workspace?
           </Typography>
           <Typography
             sx={{
@@ -358,13 +350,12 @@ const AquaMeshLanding = () => {
               mb: 3,
             }}
           >
-            Open a guided Mathematics dashboard, inspect the blocks, and use it
-            as a starting point for your own notes.
+            Enter the workspace, create dashboards, and organize them by folder.
           </Typography>
           <Button
             variant="contained"
             size="large"
-            onClick={() => openWorkspace('open-math-example')}
+            onClick={() => openWorkspace()}
             sx={{
               borderRadius: 1,
               textTransform: 'none',
@@ -373,7 +364,7 @@ const AquaMeshLanding = () => {
               '&:hover': { bgcolor: 'primary.light' },
             }}
           >
-            Open math example
+            Enter workspace
           </Button>
         </Paper>
       </Container>

--- a/apps/aquamesh/src/components/landing/AquaMeshLanding.tsx
+++ b/apps/aquamesh/src/components/landing/AquaMeshLanding.tsx
@@ -14,54 +14,53 @@ import { useNavigate } from 'react-router-dom'
 import AddchartIcon from '@mui/icons-material/Addchart'
 import DashboardCustomizeIcon from '@mui/icons-material/DashboardCustomize'
 import SaveAltIcon from '@mui/icons-material/SaveAlt'
-import WidgetsIcon from '@mui/icons-material/Widgets'
 import TaskAltIcon from '@mui/icons-material/TaskAlt'
 import SupportAgentIcon from '@mui/icons-material/SupportAgent'
-import ArchitectureIcon from '@mui/icons-material/Architecture'
 import BiotechIcon from '@mui/icons-material/Biotech'
 import ImageIcon from '@mui/icons-material/Image'
-import NotesIcon from '@mui/icons-material/Notes'
+import SchoolIcon from '@mui/icons-material/School'
+import MenuBookIcon from '@mui/icons-material/MenuBook'
 
 import { ReactComponent as Logo } from '../../../public/logo.svg'
 import ThemeModeToggle from '../shared/ThemeModeToggle'
 
 const workflow = [
   {
-    title: 'Create Widget',
-    body: 'Name a widget for your work: an operations snapshot, site review, lab log, or task tracker.',
-    icon: <WidgetsIcon />,
+    title: 'Open an example',
+    body: 'Start from a Mathematics or Tutorial dashboard so the app explains itself before you build anything.',
+    icon: <SchoolIcon />,
   },
   {
-    title: 'Add Blocks',
-    body: 'Add text, inputs, buttons, charts, and layout sections.',
+    title: 'Collect knowledge blocks',
+    body: 'Use long text, formulas, inputs, charts, images, and layout sections as visual notes.',
     icon: <AddchartIcon />,
   },
   {
-    title: 'Preview And Save',
-    body: 'Check the widget, save it to your library, and keep versions.',
+    title: 'Save reusable widgets',
+    body: 'Turn a formula card, revision tracker, or note section into a widget you can reuse.',
     icon: <SaveAltIcon />,
   },
   {
-    title: 'Add To Dashboard',
-    body: 'Place the saved widget into the dashboard canvas.',
+    title: 'Organize dashboards',
+    body: 'Keep study pages by subject, topic, or project and evolve them like a visual wiki.',
     icon: <DashboardCustomizeIcon />,
   },
 ]
 
 const useCases = [
   {
-    title: 'Operations hub',
-    body: 'Track orders, delayed work, tickets, status, and handoffs.',
-    icon: <SupportAgentIcon />,
+    title: 'Study wiki',
+    body: 'Build subject pages for mathematics, tutorials, biology, or exam revision.',
+    icon: <SchoolIcon />,
   },
   {
-    title: 'Architecture review',
-    body: 'Collect site notes, material choices, images, and decisions.',
-    icon: <ArchitectureIcon />,
+    title: 'Formula notebook',
+    body: 'Keep formulas, examples, charts, and doubts in one visual dashboard.',
+    icon: <MenuBookIcon />,
   },
   {
-    title: 'Biology field log',
-    body: 'Record observations, sample counts, charts, and next steps.',
+    title: 'Research board',
+    body: 'Pair images, notes, references, and observations for projects or labs.',
     icon: <BiotechIcon />,
   },
   {
@@ -70,32 +69,32 @@ const useCases = [
     icon: <TaskAltIcon />,
   },
   {
+    title: 'Operations hub',
+    body: 'Track orders, delayed work, tickets, status, and handoffs when you need a CRM-like view.',
+    icon: <SupportAgentIcon />,
+  },
+  {
     title: 'Image and notes board',
     body: 'Pair visual references with structured text and controls.',
     icon: <ImageIcon />,
-  },
-  {
-    title: 'Team handoff',
-    body: 'Capture notes and next actions in the same view.',
-    icon: <NotesIcon />,
   },
 ]
 
 const quickAnswers = [
   {
-    question: 'What should I do first?',
+    question: 'What is AquaMesh for?',
     answer:
-      'Start with Create Widget. Pick one concrete use case, such as an operations summary, architecture site review, lab observation log, or task tracker. Save it, then reuse it in a dashboard.',
+      'AquaMesh is becoming a visual knowledge wiki: notes, formulas, charts, images, and reusable widgets organized into dashboards.',
   },
   {
-    question: 'Which blocks should I start with?',
+    question: 'What should I open first?',
     answer:
-      'Use a chart for trends, a label for status, an image for visual context, or a note field for follow-up.',
+      'Open the Mathematics or Tutorial example from the dashboard menu. They are starter pages and mini tutorials.',
   },
   {
-    question: 'Where does my saved widget go?',
+    question: 'Can notes become dashboards?',
     answer:
-      'Saved widgets appear in Add Widget so you can reuse them across dashboards and workspaces.',
+      'That is the direction: paste or write notes, then turn them into structured dashboard blocks. This PR prepares the product around that workflow.',
   },
 ]
 
@@ -181,22 +180,29 @@ const AquaMeshLanding = () => {
               component="p"
               sx={{ fontWeight: 700, color: 'primary.dark', mb: 2 }}
             >
-              Create reusable workspace widgets without code.
+              Create a visual knowledge wiki from reusable widgets.
             </Typography>
             <Typography variant="body1" sx={{ color: 'text.secondary', mb: 3 }}>
-              Build reusable widgets from text, inputs, buttons, charts, images,
-              and layout blocks. Use them for operations, architecture reviews,
-              biology notes, project planning, or any workspace you need to
-              organize.
+              Turn study notes, formulas, charts, images, and questions into
+              visual dashboards. Start from subject examples, then adapt the
+              workspace into your own personal wiki.
             </Typography>
             <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
               <Button
                 variant="contained"
                 size="large"
+                onClick={() => openWorkspace('open-math-example')}
+                sx={{ borderRadius: 1, textTransform: 'none' }}
+              >
+                Open math example
+              </Button>
+              <Button
+                variant="outlined"
+                size="large"
                 onClick={() => openWorkspace()}
                 sx={{ borderRadius: 1, textTransform: 'none' }}
               >
-                Enter workspace
+                Start blank
               </Button>
             </Stack>
           </Grid>
@@ -233,7 +239,7 @@ const AquaMeshLanding = () => {
 
         <Box sx={{ py: 5 }}>
           <Typography variant="h4" component="h2" fontWeight={850} mb={3}>
-            Build one widget, then reuse it
+            Start from knowledge, then customize it
           </Typography>
           <Grid container spacing={2}>
             {workflow.map((step, index) => (
@@ -271,7 +277,7 @@ const AquaMeshLanding = () => {
 
         <Box sx={{ py: 5 }}>
           <Typography variant="h4" component="h2" fontWeight={850} mb={3}>
-            Use AquaMesh for real work
+            Use AquaMesh as a visual wiki
           </Typography>
           <Grid container spacing={2}>
             {useCases.map((useCase) => (
@@ -344,7 +350,7 @@ const AquaMeshLanding = () => {
           }}
         >
           <Typography variant="h4" component="h2" fontWeight={850} mb={1}>
-            Ready to build your first workspace?
+            Ready to open your first study dashboard?
           </Typography>
           <Typography
             sx={{
@@ -352,14 +358,13 @@ const AquaMeshLanding = () => {
               mb: 3,
             }}
           >
-            Enter the workspace, create one reusable widget, and place it
-            wherever it helps: a dashboard, review board, lab log, or task
-            space.
+            Open a guided Mathematics dashboard, inspect the blocks, and use it
+            as a starting point for your own notes.
           </Typography>
           <Button
             variant="contained"
             size="large"
-            onClick={() => openWorkspace()}
+            onClick={() => openWorkspace('open-math-example')}
             sx={{
               borderRadius: 1,
               textTransform: 'none',
@@ -368,7 +373,7 @@ const AquaMeshLanding = () => {
               '&:hover': { bgcolor: 'primary.light' },
             }}
           >
-            Enter workspace
+            Open math example
           </Button>
         </Paper>
       </Container>

--- a/apps/aquamesh/src/components/topnavbar/TopNavBar.tsx
+++ b/apps/aquamesh/src/components/topnavbar/TopNavBar.tsx
@@ -347,39 +347,51 @@ const TopNavBar: React.FC<TopNavBarProps> = () => {
                 )
               ) : (
                 <>
-                  <Typography
-                    sx={{
-                      px: 2,
-                      py: 1,
-                      fontWeight: 'bold',
-                      mt: 1,
-                      color: 'text.primary',
-                    }}
-                  >
-                    Example Starter Widgets
-                  </Typography>
-                  <Divider sx={{ borderColor: 'divider' }} />
-                  {topNavBarWidgets
-                    .filter((widget) => !widget.name.includes('Custom'))
-                    .map((topNavBarWidget) => (
-                      <Box key={topNavBarWidget.name}>
-                        {topNavBarWidget.items.map((item) => (
-                          <MenuItem
-                            key={item.name}
-                            onClick={() => {
-                              ensureDashboardAndAddComponent({
-                                id: `panel-${Date.now()}`,
-                                ...item,
-                              })
-                              handleClose()
-                            }}
-                            sx={{ p: 1.5 }}
-                          >
-                            {item.name}
-                          </MenuItem>
+                  {topNavBarWidgets.filter(
+                    (widget) =>
+                      !widget.name.includes('Custom') &&
+                      widget.items.length > 0,
+                  ).length > 0 && (
+                    <>
+                      <Typography
+                        sx={{
+                          px: 2,
+                          py: 1,
+                          fontWeight: 'bold',
+                          mt: 1,
+                          color: 'text.primary',
+                        }}
+                      >
+                        Starter Widgets
+                      </Typography>
+                      <Divider sx={{ borderColor: 'divider' }} />
+                      {topNavBarWidgets
+                        .filter(
+                          (widget) =>
+                            !widget.name.includes('Custom') &&
+                            widget.items.length > 0,
+                        )
+                        .map((topNavBarWidget) => (
+                          <Box key={topNavBarWidget.name}>
+                            {topNavBarWidget.items.map((item) => (
+                              <MenuItem
+                                key={item.name}
+                                onClick={() => {
+                                  ensureDashboardAndAddComponent({
+                                    id: `panel-${Date.now()}`,
+                                    ...item,
+                                  })
+                                  handleClose()
+                                }}
+                                sx={{ p: 1.5 }}
+                              >
+                                {item.name}
+                              </MenuItem>
+                            ))}
+                          </Box>
                         ))}
-                      </Box>
-                    ))}
+                    </>
+                  )}
 
                   {/* Custom Widgets Section */}
                   {topNavBarWidgets.filter((widget) =>

--- a/apps/aquamesh/src/components/tutorial/TutorialModal.tsx
+++ b/apps/aquamesh/src/components/tutorial/TutorialModal.tsx
@@ -125,12 +125,45 @@ const TutorialModal: React.FC<TutorialModalProps> = ({
 
   const options: TutorialOption[] = []
 
+  options.push(
+    {
+      title: 'Start with a guided knowledge dashboard',
+      description:
+        'Open a Mathematics or Tutorial starter dashboard first. They work like mini tutorials: formulas, notes, inputs, and charts are already arranged so the workspace has a clear purpose.',
+    },
+    {
+      icon: <ImportContactsIcon fontSize="large" color="primary" />,
+      image: placeholderImages.predefinedDashboards,
+      hasMultipleButtons: true,
+      buttons: [
+        {
+          text: 'Dashboard Basics',
+          action: () => {
+            setExplanationModalOpen(true)
+          },
+        },
+        {
+          text: 'Open Starters',
+          action: () => {
+            onClose()
+            const dashboardsButton = document.querySelector(
+              '[data-tutorial-id="dashboards-button"]',
+            )
+            if (dashboardsButton) {
+              ;(dashboardsButton as HTMLElement).click()
+            }
+          },
+        },
+      ],
+    },
+  )
+
   // Create Widget is the primary path for builder users.
   if (isAdmin) {
     options.push({
-      title: 'Create your first reusable widget',
+      title: 'Create your first reusable knowledge block',
       description:
-        'Open Create Widget and build something concrete: an operations summary, architecture site review, lab observation log, or task tracker.',
+        'Open Create Widget when you are ready to build your own formula card, revision tracker, research note, or project block.',
       icon: <CreateIcon fontSize="large" color="primary" />,
       buttonText: 'Start building',
       image: placeholderImages.customWidgetCreation,
@@ -146,9 +179,9 @@ const TutorialModal: React.FC<TutorialModalProps> = ({
     })
   } else {
     options.push({
-      title: 'Create your first reusable widget',
+      title: 'Create your first reusable knowledge block',
       description:
-        'The recommended path is to create one reusable widget for a real use case, then add it to a dashboard. Builder mode is required to save widgets.',
+        'The recommended path is to start from a dashboard example, then create one reusable block for your own notes. Builder mode is required to save widgets.',
       icon: <CreateIcon fontSize="large" color="primary" />,
       buttonText: 'View Quick Start',
       image: placeholderImages.customWidgetCreation,
@@ -160,9 +193,9 @@ const TutorialModal: React.FC<TutorialModalProps> = ({
 
   options.push(
     {
-      title: 'Use the widget in a dashboard',
+      title: 'Use saved blocks in a dashboard',
       description:
-        'After saving, open Add Widget, choose your saved widget, and place it into the current dashboard.',
+        'After saving, open Add Widget, choose your saved block, and place it into the current knowledge dashboard.',
       icon: <DashboardIcon fontSize="large" color="primary" />,
       image: placeholderImages.predefinedWidgets,
       hasMultipleButtons: true,
@@ -188,9 +221,9 @@ const TutorialModal: React.FC<TutorialModalProps> = ({
       ],
     },
     {
-      title: 'View an example dashboard',
+      title: 'View more starter dashboards',
       description:
-        'Use the dashboard menu when you want inspiration from a finished layout. Daily Operations is one example, not the only kind of workspace AquaMesh can organize.',
+        'Use the dashboard menu when you want a finished layout. Mathematics shows a multi-widget study dashboard; Tutorial explains the app concepts.',
       icon: <InfoIcon fontSize="large" color="primary" />,
       hasMultipleImages: true,
       images: [
@@ -228,7 +261,7 @@ const TutorialModal: React.FC<TutorialModalProps> = ({
   )
 
   // Determine which slides to display based on device and user role
-  const displayOptions = [options[0]]
+  const displayOptions = isMobile ? options.slice(0, 2) : options.slice(0, 3)
 
   // Keyboard navigation handler
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {

--- a/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
+++ b/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
@@ -16,6 +16,20 @@ export interface WorkspaceComponentConfig {
   customProps?: Record<string, unknown>
 }
 
+interface SavedDashboardRecord {
+  id: string
+  name: string
+  folder?: string
+  layout: DashboardLayout
+  description?: string
+  tags?: string[]
+  isPublic?: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+const STARTER_DASHBOARDS_SEEDED_KEY = 'aquamesh-starter-dashboards-seeded-v1'
+
 const createLayoutWithComponent = (
   componentConfig: WorkspaceComponentConfig,
 ): DashboardLayout => ({
@@ -40,27 +54,199 @@ const createLayoutWithComponent = (
   ],
 })
 
-const createLayoutWithComponents = (
+const createMathStarterLayout = (
   componentConfigs: WorkspaceComponentConfig[],
-): DashboardLayout => ({
-  type: 'row',
-  weight: 100,
-  children: [
-    {
-      type: 'tabset',
-      weight: 100,
-      active: true,
-      children: componentConfigs.map((componentConfig) => ({
-        type: 'tab',
-        name: componentConfig.name,
-        component: componentConfig.component,
-        config: componentConfig.customProps
-          ? { customProps: componentConfig.customProps }
-          : undefined,
-      })),
-    },
-  ],
+): DashboardLayout => {
+  const [chart, example, theory] = componentConfigs
+
+  const createTab = (componentConfig: WorkspaceComponentConfig) => ({
+    type: 'tab',
+    name: componentConfig.name,
+    component: componentConfig.component,
+    config: componentConfig.customProps
+      ? { customProps: componentConfig.customProps }
+      : undefined,
+  })
+
+  return {
+    type: 'row',
+    weight: 100,
+    children: [
+      {
+        type: 'tabset',
+        weight: 43,
+        active: true,
+        children: [createTab(chart)],
+      },
+      {
+        type: 'row',
+        weight: 57,
+        children: [
+          {
+            type: 'tabset',
+            weight: 50,
+            children: [createTab(example)],
+          },
+          {
+            type: 'tabset',
+            weight: 50,
+            children: [createTab(theory)],
+          },
+        ],
+      },
+    ],
+  }
+}
+
+const saveTemplateWidget = ({
+  widgetName,
+  templateId,
+  description,
+  category = 'Knowledge Workspace',
+  tags,
+}: {
+  widgetName: string
+  templateId: string
+  description: string
+  category?: string
+  tags: string[]
+}) => {
+  let widget = WidgetStorage.getAllWidgets().find(
+    (savedWidget) => savedWidget.name === widgetName,
+  )
+
+  if (!widget) {
+    const template = cloneTemplate(templateId)
+
+    if (template) {
+      widget = WidgetStorage.saveWidget({
+        name: widgetName,
+        description,
+        category,
+        tags,
+        components: template.components,
+        version: '1.0',
+        author: 'AquaMesh',
+      })
+    }
+  }
+
+  return widget
+}
+
+const createCustomWidgetConfig = (
+  widget: NonNullable<ReturnType<typeof saveTemplateWidget>>,
+) => ({
+  name: widget.name,
+  component: 'CustomWidget',
+  customProps: {
+    widgetId: widget.id,
+    components: widget.components,
+  },
 })
+
+const getSavedDashboards = (): SavedDashboardRecord[] => {
+  try {
+    const dashboards = window.localStorage.getItem('customDashboards')
+    return dashboards ? JSON.parse(dashboards) : []
+  } catch (error) {
+    console.error('Failed to read saved dashboards', error)
+    return []
+  }
+}
+
+const saveStarterDashboard = (
+  dashboard: Omit<SavedDashboardRecord, 'id' | 'createdAt' | 'updatedAt'>,
+) => {
+  const dashboards = getSavedDashboards()
+
+  if (
+    dashboards.some((savedDashboard) => savedDashboard.name === dashboard.name)
+  ) {
+    return
+  }
+
+  const now = new Date().toISOString()
+  dashboards.push({
+    id: `dashboard-starter-${dashboard.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
+    ...dashboard,
+    createdAt: now,
+    updatedAt: now,
+  })
+  window.localStorage.setItem('customDashboards', JSON.stringify(dashboards))
+}
+
+export const ensureStarterDashboards = () => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  if (window.localStorage.getItem(STARTER_DASHBOARDS_SEEDED_KEY) === 'true') {
+    return
+  }
+
+  const mathWidgets = [
+    saveTemplateWidget({
+      widgetName: 'Mathematics 1 — Chart',
+      templateId: 'template-math-derivatives-chart',
+      description:
+        'Practice-progress chart for the derivatives study dashboard.',
+      tags: ['mathematics', 'derivatives', 'chart'],
+    }),
+    saveTemplateWidget({
+      widgetName: 'Mathematics 1 — Derivatives Example',
+      templateId: 'template-math-derivatives-example',
+      description:
+        'Worked derivative examples and a question input for the study dashboard.',
+      tags: ['mathematics', 'derivatives', 'example'],
+    }),
+    saveTemplateWidget({
+      widgetName: 'Mathematics 1 — Theory Derivatives',
+      templateId: 'template-math-derivatives-theory',
+      description:
+        'Core derivative theory and formulas for the study dashboard.',
+      tags: ['mathematics', 'derivatives', 'theory'],
+    }),
+  ].filter(Boolean)
+
+  if (mathWidgets.length === 3) {
+    saveStarterDashboard({
+      name: 'Mathematics 1 — Derivatives',
+      folder: 'Mathematics',
+      layout: createMathStarterLayout(
+        mathWidgets.map((widget) => createCustomWidgetConfig(widget!)),
+      ),
+      description:
+        'A starter mathematics dashboard with theory, examples, and a chart.',
+      tags: ['mathematics', 'derivatives', 'starter'],
+      isPublic: true,
+    })
+  }
+
+  const tutorialWidget = saveTemplateWidget({
+    widgetName: 'AquaMesh Tutorial',
+    templateId: 'template-knowledge-tutorial',
+    description:
+      'A simple dashboard that explains widgets, dashboards, and blocks with visual examples.',
+    tags: ['tutorial', 'knowledge wiki', 'dashboard', 'blocks'],
+  })
+
+  if (tutorialWidget) {
+    saveStarterDashboard({
+      name: 'AquaMesh Tutorial',
+      folder: 'Tutorial',
+      layout: createLayoutWithComponent(
+        createCustomWidgetConfig(tutorialWidget),
+      ),
+      description:
+        'A starter dashboard that explains the basic AquaMesh concepts.',
+      tags: ['tutorial', 'widgets', 'dashboards', 'blocks'],
+      isPublic: true,
+    })
+  }
+
+  window.localStorage.setItem(STARTER_DASHBOARDS_SEEDED_KEY, 'true')
+}
 
 const hasDashboardContent = (layout?: DashboardLayout): boolean => {
   if (!layout) {
@@ -185,45 +371,6 @@ export const useWorkspaceActions = () => {
     [addDashboard],
   )
 
-  const saveTemplateWidget = useCallback(
-    ({
-      widgetName,
-      templateId,
-      description,
-      category = 'Knowledge Workspace',
-      tags,
-    }: {
-      widgetName: string
-      templateId: string
-      description: string
-      category?: string
-      tags: string[]
-    }) => {
-      let widget = WidgetStorage.getAllWidgets().find(
-        (savedWidget) => savedWidget.name === widgetName,
-      )
-
-      if (!widget) {
-        const template = cloneTemplate(templateId)
-
-        if (template) {
-          widget = WidgetStorage.saveWidget({
-            name: widgetName,
-            description,
-            category,
-            tags,
-            components: template.components,
-            version: '1.0',
-            author: 'AquaMesh',
-          })
-        }
-      }
-
-      return widget
-    },
-    [],
-  )
-
   const openOperationsExample = useCallback(() => {
     openTemplateDashboard({
       widgetName: 'Daily Operations Dashboard',
@@ -235,54 +382,32 @@ export const useWorkspaceActions = () => {
   }, [openTemplateDashboard])
 
   const openMathExample = useCallback(() => {
-    const mathWidgets = [
-      saveTemplateWidget({
-        widgetName: 'Mathematics 1 — Chart',
-        templateId: 'template-math-derivatives-chart',
-        description:
-          'Practice-progress chart for the derivatives study dashboard.',
-        tags: ['mathematics', 'derivatives', 'chart'],
-      }),
-      saveTemplateWidget({
-        widgetName: 'Mathematics 1 — Derivatives Example',
-        templateId: 'template-math-derivatives-example',
-        description:
-          'Worked derivative examples and a question input for the study dashboard.',
-        tags: ['mathematics', 'derivatives', 'example'],
-      }),
-      saveTemplateWidget({
-        widgetName: 'Mathematics 1 — Theory Derivatives',
-        templateId: 'template-math-derivatives-theory',
-        description:
-          'Core derivative theory and formulas for the study dashboard.',
-        tags: ['mathematics', 'derivatives', 'theory'],
-      }),
-    ].filter(Boolean)
+    ensureStarterDashboards()
+    const mathDashboard = getSavedDashboards().find(
+      (dashboard) => dashboard.name === 'Mathematics 1 — Derivatives',
+    )
 
-    addDashboard({
-      name: 'Mathematics 1 — Derivatives',
-      layout: createLayoutWithComponents(
-        mathWidgets.map((widget) => ({
-          name: widget!.name,
-          component: 'CustomWidget',
-          customProps: {
-            widgetId: widget!.id,
-            components: widget!.components,
-          },
-        })),
-      ),
-    })
-  }, [addDashboard, saveTemplateWidget])
+    if (mathDashboard) {
+      addDashboard({
+        name: mathDashboard.name,
+        layout: mathDashboard.layout,
+      })
+    }
+  }, [addDashboard])
 
   const openTutorialExample = useCallback(() => {
-    openTemplateDashboard({
-      widgetName: 'AquaMesh Tutorial',
-      templateId: 'template-knowledge-tutorial',
-      description:
-        'A simple dashboard that explains widgets, dashboards, and blocks with visual examples.',
-      tags: ['tutorial', 'knowledge wiki', 'dashboard', 'blocks'],
-    })
-  }, [openTemplateDashboard])
+    ensureStarterDashboards()
+    const tutorialDashboard = getSavedDashboards().find(
+      (dashboard) => dashboard.name === 'AquaMesh Tutorial',
+    )
+
+    if (tutorialDashboard) {
+      addDashboard({
+        name: tutorialDashboard.name,
+        layout: tutorialDashboard.layout,
+      })
+    }
+  }, [addDashboard])
 
   const openWidgetMenu = useCallback(() => {
     window.dispatchEvent(new CustomEvent(OPEN_WIDGET_MENU_EVENT))

--- a/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
+++ b/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
@@ -28,7 +28,7 @@ interface SavedDashboardRecord {
   updatedAt: string
 }
 
-const STARTER_DASHBOARDS_SEEDED_KEY = 'aquamesh-starter-dashboards-seeded-v2'
+const STARTER_DASHBOARDS_SEEDED_KEY = 'aquamesh-starter-dashboards-seeded-v4'
 
 const createLayoutWithComponent = (
   componentConfig: WorkspaceComponentConfig,
@@ -113,10 +113,20 @@ const saveTemplateWidget = ({
   tags: string[]
   refreshExisting?: boolean
 }) => {
-  let widget = WidgetStorage.getAllWidgets().find(
+  const savedWidgets = WidgetStorage.getAllWidgets()
+  let widget = savedWidgets.find(
     (savedWidget) => savedWidget.name === widgetName,
   )
   const template = cloneTemplate(templateId)
+
+  if (
+    widget &&
+    savedWidgets.filter((savedWidget) => savedWidget.id === widget!.id).length >
+      1
+  ) {
+    WidgetStorage.deleteWidget(widget.id)
+    widget = undefined
+  }
 
   if (template) {
     if (!widget) {

--- a/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
+++ b/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
@@ -40,6 +40,28 @@ const createLayoutWithComponent = (
   ],
 })
 
+const createLayoutWithComponents = (
+  componentConfigs: WorkspaceComponentConfig[],
+): DashboardLayout => ({
+  type: 'row',
+  weight: 100,
+  children: [
+    {
+      type: 'tabset',
+      weight: 100,
+      active: true,
+      children: componentConfigs.map((componentConfig) => ({
+        type: 'tab',
+        name: componentConfig.name,
+        component: componentConfig.component,
+        config: componentConfig.customProps
+          ? { customProps: componentConfig.customProps }
+          : undefined,
+      })),
+    },
+  ],
+})
+
 const hasDashboardContent = (layout?: DashboardLayout): boolean => {
   if (!layout) {
     return false
@@ -114,43 +136,153 @@ export const useWorkspaceActions = () => {
     })
   }, [ensureDashboardAndAddComponent])
 
-  const openOperationsExample = useCallback(() => {
-    const widgetName = 'Daily Operations Dashboard'
-    let operationsWidget = WidgetStorage.getAllWidgets().find(
-      (widget) => widget.name === widgetName,
-    )
+  const openTemplateDashboard = useCallback(
+    ({
+      widgetName,
+      templateId,
+      description,
+      tags,
+    }: {
+      widgetName: string
+      templateId: string
+      description: string
+      tags: string[]
+    }) => {
+      let widget = WidgetStorage.getAllWidgets().find(
+        (savedWidget) => savedWidget.name === widgetName,
+      )
 
-    if (!operationsWidget) {
-      const template = cloneTemplate('template-operations-dashboard')
+      if (!widget) {
+        const template = cloneTemplate(templateId)
 
-      if (template) {
-        operationsWidget = WidgetStorage.saveWidget({
-          name: widgetName,
-          description:
-            'Daily operations dashboard for orders, delayed tasks, support tickets, system status, team notes, and handoff actions.',
-          category: 'Dashboard',
-          tags: ['dashboard', 'daily operations', 'orders', 'tickets'],
-          components: template.components,
-          version: '1.0',
-          author: 'AquaMesh',
-        })
+        if (template) {
+          widget = WidgetStorage.saveWidget({
+            name: widgetName,
+            description,
+            category: 'Knowledge Workspace',
+            tags,
+            components: template.components,
+            version: '1.0',
+            author: 'AquaMesh',
+          })
+        }
       }
-    }
+
+      addDashboard({
+        name: widgetName,
+        layout: createLayoutWithComponent({
+          name: widgetName,
+          component: 'CustomWidget',
+          customProps: widget
+            ? {
+                widgetId: widget.id,
+                components: widget.components,
+              }
+            : undefined,
+        }),
+      })
+    },
+    [addDashboard],
+  )
+
+  const saveTemplateWidget = useCallback(
+    ({
+      widgetName,
+      templateId,
+      description,
+      category = 'Knowledge Workspace',
+      tags,
+    }: {
+      widgetName: string
+      templateId: string
+      description: string
+      category?: string
+      tags: string[]
+    }) => {
+      let widget = WidgetStorage.getAllWidgets().find(
+        (savedWidget) => savedWidget.name === widgetName,
+      )
+
+      if (!widget) {
+        const template = cloneTemplate(templateId)
+
+        if (template) {
+          widget = WidgetStorage.saveWidget({
+            name: widgetName,
+            description,
+            category,
+            tags,
+            components: template.components,
+            version: '1.0',
+            author: 'AquaMesh',
+          })
+        }
+      }
+
+      return widget
+    },
+    [],
+  )
+
+  const openOperationsExample = useCallback(() => {
+    openTemplateDashboard({
+      widgetName: 'Daily Operations Dashboard',
+      templateId: 'template-operations-dashboard',
+      description:
+        'Daily operations dashboard for orders, delayed tasks, support tickets, system status, team notes, and handoff actions.',
+      tags: ['dashboard', 'daily operations', 'orders', 'tickets'],
+    })
+  }, [openTemplateDashboard])
+
+  const openMathExample = useCallback(() => {
+    const mathWidgets = [
+      saveTemplateWidget({
+        widgetName: 'Mathematics 1 — Chart',
+        templateId: 'template-math-derivatives-chart',
+        description:
+          'Practice-progress chart for the derivatives study dashboard.',
+        tags: ['mathematics', 'derivatives', 'chart'],
+      }),
+      saveTemplateWidget({
+        widgetName: 'Mathematics 1 — Derivatives Example',
+        templateId: 'template-math-derivatives-example',
+        description:
+          'Worked derivative examples and a question input for the study dashboard.',
+        tags: ['mathematics', 'derivatives', 'example'],
+      }),
+      saveTemplateWidget({
+        widgetName: 'Mathematics 1 — Theory Derivatives',
+        templateId: 'template-math-derivatives-theory',
+        description:
+          'Core derivative theory and formulas for the study dashboard.',
+        tags: ['mathematics', 'derivatives', 'theory'],
+      }),
+    ].filter(Boolean)
 
     addDashboard({
-      name: widgetName,
-      layout: createLayoutWithComponent({
-        name: widgetName,
-        component: 'CustomWidget',
-        customProps: operationsWidget
-          ? {
-              widgetId: operationsWidget.id,
-              components: operationsWidget.components,
-            }
-          : undefined,
-      }),
+      name: 'Mathematics 1 — Derivatives',
+      layout: createLayoutWithComponents(
+        mathWidgets.map((widget) => ({
+          name: widget!.name,
+          component: 'CustomWidget',
+          customProps: {
+            widgetId: widget!.id,
+            components: widget!.components,
+          },
+        })),
+      ),
     })
-  }, [addDashboard])
+  }, [addDashboard, saveTemplateWidget])
+
+  const openTutorialExample = useCallback(() => {
+    openTemplateDashboard({
+      widgetName: 'AquaMesh Tutorial',
+      templateId: 'template-knowledge-tutorial',
+      description:
+        'A simple dashboard that explains widgets, dashboards, and blocks with visual examples.',
+      tags: ['tutorial', 'knowledge wiki', 'dashboard', 'blocks'],
+    })
+  }, [openTemplateDashboard])
 
   const openWidgetMenu = useCallback(() => {
     window.dispatchEvent(new CustomEvent(OPEN_WIDGET_MENU_EVENT))
@@ -160,6 +292,8 @@ export const useWorkspaceActions = () => {
     ensureDashboardAndAddComponent,
     openCreateWidget,
     openOperationsExample,
+    openMathExample,
+    openTutorialExample,
     openWidgetMenu,
   }
 }

--- a/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
+++ b/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
@@ -28,7 +28,7 @@ interface SavedDashboardRecord {
   updatedAt: string
 }
 
-const STARTER_DASHBOARDS_SEEDED_KEY = 'aquamesh-starter-dashboards-seeded-v1'
+const STARTER_DASHBOARDS_SEEDED_KEY = 'aquamesh-starter-dashboards-seeded-v2'
 
 const createLayoutWithComponent = (
   componentConfig: WorkspaceComponentConfig,
@@ -104,21 +104,22 @@ const saveTemplateWidget = ({
   description,
   category = 'Knowledge Workspace',
   tags,
+  refreshExisting = false,
 }: {
   widgetName: string
   templateId: string
   description: string
   category?: string
   tags: string[]
+  refreshExisting?: boolean
 }) => {
   let widget = WidgetStorage.getAllWidgets().find(
     (savedWidget) => savedWidget.name === widgetName,
   )
+  const template = cloneTemplate(templateId)
 
-  if (!widget) {
-    const template = cloneTemplate(templateId)
-
-    if (template) {
+  if (template) {
+    if (!widget) {
       widget = WidgetStorage.saveWidget({
         name: widgetName,
         description,
@@ -128,6 +129,15 @@ const saveTemplateWidget = ({
         version: '1.0',
         author: 'AquaMesh',
       })
+    } else if (refreshExisting) {
+      widget =
+        WidgetStorage.updateWidget(widget.id, {
+          description,
+          category,
+          tags,
+          components: template.components,
+          author: 'AquaMesh',
+        }) || widget
     }
   }
 
@@ -159,20 +169,26 @@ const saveStarterDashboard = (
   dashboard: Omit<SavedDashboardRecord, 'id' | 'createdAt' | 'updatedAt'>,
 ) => {
   const dashboards = getSavedDashboards()
+  const now = new Date().toISOString()
+  const existingIndex = dashboards.findIndex(
+    (savedDashboard) => savedDashboard.name === dashboard.name,
+  )
 
-  if (
-    dashboards.some((savedDashboard) => savedDashboard.name === dashboard.name)
-  ) {
-    return
+  if (existingIndex >= 0) {
+    dashboards[existingIndex] = {
+      ...dashboards[existingIndex],
+      ...dashboard,
+      updatedAt: now,
+    }
+  } else {
+    dashboards.push({
+      id: `dashboard-starter-${dashboard.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
+      ...dashboard,
+      createdAt: now,
+      updatedAt: now,
+    })
   }
 
-  const now = new Date().toISOString()
-  dashboards.push({
-    id: `dashboard-starter-${dashboard.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
-    ...dashboard,
-    createdAt: now,
-    updatedAt: now,
-  })
   window.localStorage.setItem('customDashboards', JSON.stringify(dashboards))
 }
 
@@ -192,6 +208,7 @@ export const ensureStarterDashboards = () => {
       description:
         'Practice-progress chart for the derivatives study dashboard.',
       tags: ['mathematics', 'derivatives', 'chart'],
+      refreshExisting: true,
     }),
     saveTemplateWidget({
       widgetName: 'Mathematics 1 — Derivatives Example',
@@ -199,6 +216,7 @@ export const ensureStarterDashboards = () => {
       description:
         'Worked derivative examples and a question input for the study dashboard.',
       tags: ['mathematics', 'derivatives', 'example'],
+      refreshExisting: true,
     }),
     saveTemplateWidget({
       widgetName: 'Mathematics 1 — Theory Derivatives',
@@ -206,6 +224,7 @@ export const ensureStarterDashboards = () => {
       description:
         'Core derivative theory and formulas for the study dashboard.',
       tags: ['mathematics', 'derivatives', 'theory'],
+      refreshExisting: true,
     }),
   ].filter(Boolean)
 
@@ -229,6 +248,7 @@ export const ensureStarterDashboards = () => {
     description:
       'A simple dashboard that explains widgets, dashboards, and blocks with visual examples.',
     tags: ['tutorial', 'knowledge wiki', 'dashboard', 'blocks'],
+    refreshExisting: true,
   })
 
   if (tutorialWidget) {

--- a/apps/aquamesh/src/theme/ThemeModeContext.tsx
+++ b/apps/aquamesh/src/theme/ThemeModeContext.tsx
@@ -20,16 +20,6 @@ const ThemeModeContext = createContext<ThemeModeContextValue | undefined>(
   undefined,
 )
 
-const getSystemThemeMode = (): ThemeMode => {
-  if (typeof window === 'undefined') {
-    return 'light'
-  }
-
-  return window.matchMedia('(prefers-color-scheme: dark)').matches
-    ? 'dark'
-    : 'light'
-}
-
 const getInitialThemeMode = (): ThemeMode => {
   if (typeof window === 'undefined') {
     return 'light'
@@ -41,7 +31,7 @@ const getInitialThemeMode = (): ThemeMode => {
     return savedMode
   }
 
-  return getSystemThemeMode()
+  return 'light'
 }
 
 export const ThemeModeProvider = ({
@@ -50,24 +40,6 @@ export const ThemeModeProvider = ({
   children: React.ReactNode
 }) => {
   const [mode, setModeState] = useState<ThemeMode>(getInitialThemeMode)
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-
-    const handleSystemPreferenceChange = (event: MediaQueryListEvent) => {
-      const savedMode = window.localStorage.getItem(THEME_STORAGE_KEY)
-
-      if (!savedMode) {
-        setModeState(event.matches ? 'dark' : 'light')
-      }
-    }
-
-    mediaQuery.addEventListener('change', handleSystemPreferenceChange)
-
-    return () => {
-      mediaQuery.removeEventListener('change', handleSystemPreferenceChange)
-    }
-  }, [])
 
   useEffect(() => {
     document.documentElement.dataset.theme = mode


### PR DESCRIPTION
## Summary
- Reposition landing copy around AquaMesh as a visual knowledge/wiki workspace
- Replace generic starter grouping with user-facing starter folders: Mathematics and Tutorial
- Add dashboard folder metadata: new dashboards can be saved to any folder name, defaulting to Default, and saved dashboards are grouped by folder in the dashboard menu
- Add a Tutorial starter dashboard explaining widgets, dashboards, and blocks with simple block examples
- Make the Mathematics starter a composed dashboard with three reusable widgets also saved into Add Widget: chart, derivatives example, and derivative theory
- Update tutorial/onboarding and empty-state copy to guide first-time users toward starter dashboards first

## Checks
- ✅ npx prettier --write targeted files
- ✅ git diff --check
- ✅ npm --prefix apps/aquamesh run build (via temporary local node_modules symlink from existing worktree; passes with existing Sass/asset warnings)
- ⚠️ npm --prefix apps/aquamesh run test:unit -- --reporter=dot blocked by missing Rollup optional dependency @rollup/rollup-linux-arm64-gnu in shared local node_modules

## Notes
This keeps the scope to product positioning, folder organization, onboarding, and default examples. It intentionally does not implement note-to-dashboard generation or deeper interactive widget architecture yet.