### PR TITLE
Clarify workspace workflows

### DIFF
--- a/apps/aquamesh/src/App.tsx
+++ b/apps/aquamesh/src/App.tsx
@@ -1,5 +1,14 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { Box, CssBaseline } from '@mui/material'
+import {
+  AppBar,
+  Box,
+  CssBaseline,
+  Dialog,
+  IconButton,
+  Toolbar,
+  Typography,
+} from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
 import { ThemeProvider } from '@mui/material/styles'
 import {
   BrowserRouter,
@@ -15,7 +24,11 @@ import Dashboards from './components/Dasboard/Dashboard'
 import DashboardProvider from './components/Dasboard/DashboardProvider'
 import LayoutProvider from './components/Layout/LayoutProvider'
 import AquaMeshLanding from './components/landing/AquaMeshLanding'
-import { useWorkspaceActions } from './customHooks/useWorkspaceActions'
+import WidgetEditor from './components/WidgetEditor/WidgetEditor'
+import {
+  OPEN_WIDGET_STUDIO_EVENT,
+  useWorkspaceActions,
+} from './customHooks/useWorkspaceActions'
 
 import { createAquaMeshTheme } from './theme'
 import { AccentColorProvider } from './theme/AccentColorContext'
@@ -58,6 +71,7 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
 const WorkspacePage = () => {
   const [menuOpen, setMenuOpen] = useState(false)
   const [searchParams, setSearchParams] = useSearchParams()
+  const [widgetStudioOpen, setWidgetStudioOpen] = useState(false)
   const {
     openCreateWidget,
     openOperationsExample,
@@ -66,6 +80,19 @@ const WorkspacePage = () => {
     openWidgetMenu,
   } = useWorkspaceActions()
   const handledActionRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const handleOpenWidgetStudio = () => setWidgetStudioOpen(true)
+
+    window.addEventListener(OPEN_WIDGET_STUDIO_EVENT, handleOpenWidgetStudio)
+
+    return () => {
+      window.removeEventListener(
+        OPEN_WIDGET_STUDIO_EVENT,
+        handleOpenWidgetStudio,
+      )
+    }
+  }, [])
 
   useEffect(() => {
     const action = searchParams.get('action')
@@ -105,6 +132,29 @@ const WorkspacePage = () => {
       <Main mt={8} sx={{ position: 'relative' }}>
         <Dashboards />
       </Main>
+      <Dialog
+        fullScreen
+        open={widgetStudioOpen}
+        onClose={() => setWidgetStudioOpen(false)}
+      >
+        <AppBar position="static" color="default" elevation={1}>
+          <Toolbar>
+            <Typography variant="h6" sx={{ flexGrow: 1, fontWeight: 700 }}>
+              Widget Studio
+            </Typography>
+            <IconButton
+              edge="end"
+              aria-label="Close Widget Studio"
+              onClick={() => setWidgetStudioOpen(false)}
+            >
+              <CloseIcon />
+            </IconButton>
+          </Toolbar>
+        </AppBar>
+        <Box sx={{ height: 'calc(100dvh - 64px)', overflow: 'auto' }}>
+          <WidgetEditor />
+        </Box>
+      </Dialog>
     </Box>
   )
 }

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -23,8 +23,9 @@ import TooltipStyled from '../TooltipStyled'
 import { ReactComponent as AddIcon } from '../../icons/add.svg'
 import { ReactComponent as CloseIcon } from '../../icons/close.svg'
 import SaveIcon from '@mui/icons-material/Save'
+import EditIcon from '@mui/icons-material/Edit'
 import DashboardCustomizeIcon from '@mui/icons-material/DashboardCustomize'
-import CreateIcon from '@mui/icons-material/Create'
+import WidgetsIcon from '@mui/icons-material/Widgets'
 import DashboardLayoutView from '../Layout/Layout'
 import { DashboardLayout } from '../../state/store'
 import { useDashboards } from './DashboardProvider'
@@ -60,6 +61,9 @@ const hasPlacedSavedWidget = (layout?: DashboardLayout): boolean => {
 
   return Boolean(layout.children?.some((child) => hasPlacedSavedWidget(child)))
 }
+
+const isDashboardEmpty = (layout?: DashboardLayout): boolean =>
+  !layout?.children || layout.children.length === 0
 
 // Dashboard Storage utilities
 const DashboardStorage = {
@@ -137,12 +141,14 @@ const DashboardStorage = {
 
 interface DashboardEmptyStateProps {
   isAdmin: boolean
-  onCreateWidget: () => void
+  onOpenWidgetMenu: () => void
+  hasDashboardOpen: boolean
 }
 
 const DashboardEmptyState = ({
   isAdmin,
-  onCreateWidget,
+  onOpenWidgetMenu,
+  hasDashboardOpen,
 }: DashboardEmptyStateProps) => (
   <Box
     sx={{
@@ -171,15 +177,17 @@ const DashboardEmptyState = ({
         sx={{ fontSize: 48, color: 'primary.main', mb: 1 }}
       />
       <Typography variant="h5" fontWeight="bold" gutterBottom>
-        Start a knowledge dashboard
+        {hasDashboardOpen
+          ? 'Build this dashboard'
+          : 'Open or create a dashboard'}
       </Typography>
       <Typography
         variant="body1"
         sx={{ color: 'foreground.contrastSecondary', mb: 3 }}
       >
-        Open a starter example from Dashboards, or create one reusable block for
-        your notes: formulas, study questions, charts, images, project tasks, or
-        research observations.
+        {hasDashboardOpen
+          ? 'This dashboard is empty. Open Widget → My Widgets, choose a saved widget, then position and resize it in the dashboard before saving.'
+          : 'Use Dashboard to create a new dashboard or open an existing one. Widget Studio is only for creating reusable widgets; dashboards are where you place them.'}
       </Typography>
       <Stack
         direction={{ xs: 'column', sm: 'row' }}
@@ -189,10 +197,11 @@ const DashboardEmptyState = ({
         {isAdmin && (
           <Button
             variant="contained"
-            startIcon={<CreateIcon />}
-            onClick={onCreateWidget}
+            startIcon={<WidgetsIcon />}
+            onClick={onOpenWidgetMenu}
+            disabled={!hasDashboardOpen}
           >
-            Create your own widget
+            Open Widget menu
           </Button>
         )}
       </Stack>
@@ -290,6 +299,7 @@ const Dashboards = () => {
     addDashboard,
     updateLayout,
     renameDashboard,
+    setDashboardEditing,
   } = useDashboards()
 
   const [saveDialogOpen, setSaveDialogOpen] = useState(false)
@@ -315,10 +325,10 @@ const Dashboards = () => {
       const savedStep = window.localStorage.getItem(DASHBOARD_ONBOARDING_KEY)
       return savedStep === 'save' || savedStep === 'done' ? savedStep : 'layout'
     })
-  const { openCreateWidget } = useWorkspaceActions()
-  const selectedDashboardIsEmpty =
-    !openDashboards[selectedDashboard]?.layout?.children ||
-    openDashboards[selectedDashboard]?.layout?.children?.length === 0
+  const { openWidgetMenu } = useWorkspaceActions()
+  const selectedDashboardIsEmpty = isDashboardEmpty(
+    openDashboards[selectedDashboard]?.layout,
+  )
 
   const completeDashboardOnboarding = () => {
     setDashboardOnboardingStep('done')
@@ -432,6 +442,7 @@ const Dashboards = () => {
             ...prev,
             [index]: false,
           }))
+          setDashboardEditing(currentDashboard.id, false)
         }
       } catch (error) {
         console.error('Error updating dashboard:', error)
@@ -505,6 +516,7 @@ const Dashboards = () => {
             ...prev,
             [currentTabIndex]: false,
           }))
+          setDashboardEditing(currentDashboard.id, false)
         }
 
         handleSaveDialogClose()
@@ -523,69 +535,93 @@ const Dashboards = () => {
         style={{ position: 'relative' }}
       >
         <TabList>
-          {openDashboards.map((dashboard, index) => (
-            <Tab key={dashboard.id}>
-              <Typography
-                variant="subtitle2"
-                sx={{
-                  flex: '1 0 0',
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  marginLeft: '0.5rem',
-                }}
-              >
-                {dashboard.name}
-              </Typography>
-              <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                {hasChanges[index] && (
-                  <TooltipStyled title="Save Dashboard">
-                    <IconButton
-                      aria-label={`Save dashboard ${dashboard.name}`}
-                      data-testid={`save-dashboard-${index}`}
-                      size="small"
-                      onClick={(ev) => {
-                        ev.stopPropagation()
-                        handleSaveDialogOpen(index)
-                      }}
-                      sx={{
-                        p: 0.5,
-                        mr: 0.5,
-                        color: 'primary.light',
-                        '&:hover': { color: 'primary.main' },
-                      }}
-                    >
-                      <SaveIcon sx={{ fontSize: 16 }} />
-                    </IconButton>
-                  </TooltipStyled>
-                )}
-                <Box
-                  className="close"
+          {openDashboards.map((dashboard, index) => {
+            const isEmptyDashboard = isDashboardEmpty(dashboard.layout)
+
+            return (
+              <Tab key={dashboard.id}>
+                <Typography
+                  variant="subtitle2"
                   sx={{
-                    display: 'flex',
-                    p: 0.5,
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    borderRadius: '999px',
-                    transition: 'all .25s ease',
-                    '&:hover': {
-                      backgroundColor: 'action.contrastHover',
-                    },
+                    flex: '1 0 0',
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    marginLeft: '0.5rem',
                   }}
                 >
-                  <CloseIcon
-                    width={16}
-                    height={16}
-                    onClick={(ev) => {
-                      // NOTE prevent the tab being closed from being selected too!
-                      ev.stopPropagation()
-                      removeDashboard(dashboard.id)
+                  {dashboard.name}
+                </Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                  {hasChanges[index] && (
+                    <TooltipStyled title="Save Dashboard">
+                      <IconButton
+                        aria-label={`Save dashboard ${dashboard.name}`}
+                        data-testid={`save-dashboard-${index}`}
+                        size="small"
+                        onClick={(ev) => {
+                          ev.stopPropagation()
+                          handleSaveDialogOpen(index)
+                        }}
+                        sx={{
+                          p: 0.5,
+                          mr: 0.5,
+                          color: 'primary.light',
+                          '&:hover': { color: 'primary.main' },
+                        }}
+                      >
+                        <SaveIcon sx={{ fontSize: 16 }} />
+                      </IconButton>
+                    </TooltipStyled>
+                  )}
+                  {dashboard.isEditing === false && !isEmptyDashboard && (
+                    <TooltipStyled title="Edit Dashboard">
+                      <IconButton
+                        aria-label={`Edit dashboard ${dashboard.name}`}
+                        size="small"
+                        onClick={(ev) => {
+                          ev.stopPropagation()
+                          setDashboardEditing(dashboard.id, true)
+                        }}
+                        sx={{
+                          p: 0.5,
+                          mr: 0.5,
+                          color: 'primary.light',
+                          '&:hover': { color: 'primary.main' },
+                        }}
+                      >
+                        <EditIcon sx={{ fontSize: 16 }} />
+                      </IconButton>
+                    </TooltipStyled>
+                  )}
+                  <Box
+                    className="close"
+                    sx={{
+                      display: 'flex',
+                      p: 0.5,
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                      borderRadius: '999px',
+                      transition: 'all .25s ease',
+                      '&:hover': {
+                        backgroundColor: 'action.contrastHover',
+                      },
                     }}
-                  />
+                  >
+                    <CloseIcon
+                      width={16}
+                      height={16}
+                      onClick={(ev) => {
+                        // NOTE prevent the tab being closed from being selected too!
+                        ev.stopPropagation()
+                        removeDashboard(dashboard.id)
+                      }}
+                    />
+                  </Box>
                 </Box>
-              </Box>
-            </Tab>
-          ))}
+              </Tab>
+            )
+          })}
           <Button
             size="small"
             variant="text"
@@ -621,9 +657,8 @@ const Dashboards = () => {
           />
         </TabList>
         {openDashboards.map((dashboard, index) => {
-          const isEmptyDashboard =
-            !dashboard.layout?.children ||
-            dashboard.layout.children.length === 0
+          const isEmptyDashboard = isDashboardEmpty(dashboard.layout)
+          const isEditing = dashboard.isEditing !== false
           const showDashboardOnboarding =
             index === selectedDashboard &&
             dashboardOnboardingStep !== 'done' &&
@@ -651,20 +686,60 @@ const Dashboards = () => {
                   {isEmptyDashboard ? (
                     <DashboardEmptyState
                       isAdmin={isAdmin}
-                      onCreateWidget={openCreateWidget}
+                      onOpenWidgetMenu={openWidgetMenu}
+                      hasDashboardOpen
                     />
                   ) : (
-                    <DashboardLayoutView
-                      layout={dashboard.layout}
-                      updateLayout={(model) => {
-                        updateLayout(model)
-                        // Mark this dashboard as having changes after layout update
-                        setHasChanges((prev) => ({
-                          ...prev,
-                          [selectedDashboard]: true,
-                        }))
-                      }}
-                    />
+                    <>
+                      {!isEditing && (
+                        <Paper
+                          elevation={0}
+                          sx={{
+                            mx: 2,
+                            mt: 1,
+                            px: 2,
+                            py: 1,
+                            border: 1,
+                            borderColor: 'divider',
+                            bgcolor: 'background.accentSurface',
+                            color: 'foreground.contrastPrimary',
+                          }}
+                        >
+                          <Stack
+                            direction="row"
+                            alignItems="center"
+                            justifyContent="space-between"
+                            spacing={2}
+                          >
+                            <Typography variant="body2">
+                              Viewer mode: dashboards open read-only. Use the
+                              pencil to add widgets or change the layout.
+                            </Typography>
+                            <Button
+                              size="small"
+                              startIcon={<EditIcon />}
+                              onClick={() =>
+                                setDashboardEditing(dashboard.id, true)
+                              }
+                            >
+                              Edit
+                            </Button>
+                          </Stack>
+                        </Paper>
+                      )}
+                      <DashboardLayoutView
+                        layout={dashboard.layout}
+                        readOnly={!isEditing}
+                        updateLayout={(model) => {
+                          updateLayout(model)
+                          // Mark this dashboard as having changes after layout update
+                          setHasChanges((prev) => ({
+                            ...prev,
+                            [selectedDashboard]: true,
+                          }))
+                        }}
+                      />
+                    </>
                   )}
                 </Box>
               </Box>
@@ -676,7 +751,8 @@ const Dashboards = () => {
       {openDashboards.length === 0 && (
         <DashboardEmptyState
           isAdmin={isAdmin}
-          onCreateWidget={openCreateWidget}
+          onOpenWidgetMenu={openWidgetMenu}
+          hasDashboardOpen={false}
         />
       )}
 

--- a/apps/aquamesh/src/components/Dasboard/DashboardOptionsMenu.tsx
+++ b/apps/aquamesh/src/components/Dasboard/DashboardOptionsMenu.tsx
@@ -153,6 +153,7 @@ const DashboardOptionsMenu: React.FC = () => {
   const createDashboardWithLayout = (dashboardName: string, layout: Layout) => {
     addDashboard({
       name: dashboardName,
+      isEditing: false,
       layout,
     })
     handleClose()
@@ -170,7 +171,15 @@ const DashboardOptionsMenu: React.FC = () => {
   }
 
   const handleCreateDashboard = () => {
-    addDashboard()
+    addDashboard({
+      name: 'Dashboard',
+      isEditing: true,
+      layout: {
+        type: 'row',
+        id: '#default-dashboard-layout',
+        children: [],
+      },
+    })
     handleClose()
   }
 

--- a/apps/aquamesh/src/components/Dasboard/DashboardProvider.tsx
+++ b/apps/aquamesh/src/components/Dasboard/DashboardProvider.tsx
@@ -22,6 +22,7 @@ interface DashboardContextType {
   updateLayout: (model: Model) => void
   updateDashboardLayout: (index: number, layout: DashboardLayout) => void
   renameDashboard: (id: string, newName: string) => void
+  setDashboardEditing: (id: string, isEditing: boolean) => void
 }
 
 const DashboardContext = React.createContext<DashboardContextType | null>(null)
@@ -90,6 +91,14 @@ const DashboardProvider: React.FC<DashboardProviderProps> = (props) => {
     setDashboards(newOpenDashboards)
   }
 
+  const setDashboardEditing = (id: string, isEditing: boolean) => {
+    const newOpenDashboards = openDashboards.map((dashboard) =>
+      dashboard.id === id ? { ...dashboard, isEditing } : dashboard,
+    )
+
+    setDashboards(newOpenDashboards)
+  }
+
   return (
     <DashboardContext.Provider
       {...props}
@@ -102,6 +111,7 @@ const DashboardProvider: React.FC<DashboardProviderProps> = (props) => {
         updateLayout,
         updateDashboardLayout,
         renameDashboard,
+        setDashboardEditing,
       }}
     />
   )

--- a/apps/aquamesh/src/components/Dasboard/fixture.ts
+++ b/apps/aquamesh/src/components/Dasboard/fixture.ts
@@ -1,12 +1,14 @@
 import { Layout } from '../../types/types'
 
 export interface DefaultDashboard {
-  name: string;
+  name: string
+  isEditing?: boolean
   layout?: Layout
 }
 
 export const DEFAULT_DASHBOARD: DefaultDashboard = {
   name: 'Dashboard',
+  isEditing: true,
   layout: {
     type: 'row',
     weight: 100,

--- a/apps/aquamesh/src/components/Layout/Layout.tsx
+++ b/apps/aquamesh/src/components/Layout/Layout.tsx
@@ -17,8 +17,9 @@ import 'flexlayout-react/style/light.css'
 import './layout.scss'
 
 interface DashboardLayoutViewProps {
-  layout?: DashboardLayout;
-  updateLayout: (model: Model) => void; 
+  layout?: DashboardLayout
+  updateLayout: (model: Model) => void
+  readOnly?: boolean
 }
 
 const CONFIG = {
@@ -47,7 +48,11 @@ const EmptyWidget = () => (
   </div>
 )
 
-const DashboardLayoutView: React.FC<DashboardLayoutViewProps>= ({ layout, updateLayout }) => {
+const DashboardLayoutView: React.FC<DashboardLayoutViewProps> = ({
+  layout,
+  updateLayout,
+  readOnly = false,
+}) => {
   const { ref } = useLayout()
 
   const factory = (node: TabNode) => {
@@ -75,9 +80,17 @@ const DashboardLayoutView: React.FC<DashboardLayoutViewProps>= ({ layout, update
 
   const model = useMemo(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const config: any = Object.assign({}, CONFIG, { layout: layout || {} })
+    const config: any = Object.assign({}, CONFIG, {
+      global: {
+        ...CONFIG.global,
+        tabSetEnableClose: !readOnly,
+        tabEnableDrag: !readOnly,
+        splitterEnableHandle: !readOnly,
+      },
+      layout: layout || {},
+    })
     return Model.fromJson(config)
-  }, [layout])
+  }, [layout, readOnly])
 
   return (
     <Layout
@@ -132,7 +145,11 @@ const DashboardLayoutView: React.FC<DashboardLayoutViewProps>= ({ layout, update
       onTabSetPlaceHolder={() => (
         <EmptyWidgetIcon width={60} height={60} opacity={0.16} />
       )}
-      onModelChange={updateLayout}
+      onModelChange={(updatedModel) => {
+        if (!readOnly) {
+          updateLayout(updatedModel)
+        }
+      }}
     />
   )
 }

--- a/apps/aquamesh/src/components/topnavbar/TopNavBar.tsx
+++ b/apps/aquamesh/src/components/topnavbar/TopNavBar.tsx
@@ -28,6 +28,7 @@ import AccentColorPicker from '../../theme/AccentColorPicker'
 import useTopNavBarWidgets from '../../customHooks/useTopNavBarWidgets'
 import { ReactComponent as Logo } from '../../../public/logo.svg'
 import DashboardOptionsMenu from '../Dasboard/DashboardOptionsMenu'
+import { useDashboards } from '../Dasboard/DashboardProvider'
 import WidgetManagementModal from '../WidgetEditor/components/dialogs/WidgetLibrary'
 import useWidgetManager from '../WidgetEditor/hooks/useWidgetManager'
 import {
@@ -115,6 +116,11 @@ const TopNavBar: React.FC<TopNavBarProps> = () => {
   const { topNavBarWidgets } = useTopNavBarWidgets()
   const { ensureDashboardAndAddComponent, openCreateWidget } =
     useWorkspaceActions()
+  const { openDashboards, selectedDashboard } = useDashboards()
+  const currentDashboard = openDashboards[selectedDashboard]
+  const canAddWidgets = Boolean(
+    currentDashboard && currentDashboard.isEditing !== false,
+  )
   const navigate = useNavigate()
 
   // Use theme and media query for responsive design
@@ -185,6 +191,22 @@ const TopNavBar: React.FC<TopNavBarProps> = () => {
   // Handle opening widgets library
   const handleOpenWidgetsLibrary = () => {
     openWidgetManagement()
+    handleClose()
+  }
+
+  const handleAddWidgetToDashboard = (item: {
+    name: string
+    component: string
+    customProps?: Record<string, unknown>
+  }) => {
+    if (!canAddWidgets) {
+      return
+    }
+
+    ensureDashboardAndAddComponent({
+      id: `panel-${Date.now()}`,
+      ...item,
+    })
     handleClose()
   }
 
@@ -306,6 +328,20 @@ const TopNavBar: React.FC<TopNavBarProps> = () => {
                     </ListItemIcon>
                     Saved Widgets
                   </MenuItem>
+                  {!canAddWidgets && (
+                    <MenuItem
+                      disabled
+                      sx={{
+                        p: 1.5,
+                        opacity: 1,
+                        whiteSpace: 'normal',
+                        color: 'text.secondary',
+                      }}
+                    >
+                      Open a dashboard in edit mode to add widgets from My
+                      Widgets.
+                    </MenuItem>
+                  )}
                   <Divider sx={{ my: 1, borderColor: 'divider' }} />
                 </>
               )}
@@ -323,12 +359,9 @@ const TopNavBar: React.FC<TopNavBarProps> = () => {
                           <MenuItem
                             key={item.name}
                             onClick={() => {
-                              ensureDashboardAndAddComponent({
-                                id: `panel-${Date.now()}`,
-                                ...item,
-                              })
-                              handleClose()
+                              handleAddWidgetToDashboard(item)
                             }}
+                            disabled={!canAddWidgets}
                             sx={{ p: 1.5 }}
                           >
                             {item.name}
@@ -394,12 +427,9 @@ const TopNavBar: React.FC<TopNavBarProps> = () => {
                               <MenuItem
                                 key={item.name}
                                 onClick={() => {
-                                  ensureDashboardAndAddComponent({
-                                    id: `panel-${Date.now()}`,
-                                    ...item,
-                                  })
-                                  handleClose()
+                                  handleAddWidgetToDashboard(item)
                                 }}
+                                disabled={!canAddWidgets}
                                 sx={{ p: 1.5 }}
                               >
                                 {item.name}
@@ -435,12 +465,9 @@ const TopNavBar: React.FC<TopNavBarProps> = () => {
                               <MenuItem
                                 key={item.name}
                                 onClick={() => {
-                                  ensureDashboardAndAddComponent({
-                                    id: `panel-${Date.now()}`,
-                                    ...item,
-                                  })
-                                  handleClose()
+                                  handleAddWidgetToDashboard(item)
                                 }}
+                                disabled={!canAddWidgets}
                                 sx={{
                                   p: 1.5,
                                   display: 'flex',

--- a/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
+++ b/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
@@ -8,6 +8,7 @@ import { cloneTemplate } from '../components/WidgetEditor/constants/templateWidg
 import { DashboardLayout } from '../state/store'
 
 export const OPEN_WIDGET_MENU_EVENT = 'aquamesh-open-widget-menu'
+export const OPEN_WIDGET_STUDIO_EVENT = 'aquamesh-open-widget-studio'
 
 export interface WorkspaceComponentConfig {
   id?: string
@@ -304,6 +305,7 @@ export const useWorkspaceActions = () => {
       if (openDashboards.length === 0) {
         addDashboard({
           name: 'Dashboard',
+          isEditing: true,
           layout: createLayoutWithComponent(componentConfig),
         })
         return
@@ -345,12 +347,8 @@ export const useWorkspaceActions = () => {
   )
 
   const openCreateWidget = useCallback(() => {
-    ensureDashboardAndAddComponent({
-      id: `widget-editor-${Date.now()}`,
-      name: 'Create Widget',
-      component: 'WidgetEditor',
-    })
-  }, [ensureDashboardAndAddComponent])
+    window.dispatchEvent(new CustomEvent(OPEN_WIDGET_STUDIO_EVENT))
+  }, [])
 
   const openTemplateDashboard = useCallback(
     ({
@@ -386,6 +384,7 @@ export const useWorkspaceActions = () => {
 
       addDashboard({
         name: widgetName,
+        isEditing: false,
         layout: createLayoutWithComponent({
           name: widgetName,
           component: 'CustomWidget',
@@ -420,6 +419,7 @@ export const useWorkspaceActions = () => {
     if (mathDashboard) {
       addDashboard({
         name: mathDashboard.name,
+        isEditing: false,
         layout: mathDashboard.layout,
       })
     }
@@ -434,6 +434,7 @@ export const useWorkspaceActions = () => {
     if (tutorialDashboard) {
       addDashboard({
         name: tutorialDashboard.name,
+        isEditing: false,
         layout: tutorialDashboard.layout,
       })
     }

--- a/apps/aquamesh/src/state/store.ts
+++ b/apps/aquamesh/src/state/store.ts
@@ -6,6 +6,7 @@ export interface StateDashboard {
   name: string
   layout?: DashboardLayout
   aquamesh?: string
+  isEditing?: boolean
 }
 
 export interface DashboardLayout {
@@ -24,6 +25,7 @@ export interface DashboardLayout {
 const DEFAULT_DASHBOARD: StateDashboard = {
   id: 'default-dashboard',
   name: 'Dashboard',
+  isEditing: true,
   layout: {
     type: 'row',
     id: '#default-dashboard-layout',


### PR DESCRIPTION
## Summary\n- move Create Widget into a fullscreen Widget Studio instead of placing the editor inside dashboards\n- make created dashboards start in editable builder mode while opened saved dashboards default to read-only viewer mode\n- add dashboard edit/pencil controls and disable adding widgets unless the current dashboard is editable\n- update empty dashboard guidance toward Add Widget → My Widgets instead of the widget editor\n\n## Verification\n- git diff --check\n- npm run build --workspace aquamesh\n\nBuild passes with existing warnings: missing .env.production, outdated Browserslist, Sass legacy/deprecation warnings, and asset size warnings.