### PR TITLE
Show knowledge blocks in widget palette

### DIFF
--- a/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/core/ComponentPalette.tsx
@@ -50,12 +50,14 @@ const groupByCategory = (components: ComponentType[]) => {
 // Define the component palette groups and expand state
 const PALETTE_GROUPS = [
   'UI Components',
+  'Knowledge Blocks',
   'Layout Containers',
   'Chart Components',
 ]
 const MOBILE_CONTENT_LAYOUT_GROUP = 'Content and layout'
 const PALETTE_GROUP_LABELS: Record<string, string> = {
   'UI Components': 'Content and Controls',
+  'Knowledge Blocks': 'Knowledge Blocks',
   'Layout Containers': 'Layout Helpers',
   'Chart Components': 'Charts',
   [MOBILE_CONTENT_LAYOUT_GROUP]: 'Content and layout',
@@ -307,7 +309,7 @@ const ComponentPalette = ({
         ).map((category) => {
           const groupCategories =
             isPhone && category === MOBILE_CONTENT_LAYOUT_GROUP
-              ? ['UI Components', 'Layout Containers']
+              ? ['UI Components', 'Knowledge Blocks', 'Layout Containers']
               : [category]
           const components = groupCategories.flatMap(
             (groupCategory) => groupedComponents[groupCategory] || [],


### PR DESCRIPTION
## Summary\n- expose the existing Knowledge Blocks category in Edit Building Blocks\n- make Long Text, List, Image, and PDF selectable in the widget builder\n- include Knowledge Blocks in the mobile content/layout palette grouping\n\n## Verification\n- git diff --check\n- npm run build --workspace aquamesh\n\nBuild passes with existing warnings: missing .env.production, outdated Browserslist, Sass legacy/deprecation warnings, and asset size warnings.