### PR TITLE
feat: add dashboard folder colors

### DIFF
--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -29,6 +29,12 @@ import DashboardLayoutView from '../Layout/Layout'
 import { DashboardLayout } from '../../state/store'
 import { useDashboards } from './DashboardProvider'
 import { useWorkspaceActions } from '../../customHooks/useWorkspaceActions'
+import {
+  DEFAULT_FOLDER_COLOR,
+  FOLDER_COLOR_PRESETS,
+  normalizeFolderColor,
+  normalizeFolderName,
+} from './folderColors'
 import './tabs.scss'
 
 // Define custom dashboard type for localStorage
@@ -36,6 +42,7 @@ interface SavedDashboard {
   id: string
   name: string
   folder?: string
+  folderColor?: string
   layout: DashboardLayout
   description?: string
   tags?: string[]
@@ -116,6 +123,17 @@ const DashboardStorage = {
     } catch (error) {
       console.error('Failed to delete dashboard', error)
     }
+  },
+
+  getFolderColor: (folder: string): string => {
+    const folderName = normalizeFolderName(folder)
+    const dashboard = DashboardStorage.getAll().find(
+      (savedDashboard) =>
+        normalizeFolderName(savedDashboard.folder) === folderName &&
+        savedDashboard.folderColor,
+    )
+
+    return normalizeFolderColor(dashboard?.folderColor)
   },
 
   // Check if the current layout is different from the saved one
@@ -295,6 +313,8 @@ const Dashboards = () => {
   const [saveDialogOpen, setSaveDialogOpen] = useState(false)
   const [dashboardName, setDashboardName] = useState('')
   const [dashboardFolder, setDashboardFolder] = useState('Default')
+  const [dashboardFolderColor, setDashboardFolderColor] =
+    useState(DEFAULT_FOLDER_COLOR)
   const [dashboardDescription, setDashboardDescription] = useState('')
   const [dashboardTags, setDashboardTags] = useState<string[]>([])
   const [isPublic, setIsPublic] = useState(false)
@@ -441,6 +461,7 @@ const Dashboards = () => {
       setCurrentTabIndex(index)
       setDashboardName(currentDashboard.name || '')
       setDashboardFolder('Default')
+      setDashboardFolderColor(DashboardStorage.getFolderColor('Default'))
       setDashboardDescription('')
       setDashboardTags(['dashboard'])
       setIsPublic(false)
@@ -453,6 +474,7 @@ const Dashboards = () => {
     setSaveDialogOpen(false)
     setDashboardName('')
     setDashboardFolder('Default')
+    setDashboardFolderColor(DEFAULT_FOLDER_COLOR)
     setDashboardDescription('')
     setDashboardTags([])
     setIsPublic(false)
@@ -487,6 +509,7 @@ const Dashboards = () => {
             id: `dashboard-${Date.now()}`,
             name: dashboardName.trim(),
             folder: dashboardFolder.trim() || 'Default',
+            folderColor: normalizeFolderColor(dashboardFolderColor),
             layout: currentDashboard.layout,
             description: dashboardDescription.trim() || undefined,
             tags: dashboardTags.length > 0 ? dashboardTags : ['dashboard'],
@@ -790,7 +813,13 @@ const Dashboards = () => {
             fullWidth
             variant="outlined"
             value={dashboardFolder}
-            onChange={(e) => setDashboardFolder(e.target.value)}
+            onChange={(e) => {
+              const nextFolder = e.target.value
+              setDashboardFolder(nextFolder)
+              setDashboardFolderColor(
+                DashboardStorage.getFolderColor(nextFolder),
+              )
+            }}
             helperText="Dashboards with the same folder name are grouped together."
             InputLabelProps={{
               shrink: true,
@@ -812,6 +841,49 @@ const Dashboards = () => {
               },
             }}
           />
+
+          <Box sx={{ mt: 2, mb: 1 }}>
+            <Typography variant="subtitle2" color="text.primary" gutterBottom>
+              Folder color
+            </Typography>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                flexWrap: 'wrap',
+              }}
+            >
+              {FOLDER_COLOR_PRESETS.map((color) => (
+                <IconButton
+                  key={color}
+                  size="small"
+                  aria-label={`Use folder color ${color}`}
+                  onClick={() => setDashboardFolderColor(color)}
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    border: '2px solid',
+                    borderColor:
+                      normalizeFolderColor(dashboardFolderColor) === color
+                        ? 'text.primary'
+                        : 'divider',
+                    bgcolor: color,
+                    '&:hover': { bgcolor: color, opacity: 0.85 },
+                  }}
+                />
+              ))}
+              <TextField
+                type="color"
+                label="Custom"
+                value={normalizeFolderColor(dashboardFolderColor)}
+                onChange={(e) => setDashboardFolderColor(e.target.value)}
+                size="small"
+                InputLabelProps={{ shrink: true }}
+                sx={{ width: 96 }}
+              />
+            </Box>
+          </Box>
 
           <TextField
             margin="normal"

--- a/apps/aquamesh/src/components/Dasboard/DashboardLibrary.tsx
+++ b/apps/aquamesh/src/components/Dasboard/DashboardLibrary.tsx
@@ -41,11 +41,18 @@ import { useDashboards } from './DashboardProvider'
 import { DefaultDashboard } from './fixture'
 import { ensureStarterDashboards } from '../../customHooks/useWorkspaceActions'
 import DeleteConfirmationDialog from '../WidgetEditor/components/dialogs/DeleteConfirmationDialog'
+import {
+  DEFAULT_FOLDER_COLOR,
+  FOLDER_COLOR_PRESETS,
+  normalizeFolderColor,
+  normalizeFolderName,
+} from './folderColors'
 
 interface SavedDashboard {
   id: string
   name: string
   folder?: string
+  folderColor?: string
   layout: Layout
   description?: string
   tags?: string[]
@@ -172,6 +179,7 @@ const SavedDashboardsDialog: React.FC<SavedDashboardsDialogProps> = ({
             id: string
             name: string
             folder?: string
+            folderColor?: string
             layout: Layout
             description?: string
             tags?: string[]
@@ -181,7 +189,8 @@ const SavedDashboardsDialog: React.FC<SavedDashboardsDialogProps> = ({
           }) => ({
             id: dashboard.id,
             name: dashboard.name,
-            folder: dashboard.folder?.trim() || 'Default',
+            folder: normalizeFolderName(dashboard.folder),
+            folderColor: normalizeFolderColor(dashboard.folderColor),
             layout: dashboard.layout,
             description: dashboard.description || 'No description',
             tags: dashboard.tags || ['dashboard'],
@@ -411,9 +420,24 @@ const SavedDashboardsDialog: React.FC<SavedDashboardsDialogProps> = ({
   // Function to save edited dashboard
   const handleSaveEditedDashboard = (editedDashboard: SavedDashboard) => {
     try {
-      const updatedDashboards = dashboards.map((dashboard) =>
-        dashboard.id === editedDashboard.id ? editedDashboard : dashboard,
+      const editedFolder = normalizeFolderName(editedDashboard.folder)
+      const editedFolderColor = normalizeFolderColor(
+        editedDashboard.folderColor,
       )
+      const updatedDashboards = dashboards.map((dashboard) => {
+        const nextDashboard =
+          dashboard.id === editedDashboard.id ? editedDashboard : dashboard
+
+        if (normalizeFolderName(nextDashboard.folder) === editedFolder) {
+          return {
+            ...nextDashboard,
+            folder: editedFolder,
+            folderColor: editedFolderColor,
+          }
+        }
+
+        return nextDashboard
+      })
       setDashboards(updatedDashboards)
       localStorage.setItem(
         'customDashboards',
@@ -800,8 +824,10 @@ const SavedDashboardsDialog: React.FC<SavedDashboardsDialogProps> = ({
                                     ml: 1,
                                     height: 20,
                                     fontSize: '0.7rem',
-                                    bgcolor: 'action.hover',
-                                    color: 'text.secondary',
+                                    bgcolor: `${normalizeFolderColor(dashboard.folderColor)}22`,
+                                    color: normalizeFolderColor(
+                                      dashboard.folderColor,
+                                    ),
                                   }}
                                 />
                                 {dashboard.isPublic && (
@@ -1074,6 +1100,7 @@ const EditDashboardDialog: React.FC<EditDashboardDialogProps> = ({
 }) => {
   const [name, setName] = useState('')
   const [folder, setFolder] = useState('Default')
+  const [folderColor, setFolderColor] = useState(DEFAULT_FOLDER_COLOR)
   const [description, setDescription] = useState('')
   const [tags, setTags] = useState<string[]>([])
   const [isPublic, setIsPublic] = useState(false)
@@ -1084,6 +1111,7 @@ const EditDashboardDialog: React.FC<EditDashboardDialogProps> = ({
     if (dashboard) {
       setName(dashboard.name)
       setFolder(dashboard.folder || 'Default')
+      setFolderColor(normalizeFolderColor(dashboard.folderColor))
       setDescription(dashboard.description || '')
       setTags(dashboard.tags || [])
       setIsPublic(dashboard.isPublic || false)
@@ -1096,7 +1124,8 @@ const EditDashboardDialog: React.FC<EditDashboardDialogProps> = ({
       const updatedDashboard: SavedDashboard = {
         ...dashboard,
         name: name.trim(),
-        folder: folder.trim() || 'Default',
+        folder: normalizeFolderName(folder),
+        folderColor: normalizeFolderColor(folderColor),
         description: description.trim() || 'No description',
         tags: tags.length > 0 ? tags : ['dashboard'],
         isPublic,
@@ -1224,6 +1253,52 @@ const EditDashboardDialog: React.FC<EditDashboardDialogProps> = ({
               },
             }}
           />
+
+          <Box sx={{ mt: 2, mb: 1 }}>
+            <Typography variant="subtitle2" color="text.primary" gutterBottom>
+              Folder color
+            </Typography>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                flexWrap: 'wrap',
+              }}
+            >
+              {FOLDER_COLOR_PRESETS.map((color) => (
+                <IconButton
+                  key={color}
+                  size="small"
+                  aria-label={`Use folder color ${color}`}
+                  onClick={() => setFolderColor(color)}
+                  sx={{
+                    width: 32,
+                    height: 32,
+                    border: '2px solid',
+                    borderColor:
+                      normalizeFolderColor(folderColor) === color
+                        ? 'text.primary'
+                        : 'divider',
+                    bgcolor: color,
+                    '&:hover': { bgcolor: color, opacity: 0.85 },
+                  }}
+                />
+              ))}
+              <TextField
+                type="color"
+                label="Custom"
+                value={normalizeFolderColor(folderColor)}
+                onChange={(e) => setFolderColor(e.target.value)}
+                size="small"
+                InputLabelProps={{ shrink: true }}
+                sx={{ width: 96 }}
+              />
+            </Box>
+            <Typography variant="caption" color="text.secondary">
+              The color is applied to every dashboard in this folder.
+            </Typography>
+          </Box>
 
           <TextField
             fullWidth

--- a/apps/aquamesh/src/components/Dasboard/DashboardOptionsMenu.tsx
+++ b/apps/aquamesh/src/components/Dasboard/DashboardOptionsMenu.tsx
@@ -17,12 +17,18 @@ import { useDashboards } from './DashboardProvider'
 import SavedDashboardsDialog from './DashboardLibrary'
 import { Layout } from '../../types/types'
 import { ensureStarterDashboards } from '../../customHooks/useWorkspaceActions'
+import {
+  DEFAULT_FOLDER_COLOR,
+  normalizeFolderColor,
+  normalizeFolderName,
+} from './folderColors'
 
 // Define saved dashboard type
 interface SavedDashboard {
   id: string
   name: string
   folder?: string
+  folderColor?: string
   layout: Layout
   description?: string
   tags?: string[]
@@ -127,17 +133,21 @@ const DashboardOptionsMenu: React.FC = () => {
   const dashboardsByFolder = visibleCustomDashboards.reduce<
     Record<string, SavedDashboard[]>
   >((folders, dashboard) => {
-    const rawFolderName = dashboard.folder?.trim() || 'Default'
-    const folderName =
-      rawFolderName.toLowerCase() === 'mathematics'
-        ? 'Mathematics'
-        : rawFolderName.toLowerCase() === 'tutorial'
-          ? 'Tutorial'
-          : rawFolderName
+    const folderName = normalizeFolderName(dashboard.folder)
     folders[folderName] = folders[folderName] || []
     folders[folderName].push(dashboard)
     return folders
   }, {})
+
+  const getFolderColor = (folderName: string, dashboards: SavedDashboard[]) =>
+    normalizeFolderColor(
+      dashboards.find((dashboard) => dashboard.folderColor)?.folderColor ||
+        (folderName === 'Mathematics'
+          ? '#1976D2'
+          : folderName === 'Tutorial'
+            ? DEFAULT_FOLDER_COLOR
+            : undefined),
+    )
 
   // Handle opening and closing dropdown
   const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -248,31 +258,42 @@ const DashboardOptionsMenu: React.FC = () => {
         {visibleCustomDashboards.length > 0 && (
           <>
             {Object.entries(dashboardsByFolder).map(
-              ([folderName, dashboards]) => (
-                <React.Fragment key={folderName}>
-                  <Typography
-                    sx={{
-                      px: 2,
-                      py: 1,
-                      fontWeight: 'bold',
-                      mt: 1,
-                      color: 'text.primary',
-                    }}
-                  >
-                    {folderName}
-                  </Typography>
-                  <Divider sx={{ borderColor: 'divider' }} />
-                  {[...dashboards].reverse().map((dashboard) => (
-                    <MenuItem
-                      key={dashboard.id}
-                      onClick={() => loadCustomDashboard(dashboard)}
-                      sx={{ p: 1.5 }}
+              ([folderName, dashboards]) => {
+                const folderColor = getFolderColor(folderName, dashboards)
+
+                return (
+                  <React.Fragment key={folderName}>
+                    <Typography
+                      sx={{
+                        px: 2,
+                        py: 1,
+                        fontWeight: 'bold',
+                        mt: 1,
+                        color: 'text.primary',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1,
+                      }}
                     >
-                      {dashboard.name}
-                    </MenuItem>
-                  ))}
-                </React.Fragment>
-              ),
+                      <FolderIcon
+                        fontSize="small"
+                        sx={{ color: folderColor }}
+                      />
+                      {folderName}
+                    </Typography>
+                    <Divider sx={{ borderColor: 'divider' }} />
+                    {[...dashboards].reverse().map((dashboard) => (
+                      <MenuItem
+                        key={dashboard.id}
+                        onClick={() => loadCustomDashboard(dashboard)}
+                        sx={{ p: 1.5 }}
+                      >
+                        {dashboard.name}
+                      </MenuItem>
+                    ))}
+                  </React.Fragment>
+                )
+              },
             )}
           </>
         )}

--- a/apps/aquamesh/src/components/Dasboard/folderColors.ts
+++ b/apps/aquamesh/src/components/Dasboard/folderColors.ts
@@ -1,0 +1,33 @@
+export const DEFAULT_FOLDER_COLOR = '#007C66'
+
+export const FOLDER_COLOR_PRESETS = [
+  '#007C66',
+  '#1976D2',
+  '#7B1FA2',
+  '#D81B60',
+  '#EF6C00',
+  '#2E7D32',
+  '#455A64',
+  '#5D4037',
+]
+
+export const normalizeFolderName = (folder?: string) => {
+  const rawFolderName = folder?.trim() || 'Default'
+
+  if (rawFolderName.toLowerCase() === 'mathematics') {
+    return 'Mathematics'
+  }
+
+  if (rawFolderName.toLowerCase() === 'tutorial') {
+    return 'Tutorial'
+  }
+
+  return rawFolderName
+}
+
+export const normalizeFolderColor = (color?: string) => {
+  const trimmedColor = color?.trim()
+  return trimmedColor && /^#[0-9a-f]{6}$/i.test(trimmedColor)
+    ? trimmedColor
+    : DEFAULT_FOLDER_COLOR
+}

--- a/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
+++ b/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
@@ -6,6 +6,7 @@ import { useLayout } from '../components/Layout/LayoutProvider'
 import WidgetStorage from '../components/WidgetEditor/WidgetStorage'
 import { cloneTemplate } from '../components/WidgetEditor/constants/templateWidgets'
 import { DashboardLayout } from '../state/store'
+import { normalizeFolderColor } from '../components/Dasboard/folderColors'
 
 export const OPEN_WIDGET_MENU_EVENT = 'aquamesh-open-widget-menu'
 
@@ -20,6 +21,7 @@ interface SavedDashboardRecord {
   id: string
   name: string
   folder?: string
+  folderColor?: string
   layout: DashboardLayout
   description?: string
   tags?: string[]
@@ -188,12 +190,14 @@ const saveStarterDashboard = (
     dashboards[existingIndex] = {
       ...dashboards[existingIndex],
       ...dashboard,
+      folderColor: normalizeFolderColor(dashboard.folderColor),
       updatedAt: now,
     }
   } else {
     dashboards.push({
       id: `dashboard-starter-${dashboard.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
       ...dashboard,
+      folderColor: normalizeFolderColor(dashboard.folderColor),
       createdAt: now,
       updatedAt: now,
     })
@@ -242,6 +246,7 @@ export const ensureStarterDashboards = () => {
     saveStarterDashboard({
       name: 'Mathematics 1 — Derivatives',
       folder: 'Mathematics',
+      folderColor: '#1976D2',
       layout: createMathStarterLayout(
         mathWidgets.map((widget) => createCustomWidgetConfig(widget!)),
       ),
@@ -265,6 +270,7 @@ export const ensureStarterDashboards = () => {
     saveStarterDashboard({
       name: 'AquaMesh Tutorial',
       folder: 'Tutorial',
+      folderColor: '#007C66',
       layout: createLayoutWithComponent(
         createCustomWidgetConfig(tutorialWidget),
       ),
@@ -288,6 +294,7 @@ export const ensureStarterDashboards = () => {
     saveStarterDashboard({
       name: 'AquaMesh Interactivity',
       folder: 'Tutorial',
+      folderColor: '#007C66',
       layout: createLayoutWithComponent(
         createCustomWidgetConfig(interactivityWidget),
       ),


### PR DESCRIPTION
## Summary
- add selectable folder colors when saving a new dashboard
- add folder color editing in the saved dashboards dialog, applying the color to every dashboard in that folder
- show colored folder icons in the dashboard menu and colored folder chips in the dashboard library
- seed starter dashboard folders with default Mathematics/Tutorial colors

## Verification
- git diff --check
- npm run build --workspace aquamesh