### PR TITLE
fix: keep an empty dashboard open

### DIFF
--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -108,6 +108,18 @@ const hasPlacedSavedWidget = (layout?: DashboardLayout): boolean => {
   return Boolean(layout.children?.some((child) => hasPlacedSavedWidget(child)))
 }
 
+const hasDashboardContent = (layout?: DashboardLayout): boolean => {
+  if (!layout) {
+    return false
+  }
+
+  if (layout.type === 'tab' && Boolean(layout.component)) {
+    return true
+  }
+
+  return Boolean(layout.children?.some((child) => hasDashboardContent(child)))
+}
+
 // Dashboard Storage utilities
 const DashboardStorage = {
   getAll: (): SavedDashboard[] => {
@@ -507,9 +519,9 @@ const Dashboards = () => {
     })
   const { addComponent } = useLayout()
   const { topNavBarWidgets } = useTopNavBarWidgets()
-  const selectedDashboardIsEmpty =
-    !openDashboards[selectedDashboard]?.layout?.children ||
-    openDashboards[selectedDashboard]?.layout?.children?.length === 0
+  const selectedDashboardIsEmpty = !hasDashboardContent(
+    openDashboards[selectedDashboard]?.layout,
+  )
   const dashboardEditorIndex = dashboardEditorId
     ? openDashboards.findIndex(
         (dashboard) => dashboard.id === dashboardEditorId,
@@ -519,9 +531,9 @@ const Dashboards = () => {
     draftDashboard ||
     (dashboardEditorIndex >= 0 ? openDashboards[dashboardEditorIndex] : null)
   const dashboardEditorIsDraft = Boolean(draftDashboard)
-  const dashboardEditorIsEmpty =
-    !dashboardEditorDashboard?.layout?.children ||
-    dashboardEditorDashboard.layout.children.length === 0
+  const dashboardEditorIsEmpty = !hasDashboardContent(
+    dashboardEditorDashboard?.layout,
+  )
   const customWidgetPanels = topNavBarWidgets.filter((widget) =>
     widget.name.includes('Custom'),
   )
@@ -735,9 +747,14 @@ const Dashboards = () => {
 
   const handleSaveDialogOpen = (index: number) => {
     if (dashboardEditorIsDraft && draftDashboard) {
+      if (!hasDashboardContent(draftDashboard.layout)) {
+        return
+      }
+
       setCurrentTabIndex(null)
       setDashboardName('')
       setDashboardFolder('Default')
+      setDashboardFolderColor(DashboardStorage.getFolderColor('Default'))
       setDashboardDescription('')
       setDashboardTags(['dashboard'])
       setIsPublic(false)
@@ -748,13 +765,17 @@ const Dashboards = () => {
 
     const currentDashboard = openDashboards[index]
 
+    if (!currentDashboard || !hasDashboardContent(currentDashboard.layout)) {
+      return
+    }
+
     // Check if it's an update of an existing dashboard
     const existingDashboard = DashboardStorage.getByName(currentDashboard.name)
 
     if (existingDashboard) {
       // Direct update without showing the dialog for existing dashboards
       try {
-        if (currentDashboard.layout) {
+        if (hasDashboardContent(currentDashboard.layout)) {
           const updatedDashboard: SavedDashboard = {
             ...existingDashboard,
             layout: currentDashboard.layout,
@@ -823,11 +844,16 @@ const Dashboards = () => {
 
   const handleSaveDashboard = () => {
     if (draftDashboard && dashboardName.trim() !== '') {
+      if (!hasDashboardContent(draftDashboard.layout)) {
+        return
+      }
+
       try {
         const newDashboard: SavedDashboard = {
           id: `dashboard-${Date.now()}`,
           name: dashboardName.trim(),
           folder: dashboardFolder.trim() || 'Default',
+          folderColor: normalizeFolderColor(dashboardFolderColor),
           layout: draftDashboard.layout,
           description: dashboardDescription.trim() || undefined,
           tags: dashboardTags.length > 0 ? dashboardTags : ['dashboard'],
@@ -853,8 +879,13 @@ const Dashboards = () => {
 
     if (currentTabIndex !== null && dashboardName.trim() !== '') {
       const currentDashboard = openDashboards[currentTabIndex]
+
+      if (!currentDashboard || !hasDashboardContent(currentDashboard.layout)) {
+        return
+      }
+
       try {
-        if (currentDashboard.layout) {
+        if (hasDashboardContent(currentDashboard.layout)) {
           const newDashboard: SavedDashboard = {
             id: `dashboard-${Date.now()}`,
             name: dashboardName.trim(),
@@ -925,7 +956,7 @@ const Dashboards = () => {
                 {dashboard.name}
               </Typography>
               <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                {hasChanges[index] && (
+                {hasChanges[index] && hasDashboardContent(dashboard.layout) && (
                   <TooltipStyled title="Save Dashboard">
                     <IconButton
                       aria-label={`Save dashboard ${dashboard.name}`}
@@ -1029,9 +1060,7 @@ const Dashboards = () => {
           />
         </TabList>
         {openDashboards.map((dashboard, index) => {
-          const isEmptyDashboard =
-            !dashboard.layout?.children ||
-            dashboard.layout.children.length === 0
+          const isEmptyDashboard = !hasDashboardContent(dashboard.layout)
           const showDashboardOnboarding =
             index === selectedDashboard &&
             dashboardOnboardingStep !== 'done' &&

--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -941,90 +941,99 @@ const Dashboards = () => {
         style={{ position: 'relative' }}
       >
         <TabList>
-          {openDashboards.map((dashboard, index) => (
-            <Tab key={dashboard.id}>
-              <Typography
-                variant="subtitle2"
-                sx={{
-                  flex: '1 0 0',
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  marginLeft: '0.5rem',
-                }}
-              >
-                {dashboard.name}
-              </Typography>
-              <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                {hasChanges[index] && hasDashboardContent(dashboard.layout) && (
-                  <TooltipStyled title="Save Dashboard">
-                    <IconButton
-                      aria-label={`Save dashboard ${dashboard.name}`}
-                      data-testid={`save-dashboard-${index}`}
-                      size="small"
-                      onClick={(ev) => {
-                        ev.stopPropagation()
-                        handleSaveDialogOpen(index)
-                      }}
-                      sx={{
-                        p: 0.5,
-                        mr: 0.5,
-                        color: 'primary.light',
-                        '&:hover': { color: 'primary.main' },
-                      }}
-                    >
-                      <SaveIcon sx={{ fontSize: 16 }} />
-                    </IconButton>
-                  </TooltipStyled>
-                )}
-                {dashboard.layout?.children &&
-                  dashboard.layout.children.length > 0 && (
-                    <TooltipStyled title="Edit Dashboard">
-                      <IconButton
-                        aria-label={`Edit dashboard ${dashboard.name}`}
-                        size="small"
-                        onClick={(ev) => {
-                          ev.stopPropagation()
-                          openDashboardEditor(dashboard.id)
-                        }}
-                        sx={{
-                          p: 0.5,
-                          mr: 0.5,
-                          color: 'text.secondary',
-                          '&:hover': { color: 'primary.main' },
-                        }}
-                      >
-                        <EditIcon sx={{ fontSize: 16 }} />
-                      </IconButton>
-                    </TooltipStyled>
-                  )}
-                <Box
-                  className="close"
+          {openDashboards.map((dashboard, index) => {
+            const isOnlyEmptyDashboard =
+              openDashboards.length === 1 &&
+              !hasDashboardContent(dashboard.layout)
+
+            return (
+              <Tab key={dashboard.id}>
+                <Typography
+                  variant="subtitle2"
                   sx={{
-                    display: 'flex',
-                    p: 0.5,
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    borderRadius: '999px',
-                    transition: 'all .25s ease',
-                    '&:hover': {
-                      backgroundColor: 'action.contrastHover',
-                    },
+                    flex: '1 0 0',
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    marginLeft: '0.5rem',
                   }}
                 >
-                  <CloseIcon
-                    width={16}
-                    height={16}
-                    onClick={(ev) => {
-                      // NOTE prevent the tab being closed from being selected too!
-                      ev.stopPropagation()
-                      removeDashboard(dashboard.id)
-                    }}
-                  />
+                  {dashboard.name}
+                </Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                  {hasChanges[index] &&
+                    hasDashboardContent(dashboard.layout) && (
+                      <TooltipStyled title="Save Dashboard">
+                        <IconButton
+                          aria-label={`Save dashboard ${dashboard.name}`}
+                          data-testid={`save-dashboard-${index}`}
+                          size="small"
+                          onClick={(ev) => {
+                            ev.stopPropagation()
+                            handleSaveDialogOpen(index)
+                          }}
+                          sx={{
+                            p: 0.5,
+                            mr: 0.5,
+                            color: 'primary.light',
+                            '&:hover': { color: 'primary.main' },
+                          }}
+                        >
+                          <SaveIcon sx={{ fontSize: 16 }} />
+                        </IconButton>
+                      </TooltipStyled>
+                    )}
+                  {dashboard.layout?.children &&
+                    dashboard.layout.children.length > 0 && (
+                      <TooltipStyled title="Edit Dashboard">
+                        <IconButton
+                          aria-label={`Edit dashboard ${dashboard.name}`}
+                          size="small"
+                          onClick={(ev) => {
+                            ev.stopPropagation()
+                            openDashboardEditor(dashboard.id)
+                          }}
+                          sx={{
+                            p: 0.5,
+                            mr: 0.5,
+                            color: 'text.secondary',
+                            '&:hover': { color: 'primary.main' },
+                          }}
+                        >
+                          <EditIcon sx={{ fontSize: 16 }} />
+                        </IconButton>
+                      </TooltipStyled>
+                    )}
+                  {!isOnlyEmptyDashboard && (
+                    <Box
+                      className="close"
+                      sx={{
+                        display: 'flex',
+                        p: 0.5,
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                        borderRadius: '999px',
+                        transition: 'all .25s ease',
+                        '&:hover': {
+                          backgroundColor: 'action.contrastHover',
+                        },
+                      }}
+                    >
+                      <CloseIcon
+                        width={16}
+                        height={16}
+                        onClick={(ev) => {
+                          // NOTE prevent the tab being closed from being selected too!
+                          ev.stopPropagation()
+                          removeDashboard(dashboard.id)
+                        }}
+                      />
+                    </Box>
+                  )}
                 </Box>
-              </Box>
-            </Tab>
-          ))}
+              </Tab>
+            )
+          })}
           <Button
             size="small"
             variant="text"

--- a/apps/aquamesh/src/components/Dasboard/DashboardProvider.tsx
+++ b/apps/aquamesh/src/components/Dasboard/DashboardProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useContext } from 'react'
 
 import { nanoid } from 'nanoid'
@@ -29,6 +29,11 @@ interface DashboardContextType {
 }
 
 const DashboardContext = React.createContext<DashboardContextType | null>(null)
+
+const createEmptyDashboard = (): StateDashboard => ({
+  id: nanoid(),
+  ...DEFAULT_DASHBOARD,
+})
 
 const DashboardProvider: React.FC<DashboardProviderProps> = (props) => {
   const selectedDashboard = useStore((state) => state.selectedDashboard)
@@ -67,8 +72,30 @@ const DashboardProvider: React.FC<DashboardProviderProps> = (props) => {
     return editingDashboardIds.includes(id)
   }
 
+  useEffect(() => {
+    if (openDashboards.length === 0) {
+      const emptyDashboard = createEmptyDashboard()
+      setDashboards([emptyDashboard])
+      setSelectedDashboard(0)
+      setEditingDashboardIds([emptyDashboard.id])
+      return
+    }
+
+    if (selectedDashboard < 0 || selectedDashboard >= openDashboards.length) {
+      setSelectedDashboard(0)
+    }
+  }, [openDashboards, selectedDashboard, setDashboards, setSelectedDashboard])
+
   const removeDashboard = (id: string) => {
     const dashboards = openDashboards.filter((dashboard) => dashboard.id !== id)
+
+    if (dashboards.length === 0) {
+      const emptyDashboard = createEmptyDashboard()
+      setDashboards([emptyDashboard])
+      setSelectedDashboard(0)
+      setEditingDashboardIds([emptyDashboard.id])
+      return
+    }
 
     setDashboards(dashboards)
     setEditingDashboardIds((currentIds) =>
@@ -76,7 +103,7 @@ const DashboardProvider: React.FC<DashboardProviderProps> = (props) => {
     )
 
     if (selectedDashboard >= dashboards.length) {
-      setSelectedDashboard(selectedDashboard - 1)
+      setSelectedDashboard(Math.max(0, dashboards.length - 1))
     }
   }
 

--- a/apps/aquamesh/src/state/store.ts
+++ b/apps/aquamesh/src/state/store.ts
@@ -21,15 +21,17 @@ export interface DashboardLayout {
   children?: DashboardLayout[]
 }
 
-const DEFAULT_DASHBOARD: StateDashboard = {
-  id: 'default-dashboard',
+const createDefaultDashboard = (): StateDashboard => ({
+  id: `default-dashboard-${Date.now()}`,
   name: 'Dashboard',
   layout: {
     type: 'row',
     id: '#default-dashboard-layout',
     children: [],
   },
-}
+})
+
+const DEFAULT_DASHBOARD: StateDashboard = createDefaultDashboard()
 
 interface StoreState {
   selectedDashboard: number
@@ -45,8 +47,24 @@ export const useStore = create<StoreState>()(
     (set, get) => ({
       selectedDashboard: 0,
       openDashboards: [DEFAULT_DASHBOARD],
-      setDashboards: (element) => set({ openDashboards: element }),
-      setSelectedDashboard: (index) => set({ selectedDashboard: index }),
+      setDashboards: (element) =>
+        set((state) => {
+          const openDashboards =
+            element.length > 0 ? element : [createDefaultDashboard()]
+          const selectedDashboard = Math.min(
+            Math.max(state.selectedDashboard, 0),
+            openDashboards.length - 1,
+          )
+
+          return { openDashboards, selectedDashboard }
+        }),
+      setSelectedDashboard: (index) =>
+        set((state) => ({
+          selectedDashboard: Math.min(
+            Math.max(index, 0),
+            Math.max(state.openDashboards.length - 1, 0),
+          ),
+        })),
       changeWidgetData: (data) => {
         const state = get()
         const updatedOpenDashboards = [...state.openDashboards]


### PR DESCRIPTION
## Summary
- enforce that the dashboard store/provider always keeps at least one dashboard tab open
- spawn a fresh empty dashboard when the last open dashboard is closed or persisted state is empty
- clamp selected dashboard indexes so the UI cannot point at a missing dashboard
- prevent empty dashboards/drafts from opening the save flow or being saved as saved dashboards
- hide the tab save action for empty dashboards

## Verification
- git diff --check
- npm run build --workspace aquamesh