### PR TITLE
AquaMesh:DEV Vercel direct PR smoke test

### DIFF
--- a/apps/aquamesh/package.json
+++ b/apps/aquamesh/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "webpack serve --mode development",
     "start:live": "webpack serve --mode development --live-reload --hot",
-    "build": "webpack --mode production --config webpack.config.prod.js",
+    "build": "webpack-cli --mode production --config webpack.config.prod.js",
     "serve": "serve -l 3000 -s dist",
     "bs": "npm run build && npm run serve",
     "test": "vitest --run --config ./vitest.config.ts ./tests/unit/ --reporter verbose && npx playwright test",

--- a/docs/vercel-direct-pr-smoke.md
+++ b/docs/vercel-direct-pr-smoke.md
@@ -1,0 +1,3 @@
+# Vercel direct PR smoke test
+
+This file is intentionally harmless. It exists only to verify that Pichikachu can push a branch directly to `CosmeValera/AquaMesh` and open a same-repository PR so Vercel preview authorization works without fork approval.


### PR DESCRIPTION
Smoke-test PR opened from a branch pushed directly to CosmeValera/AquaMesh, not from a fork. The content is intentionally irrelevant; this is only to verify Vercel preview/auth behavior.