### PR TITLE
Add Study Paths and AI Prompt mode

### DIFF
--- a/apps/aquamesh/package-lock.json
+++ b/apps/aquamesh/package-lock.json
@@ -17,10 +17,10 @@
         "@mui/material": "^5.14.1",
         "@vitejs/plugin-react": "^4.3.1",
         "axios": "^1.4.0",
+        "date-fns": "^4.1.0",
         "flexlayout-react": "^0.7.8",
         "happy-dom": "^15.3.1",
         "jsdom": "^25.0.0",
-        "keycloak-js": "^25.0.1",
         "nanoid": "^4.0.2",
         "prettier": "3.0.0",
         "primeflex": "^3.3.1",
@@ -33,6 +33,7 @@
         "react-use": "^17.4.0",
         "socket.io-client": "2.1.1",
         "tesseract.js": "^7.0.0",
+        "uuid": "^11.1.1",
         "web-vitals": "^2.1.4",
         "zustand": "^4.5.4"
       },
@@ -7375,6 +7376,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
@@ -10380,11 +10391,6 @@
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
-    "node_modules/js-sha256": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.0.tgz",
-      "integrity": "sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10527,23 +10533,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/jwt-decode": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
-      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/keycloak-js": {
-      "version": "25.0.2",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-25.0.2.tgz",
-      "integrity": "sha512-ACLf5O5PqzfDJwGqvLpqM0kflYWmyl3+T7M2C23gztJYccDxdfNP54+B9OkXz2GnDpLUId0ceoA+lbHw9t4Wng==",
-      "dependencies": {
-        "js-sha256": "^0.11.0",
-        "jwt-decode": "^4.0.0"
       }
     },
     "node_modules/keyv": {
@@ -13261,6 +13250,17 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -14593,12 +14593,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/apps/aquamesh/package.json
+++ b/apps/aquamesh/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "webpack serve --mode development",
     "start:live": "webpack serve --mode development --live-reload --hot",
-    "build": "webpack --mode production --config webpack.config.prod.js",
+    "build": "webpack-cli --mode production --config webpack.config.prod.js",
     "serve": "serve -l 3000 -s dist",
     "bs": "npm run build && npm run serve",
     "test": "vitest --run --config ./vitest.config.ts ./tests/unit/ --reporter verbose && npx playwright test",
@@ -67,6 +67,7 @@
     "@mui/material": "^5.14.1",
     "@vitejs/plugin-react": "^4.3.1",
     "axios": "^1.4.0",
+    "date-fns": "^4.1.0",
     "flexlayout-react": "^0.7.8",
     "happy-dom": "^15.3.1",
     "jsdom": "^25.0.0",
@@ -82,6 +83,7 @@
     "react-use": "^17.4.0",
     "socket.io-client": "2.1.1",
     "tesseract.js": "^7.0.0",
+    "uuid": "^11.1.1",
     "web-vitals": "^2.1.4",
     "zustand": "^4.5.4"
   }

--- a/apps/aquamesh/src/components/WidgetEditor/components/dialogs/SettingsDialog.tsx
+++ b/apps/aquamesh/src/components/WidgetEditor/components/dialogs/SettingsDialog.tsx
@@ -14,6 +14,7 @@ import {
   Chip,
   TextField,
   MenuItem,
+  Alert,
 } from '@mui/material'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'

--- a/apps/aquamesh/src/components/studyPack/CreateStudyPackModal.tsx
+++ b/apps/aquamesh/src/components/studyPack/CreateStudyPackModal.tsx
@@ -740,7 +740,10 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
         apiToken: credentials.apiToken,
         model: credentials.model,
         title: packTitle.trim() || 'Study Pack',
-        rawNotes: sourceText,
+        rawNotes:
+          studyTaskMode === 'aiPrompt'
+            ? `AI Tutor request: ${sourceText}`
+            : sourceText,
         packId: getPackId(packTitle),
         generationTargets,
         generationAmount,

--- a/apps/aquamesh/src/components/studyPack/CreateStudyPackModal.tsx
+++ b/apps/aquamesh/src/components/studyPack/CreateStudyPackModal.tsx
@@ -109,26 +109,9 @@ const studyTaskModeOptions: Array<{
     helper: 'Turn pasted notes, files, or images into study material.',
   },
   {
-    label: 'AI prompt',
+    label: 'AI Tutor',
     value: 'aiPrompt',
     helper: 'Ask AquaMesh to teach a topic and create the notes plus practice.',
-  },
-]
-
-const learningOutputOptions: Array<{
-  label: string
-  value: LearningOutputMode
-  helper: string
-}> = [
-  {
-    label: 'Single Study Pack',
-    value: 'studyPack',
-    helper: 'One dashboard with source notes, summaries, quizzes, and flashcards.',
-  },
-  {
-    label: 'Study Path',
-    value: 'studyPath',
-    helper: 'An ordered journey: intro, theory, examples, practice, final review.',
   },
 ]
 
@@ -1179,23 +1162,6 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                 sx={{ minWidth: { md: 190 } }}
               >
                 {studyTaskModeOptions.map((option) => (
-                  <MenuItem key={option.value} value={option.value}>
-                    {option.label}
-                  </MenuItem>
-                ))}
-              </TextField>
-              <TextField
-                select
-                label="Output"
-                value={learningOutputMode}
-                onChange={(event) =>
-                  setLearningOutputMode(
-                    event.target.value as LearningOutputMode,
-                  )
-                }
-                sx={{ minWidth: { md: 190 } }}
-              >
-                {learningOutputOptions.map((option) => (
                   <MenuItem key={option.value} value={option.value}>
                     {option.label}
                   </MenuItem>

--- a/apps/aquamesh/src/components/studyPack/CreateStudyPackModal.tsx
+++ b/apps/aquamesh/src/components/studyPack/CreateStudyPackModal.tsx
@@ -57,6 +57,8 @@ type ReviewType =
 type SourceInputType = 'text' | 'image'
 type StudyPackCreationMode = 'basic' | 'ai'
 type GenerationAmount = 'few' | 'medium' | 'many'
+type StudyTaskMode = 'importNotes' | 'aiPrompt'
+type LearningOutputMode = 'studyPack' | 'studyPath'
 
 interface ReviewItem {
   object: StudyObject
@@ -94,6 +96,40 @@ const creationModeOptions: Array<{
 }> = [
   { label: 'AI', value: 'ai' },
   { label: 'Basic fallback', value: 'basic' },
+]
+
+const studyTaskModeOptions: Array<{
+  label: string
+  value: StudyTaskMode
+  helper: string
+}> = [
+  {
+    label: 'Import notes',
+    value: 'importNotes',
+    helper: 'Turn pasted notes, files, or images into study material.',
+  },
+  {
+    label: 'AI prompt',
+    value: 'aiPrompt',
+    helper: 'Ask AquaMesh to teach a topic and create the notes plus practice.',
+  },
+]
+
+const learningOutputOptions: Array<{
+  label: string
+  value: LearningOutputMode
+  helper: string
+}> = [
+  {
+    label: 'Single Study Pack',
+    value: 'studyPack',
+    helper: 'One dashboard with source notes, summaries, quizzes, and flashcards.',
+  },
+  {
+    label: 'Study Path',
+    value: 'studyPath',
+    helper: 'An ordered journey: intro, theory, examples, practice, final review.',
+  },
 ]
 
 const generationTargetGroups = [
@@ -322,6 +358,70 @@ const createPreviewWidgetGroups = (
     objectIds: group.objects.map((object) => object.id),
   }))
 
+const studyPathStepNames = [
+  '1. Introduction',
+  '2. Theory',
+  '3. Examples',
+  '4. Practice',
+  '5. Final Review',
+]
+
+const getStudyPathStepIndex = (object: StudyObject, index: number): number => {
+  if (object.kind === 'quiz' || object.kind === 'qa' || object.kind === 'reveal') {
+    return 3
+  }
+
+  if (object.kind === 'reviewPrompt') {
+    return 4
+  }
+
+  if (object.kind === 'comparison' || object.kind === 'sequence' || object.kind === 'table') {
+    return 2
+  }
+
+  if (object.kind === 'term' || object.kind === 'note' || object.kind === 'markdown') {
+    return index < 2 ? 0 : 1
+  }
+
+  return Math.min(index % studyPathStepNames.length, studyPathStepNames.length - 1)
+}
+
+const createStudyPathPreviewGroups = (
+  objects: StudyObject[],
+): PreviewWidgetGroup[] => {
+  const groups = studyPathStepNames.map((name, index) => ({
+    id: `study-path-step-${index + 1}`,
+    name,
+    objectIds: [] as string[],
+  }))
+
+  objects.forEach((object, index) => {
+    groups[getStudyPathStepIndex(object, index)].objectIds.push(object.id)
+  })
+
+  return groups.filter((group) => group.objectIds.length > 0)
+}
+
+const createGeneratedSourceNotes = (
+  title: string,
+  prompt: string,
+  objects: StudyObject[],
+): string => {
+  const sourceSections = objects
+    .filter((object) =>
+      ['markdown', 'note', 'term', 'list', 'comparison', 'sequence', 'table', 'code'].includes(
+        object.kind,
+      ),
+    )
+    .slice(0, 10)
+    .map((object) => `## ${getObjectTitle(object)}\n\n${getObjectPreview(object)}`)
+    .join('\n\n')
+
+  return `# ${title}\n\nGenerated from AI prompt: ${prompt.trim()}\n\n${
+    sourceSections || 'AquaMesh generated practice-first study material from this learning prompt.'
+  }`
+}
+
 const applyReviewItem = (item: ReviewItem): StudyObject | null => {
   if (item.type === 'ignore') {
     return null
@@ -469,6 +569,10 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
 }) => {
   const [step, setStep] = useState<'source' | 'review'>('source')
   const [creationMode, setCreationMode] = useState<StudyPackCreationMode>('ai')
+  const [studyTaskMode, setStudyTaskMode] =
+    useState<StudyTaskMode>('importNotes')
+  const [learningOutputMode, setLearningOutputMode] =
+    useState<LearningOutputMode>('studyPack')
   const [sourceInputType, setSourceInputType] =
     useState<SourceInputType>('text')
   const [sourceText, setSourceText] = useState('')
@@ -529,6 +633,8 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
   const reset = () => {
     setStep('source')
     setCreationMode('ai')
+    setStudyTaskMode('importNotes')
+    setLearningOutputMode('studyPack')
     setSourceInputType('text')
     setSourceText('')
     setSourceFormat('text')
@@ -611,10 +717,12 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
     setSourceFormat(parsed.sourceFormat)
     setReviewItems(reviewableItems)
     setWidgetGroups(
-      createPreviewWidgetGroups(
-        reviewableItems.map((item) => item.object),
-        parsed.title,
-      ),
+      learningOutputMode === 'studyPath'
+        ? createStudyPathPreviewGroups(reviewableItems.map((item) => item.object))
+        : createPreviewWidgetGroups(
+            reviewableItems.map((item) => item.object),
+            parsed.title,
+          ),
     )
     setError(parsed.warnings[0] || augmented.warnings[0] || '')
     setStep('review')
@@ -653,6 +761,8 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
         packId: getPackId(packTitle),
         generationTargets,
         generationAmount,
+        promptMode: studyTaskMode === 'aiPrompt',
+        studyPathMode: learningOutputMode === 'studyPath',
       })
       const nextTitle = draft.title || packTitle
       setAiProgressLabel('Preparing review screen')
@@ -661,10 +771,14 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
       setSourceFormat(draft.sourceFormat || 'text')
       setReviewItems(reviewableItems)
       setWidgetGroups(
-        createPreviewWidgetGroups(
-          reviewableItems.map((item) => item.object),
-          nextTitle,
-        ),
+        learningOutputMode === 'studyPath'
+          ? createStudyPathPreviewGroups(
+              reviewableItems.map((item) => item.object),
+            )
+          : createPreviewWidgetGroups(
+              reviewableItems.map((item) => item.object),
+              nextTitle,
+            ),
       )
       setError(
         draft.warnings[0] ||
@@ -763,11 +877,15 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
     }
 
     if (!sourceText.trim()) {
-      setError('Add notes before continuing.')
+      setError(
+        studyTaskMode === 'aiPrompt'
+          ? 'Describe what you want to learn before continuing.'
+          : 'Add notes before continuing.',
+      )
       return
     }
 
-    if (creationMode === 'ai') {
+    if (creationMode === 'ai' || studyTaskMode === 'aiPrompt') {
       await parseSourceWithAi()
       return
     }
@@ -953,12 +1071,18 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
     const widgets = createStudyPackOrchestratorWidgets(pack, {
       includeSourceWidget,
       includeSummaryChart: includeSourceChart,
-      rawSource: sourceText,
+      rawSource:
+        studyTaskMode === 'aiPrompt'
+          ? createGeneratedSourceNotes(pack.title, sourceText, objects)
+          : sourceText,
       widgetGroups: groups,
     })
 
     onCreatePack({
-      name: packTitle.trim() || 'Study Pack',
+      name:
+        learningOutputMode === 'studyPath'
+          ? `${packTitle.trim() || 'Study Pack'} Study Path`
+          : packTitle.trim() || 'Study Pack',
       widgets,
       layoutMode:
         includeSourceWidget || layoutMode !== 'orchestrator'
@@ -1042,8 +1166,46 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
               </TextField>
               <TextField
                 select
+                label="Study task"
+                value={studyTaskMode}
+                onChange={(event) => {
+                  const value = event.target.value as StudyTaskMode
+                  setStudyTaskMode(value)
+                  if (value === 'aiPrompt') {
+                    setCreationMode('ai')
+                    setSourceInputType('text')
+                  }
+                }}
+                sx={{ minWidth: { md: 190 } }}
+              >
+                {studyTaskModeOptions.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </TextField>
+              <TextField
+                select
+                label="Output"
+                value={learningOutputMode}
+                onChange={(event) =>
+                  setLearningOutputMode(
+                    event.target.value as LearningOutputMode,
+                  )
+                }
+                sx={{ minWidth: { md: 190 } }}
+              >
+                {learningOutputOptions.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </TextField>
+              <TextField
+                select
                 label="Source type"
                 value={sourceInputType}
+                disabled={studyTaskMode === 'aiPrompt'}
                 onChange={(event) =>
                   handleSourceInputTypeChange(
                     event.target.value as SourceInputType,
@@ -1068,6 +1230,14 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
               }}
             >
               <Stack spacing={1.5}>
+                <Alert severity="info">
+                  {studyTaskMode === 'aiPrompt'
+                    ? 'AI Prompt mode lets you say what you want to learn. AquaMesh writes the source notes first, then builds exercises from that generated lesson.'
+                    : 'Import Notes mode keeps generation grounded in your pasted notes, uploaded text, or extracted image text.'}{' '}
+                  {learningOutputMode === 'studyPath'
+                    ? 'Study Path output organizes the pack as an ordered learning journey instead of one mixed dashboard.'
+                    : 'Single Study Pack output keeps everything in one compact workspace.'}
+                </Alert>
                 <Stack direction="row" spacing={1} alignItems="center">
                   <AutoAwesomeIcon
                     color={creationMode === 'ai' ? 'primary' : 'action'}
@@ -1077,9 +1247,11 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                     <Typography variant="subtitle2" fontWeight={800}>
                       {creationMode === 'ai' ? 'AI mode' : 'Basic mode'}
                     </Typography>
-                    <Typography variant="body2" color="text.secondary">
+                  <Typography variant="body2" color="text.secondary">
                       {creationMode === 'ai'
-                        ? 'Default path for Study Packs. AquaMesh can read notes and generate summaries, flashcards, quizzes, and practice prompts from grounded source material.'
+                        ? studyTaskMode === 'aiPrompt'
+                          ? 'Describe a learning goal like “Teach me French passé composé”; AquaMesh creates lesson notes, practice, flashcards, and review steps.'
+                          : 'Default path for Study Packs. AquaMesh can read notes and generate summaries, flashcards, quizzes, and practice prompts from grounded source material.'
                         : 'Offline fallback for Study Packs. AquaMesh uses local parsing and grounded practice generation from the notes you provide.'}
                     </Typography>
                   </Box>
@@ -1142,33 +1314,52 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
             {sourceInputType === 'text' ? (
               <>
                 <TextField
-                  label="Paste notes"
+                  label={
+                    studyTaskMode === 'aiPrompt'
+                      ? 'What do you want to learn?'
+                      : 'Paste notes'
+                  }
                   value={sourceText}
                   onChange={(event) => setSourceText(event.target.value)}
                   fullWidth
                   multiline
                   minRows={16}
-                  placeholder={`# Derivatives\n\nDefinition:: A derivative measures instantaneous rate of change.\n\nQ: What is the power rule?\nA: d/dx x^n = nx^(n-1)\n\n- [ ] I can explain what a derivative means`}
+                  placeholder={
+                    studyTaskMode === 'aiPrompt'
+                      ? 'Teach me French passé composé for a beginner. Put the explanation on the left and exercises on the right.'
+                      : `# Derivatives\n\nDefinition:: A derivative measures instantaneous rate of change.\n\nQ: What is the power rule?\nA: d/dx x^n = nx^(n-1)\n\n- [ ] I can explain what a derivative means`
+                  }
                 />
-                <Button
-                  component="label"
-                  variant="outlined"
-                  startIcon={<UploadFileIcon />}
-                  sx={{ alignSelf: 'flex-start' }}
-                >
-                  Upload notes
-                  <input
-                    hidden
-                    type="file"
-                    multiple
-                    accept=".md,.txt,.csv,.pdf,text/markdown,text/plain,text/csv,application/pdf"
-                    onChange={handleFileUpload}
-                  />
-                </Button>
-                <Typography variant="caption" color="text.secondary">
-                  Supports multiple .md, .txt, or .csv files. PDF parsing is a
-                  planned upgrade; paste exported PDF text for now.
-                </Typography>
+                {studyTaskMode === 'importNotes' && (
+                  <>
+                    <Button
+                      component="label"
+                      variant="outlined"
+                      startIcon={<UploadFileIcon />}
+                      sx={{ alignSelf: 'flex-start' }}
+                    >
+                      Upload notes
+                      <input
+                        hidden
+                        type="file"
+                        multiple
+                        accept=".md,.txt,.csv,.pdf,text/markdown,text/plain,text/csv,application/pdf"
+                        onChange={handleFileUpload}
+                      />
+                    </Button>
+                    <Typography variant="caption" color="text.secondary">
+                      Supports multiple .md, .txt, or .csv files. PDF parsing is a
+                      planned upgrade; paste exported PDF text for now.
+                    </Typography>
+                  </>
+                )}
+                {studyTaskMode === 'aiPrompt' && (
+                  <Typography variant="caption" color="text.secondary">
+                    AquaMesh will not create heavy PDF/image resources unless you
+                    explicitly ask for them. It will prefer text, quizzes,
+                    flashcards, tables, and review prompts.
+                  </Typography>
+                )}
               </>
             ) : (
               <>
@@ -1465,7 +1656,9 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                       gap={1}
                     >
                       <Typography variant="subtitle2">
-                        Generated study sections
+                        {learningOutputMode === 'studyPath'
+                          ? 'Study Path steps'
+                          : 'Generated study sections'}
                       </Typography>
                       <Button size="small" onClick={addWidgetGroup}>
                         Add section
@@ -1626,7 +1819,9 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
           </Button>
         ) : (
           <Button variant="contained" onClick={createPack}>
-            Create pack
+            {learningOutputMode === 'studyPath'
+              ? 'Create Study Path'
+              : 'Create pack'}
           </Button>
         )}
       </DialogActions>

--- a/apps/aquamesh/src/components/studyPack/CreateStudyPathModal.tsx
+++ b/apps/aquamesh/src/components/studyPack/CreateStudyPathModal.tsx
@@ -1,0 +1,347 @@
+import React, { useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  LinearProgress,
+  MenuItem,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material'
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome'
+import RouteIcon from '@mui/icons-material/Route'
+import {
+  createStudyPackOrchestratorWidgets,
+  StudyObject,
+  StudyPackDashboardLayoutMode,
+} from '../../studyPack'
+import {
+  AiStudyPathDraft,
+  generateStudyPathWithAi,
+  resolveStudyPackAiCredentials,
+} from '../../studyPack/ai'
+
+type GenerationAmount = 'few' | 'medium' | 'many'
+
+interface CreateStudyPathModalProps {
+  open: boolean
+  onClose: () => void
+  onCreatePath: (payload: {
+    folderName: string
+    dashboards: Array<{
+      name: string
+      widgets: ReturnType<typeof createStudyPackOrchestratorWidgets>
+      layoutMode?: StudyPackDashboardLayoutMode
+      folderName: string
+    }>
+  }) => void
+}
+
+const generationAmountOptions: Array<{
+  label: string
+  value: GenerationAmount
+  helper: string
+}> = [
+  { label: 'Compact', value: 'few', helper: 'Short path, fewer exercises' },
+  { label: 'Balanced', value: 'medium', helper: 'Best default' },
+  { label: 'Deep', value: 'many', helper: 'More practice per lesson' },
+]
+
+const getObjectPreview = (object?: StudyObject) => {
+  if (!object) {
+    return 'Generated study widgets for this lesson.'
+  }
+
+  switch (object.kind) {
+    case 'markdown':
+      return object.markdown
+    case 'note':
+      return object.body
+    case 'term':
+      return `${object.term}: ${object.definition}`
+    case 'qa':
+      return object.question
+    case 'quiz':
+      return object.question
+    case 'list':
+      return object.items.slice(0, 2).join(' · ')
+    case 'sequence':
+      return object.steps.slice(0, 2).join(' → ')
+    case 'reviewPrompt':
+      return object.prompt
+    case 'code':
+      return object.caption || object.code
+    case 'table':
+      return object.headers.join(' · ')
+    case 'comparison':
+      return object.columns.join(' vs ')
+    case 'resource':
+      return object.label
+    case 'reveal':
+      return object.prompt
+    default:
+      return 'Generated study widgets for this lesson.'
+  }
+}
+
+const truncate = (value: string, max = 150) => {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  return normalized.length > max
+    ? `${normalized.slice(0, Math.max(0, max - 1))}…`
+    : normalized
+}
+
+const makePackId = (title: string, index: number) =>
+  `${title}-${index + 1}`.toLowerCase().replace(/[^a-z0-9]+/g, '-') ||
+  `study-path-${index + 1}`
+
+const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
+  open,
+  onClose,
+  onCreatePath,
+}) => {
+  const [step, setStep] = useState<'prompt' | 'review'>('prompt')
+  const [pathTitle, setPathTitle] = useState('Study Path')
+  const [folderName, setFolderName] = useState('Study Path')
+  const [prompt, setPrompt] = useState('')
+  const [generationAmount, setGenerationAmount] =
+    useState<GenerationAmount>('medium')
+  const [draft, setDraft] = useState<AiStudyPathDraft | null>(null)
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [error, setError] = useState('')
+
+  const reset = () => {
+    setStep('prompt')
+    setPathTitle('Study Path')
+    setFolderName('Study Path')
+    setPrompt('')
+    setGenerationAmount('medium')
+    setDraft(null)
+    setIsGenerating(false)
+    setError('')
+  }
+
+  const handleClose = () => {
+    reset()
+    onClose()
+  }
+
+  const generatePath = async () => {
+    if (!prompt.trim()) {
+      setError('Describe what you want AquaMesh to teach.')
+      return
+    }
+
+    const credentials = resolveStudyPackAiCredentials()
+    if (!credentials.apiToken) {
+      setError(
+        'Study Path needs AI. Add your Gemini API key in Settings first.',
+      )
+      return
+    }
+
+    setIsGenerating(true)
+    setError('')
+
+    try {
+      const nextDraft = await generateStudyPathWithAi({
+        apiToken: credentials.apiToken,
+        model: credentials.model,
+        title: pathTitle.trim() || 'Study Path',
+        folderName: folderName.trim() || pathTitle.trim() || 'Study Path',
+        prompt,
+        generationAmount,
+      })
+      setDraft(nextDraft)
+      setPathTitle(nextDraft.title)
+      setFolderName(nextDraft.folderName)
+      setStep('review')
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Could not generate this Study Path.',
+      )
+    } finally {
+      setIsGenerating(false)
+    }
+  }
+
+  const createPath = () => {
+    if (!draft) {
+      return
+    }
+
+    const effectiveFolder = folderName.trim() || draft.folderName || draft.title
+    onCreatePath({
+      folderName: effectiveFolder,
+      dashboards: draft.dashboards.map((dashboard, index) => ({
+        name: dashboard.title || `${draft.title} ${index + 1}`,
+        folderName: effectiveFolder,
+        layoutMode: 'orchestrator',
+        widgets: createStudyPackOrchestratorWidgets(
+          {
+            id: makePackId(dashboard.title || draft.title, index),
+            title: dashboard.title || `${draft.title} ${index + 1}`,
+            sourceFormat: dashboard.sourceFormat || 'text',
+            rawSource: dashboard.rawNotes || prompt,
+            objects: dashboard.objects,
+            warnings: dashboard.warnings || [],
+          },
+          {
+            rawSource: dashboard.rawNotes || prompt,
+            includeSourceWidget: true,
+            includeSummaryChart: true,
+            widgetIdPrefix: makePackId(dashboard.title || draft.title, index),
+          },
+        ),
+      })),
+    })
+    handleClose()
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
+      <DialogTitle>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <RouteIcon color="primary" />
+          <Box>
+            <Typography variant="h6">Create Study Path</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Generate several ordered Study Pack dashboards in one folder.
+            </Typography>
+          </Box>
+        </Stack>
+      </DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2.5} sx={{ pt: 1 }}>
+          {error && <Alert severity="error">{error}</Alert>}
+          {step === 'prompt' ? (
+            <>
+              <TextField
+                label="Path title"
+                value={pathTitle}
+                onChange={(event) => {
+                  setPathTitle(event.target.value)
+                  if (!folderName.trim() || folderName === pathTitle) {
+                    setFolderName(event.target.value)
+                  }
+                }}
+                fullWidth
+              />
+              <TextField
+                label="Folder name"
+                value={folderName}
+                onChange={(event) => setFolderName(event.target.value)}
+                helperText="All generated Study Packs will be saved into this dashboard folder. You can edit it before creating them."
+                fullWidth
+              />
+              <TextField
+                label="What should AquaMesh teach?"
+                value={prompt}
+                onChange={(event) => setPrompt(event.target.value)}
+                placeholder="Example: Teach me French passé composé from scratch, with examples and practice."
+                multiline
+                minRows={5}
+                fullWidth
+              />
+              <TextField
+                select
+                label="Path depth"
+                value={generationAmount}
+                onChange={(event) =>
+                  setGenerationAmount(event.target.value as GenerationAmount)
+                }
+                sx={{ maxWidth: 320 }}
+              >
+                {generationAmountOptions.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label} - {option.helper}
+                  </MenuItem>
+                ))}
+              </TextField>
+              <Alert severity="info">
+                Study Path asks Gemini for an array of dashboards, not one large
+                Study Pack. The next screen previews each dashboard before
+                saving anything.
+              </Alert>
+              {isGenerating && (
+                <Paper elevation={0} sx={{ p: 2, border: 1, borderColor: 'primary.main' }}>
+                  <Stack spacing={1}>
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <AutoAwesomeIcon color="primary" fontSize="small" />
+                      <Typography variant="subtitle2" fontWeight={800}>
+                        Generating ordered dashboards…
+                      </Typography>
+                    </Stack>
+                    <LinearProgress />
+                  </Stack>
+                </Paper>
+              )}
+            </>
+          ) : (
+            <>
+              <TextField
+                label="Folder name"
+                value={folderName}
+                onChange={(event) => setFolderName(event.target.value)}
+                helperText="Edit where the generated Study Packs will be saved."
+                fullWidth
+              />
+              <Stack spacing={1.5}>
+                {draft?.dashboards.map((dashboard, index) => (
+                  <Paper
+                    key={`${dashboard.title}-${index}`}
+                    elevation={0}
+                    sx={{ p: 2, border: 1, borderColor: 'divider' }}
+                  >
+                    <Stack spacing={1}>
+                      <Stack direction="row" gap={1} flexWrap="wrap" alignItems="center">
+                        <Chip label={`Dashboard ${index + 1}`} color="primary" size="small" />
+                        <Chip label={`${dashboard.objects.length} study items`} size="small" />
+                      </Stack>
+                      <Typography variant="subtitle1" fontWeight={800}>
+                        {dashboard.title}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {dashboard.summary}
+                      </Typography>
+                      <Typography variant="body2">
+                        {truncate(getObjectPreview(dashboard.objects[0]))}
+                      </Typography>
+                    </Stack>
+                  </Paper>
+                ))}
+              </Stack>
+              {draft?.warnings.length ? (
+                <Alert severity="warning">{draft.warnings.join(' ')}</Alert>
+              ) : null}
+            </>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        {step === 'review' && <Button onClick={() => setStep('prompt')}>Back</Button>}
+        {step === 'prompt' ? (
+          <Button variant="contained" onClick={generatePath} disabled={isGenerating}>
+            {isGenerating ? 'Generating...' : 'Generate Study Path'}
+          </Button>
+        ) : (
+          <Button variant="contained" onClick={createPath}>
+            Create {draft?.dashboards.length || 0} dashboards
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default CreateStudyPathModal

--- a/apps/aquamesh/src/components/topnavbar/TopNavBar.tsx
+++ b/apps/aquamesh/src/components/topnavbar/TopNavBar.tsx
@@ -28,6 +28,7 @@ import Brightness6Icon from '@mui/icons-material/Brightness6'
 import CloseIcon from '@mui/icons-material/Close'
 import SettingsIcon from '@mui/icons-material/Settings'
 import SwitchAccountIcon from '@mui/icons-material/SwitchAccount'
+import RouteIcon from '@mui/icons-material/Route'
 
 import AccentColorPicker from '../../theme/AccentColorPicker'
 import { ReactComponent as Logo } from '../../../public/logo.svg'
@@ -44,6 +45,7 @@ import { CustomWidget } from '../WidgetEditor/WidgetStorage'
 import SettingsDialog from '../WidgetEditor/components/dialogs/SettingsDialog'
 import { dispatchWorkspaceOnboardingEvent } from '../onboarding/onboardingEvents'
 import CreateStudyPackModal from '../studyPack/CreateStudyPackModal'
+import CreateStudyPathModal from '../studyPack/CreateStudyPathModal'
 
 // Define user data type
 interface UserData {
@@ -149,6 +151,7 @@ const TopNavBar: React.FC<TopNavBarProps> = () => {
   const [isHelpOpen, setIsHelpOpen] = useState(false)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
   const [studyPackOpen, setStudyPackOpen] = useState(false)
+  const [studyPathOpen, setStudyPathOpen] = useState(false)
   const [widgetEditorOpen, setWidgetEditorOpen] = useState(false)
   const [widgetEditorPayload, setWidgetEditorPayload] = useState<{
     loadWidget?: CustomWidget
@@ -183,6 +186,7 @@ const TopNavBar: React.FC<TopNavBarProps> = () => {
     openCreateDashboard,
     openCreateStudyPack,
     createStudyPackDashboard,
+    createStudyPackDashboards,
   } = useWorkspaceActions()
   const navigate = useNavigate()
 
@@ -390,6 +394,38 @@ const TopNavBar: React.FC<TopNavBarProps> = () => {
                 data-tutorial-id="create-study-pack-button"
               >
                 Create Study Pack
+              </Button>
+            )}
+
+            {isPhone || isTablet ? (
+              <ButtonWithLabel
+                icon={<RouteIcon />}
+                label="Study Path"
+                onClick={() => setStudyPathOpen(true)}
+                disabled={!isAdmin}
+                title={
+                  isAdmin
+                    ? 'Create Study Path'
+                    : 'Viewer mode cannot create study paths'
+                }
+                sx={!isAdmin ? { opacity: 0.45, pointerEvents: 'none' } : {}}
+              />
+            ) : (
+              <Button
+                onClick={() => setStudyPathOpen(true)}
+                disabled={!isAdmin}
+                sx={{
+                  color: 'foreground.contrastPrimary',
+                  display: 'flex',
+                  alignItems: 'center',
+                  minWidth: 'auto',
+                  mx: 1,
+                  px: 2,
+                  opacity: isAdmin ? 1 : 0.45,
+                }}
+                startIcon={<RouteIcon />}
+              >
+                Study Path
               </Button>
             )}
 
@@ -704,6 +740,11 @@ const TopNavBar: React.FC<TopNavBarProps> = () => {
         open={studyPackOpen}
         onClose={() => setStudyPackOpen(false)}
         onCreatePack={createStudyPackDashboard}
+      />
+      <CreateStudyPathModal
+        open={studyPathOpen}
+        onClose={() => setStudyPathOpen(false)}
+        onCreatePath={createStudyPackDashboards}
       />
       <Dialog
         fullScreen

--- a/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
+++ b/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
@@ -218,13 +218,14 @@ const getUniqueSavedDashboardName = (
 const saveStudyPackDashboard = (
   name: string,
   layout: DashboardLayout,
+  folderName = 'Study Packs',
 ): SavedDashboardRecord => {
   const dashboards = getSavedDashboards()
   const now = new Date().toISOString()
   const dashboard: SavedDashboardRecord = {
     id: `study-pack-dashboard-${Date.now()}-${Math.floor(Math.random() * 1000000)}`,
     name: getUniqueSavedDashboardName(name, dashboards),
-    folder: 'Study Packs',
+    folder: folderName.trim() || 'Study Packs',
     folderColor: '#007C66',
     layout,
     description: 'Generated from student notes.',
@@ -573,6 +574,7 @@ export const useWorkspaceActions = () => {
       name,
       widgets,
       layoutMode = 'smart',
+      folderName = 'Study Packs',
     }: {
       name: string
       widgets: Array<{
@@ -585,6 +587,7 @@ export const useWorkspaceActions = () => {
         author?: string
       }>
       layoutMode?: StudyPackDashboardLayoutMode
+      folderName?: string
     }) => {
       const savedWidgets = widgets.map((widget) =>
         WidgetStorage.saveWidget({
@@ -600,7 +603,7 @@ export const useWorkspaceActions = () => {
       const layout = createStudyPackDashboardLayout(savedWidgets, {
         mode: layoutMode,
       })
-      const dashboard = saveStudyPackDashboard(name, layout)
+      const dashboard = saveStudyPackDashboard(name, layout, folderName)
 
       addDashboard({
         name: dashboard.name,
@@ -610,6 +613,36 @@ export const useWorkspaceActions = () => {
       return dashboard
     },
     [addDashboard],
+  )
+
+  const createStudyPackDashboards = useCallback(
+    ({
+      dashboards,
+      folderName = 'Study Packs',
+    }: {
+      folderName?: string
+      dashboards: Array<{
+        name: string
+        widgets: Array<{
+          name: string
+          components: ComponentData[]
+          category?: string
+          tags?: string[]
+          description?: string
+          version?: string
+          author?: string
+        }>
+        layoutMode?: StudyPackDashboardLayoutMode
+        folderName?: string
+      }>
+    }) =>
+      dashboards.map((dashboard) =>
+        createStudyPackDashboard({
+          ...dashboard,
+          folderName: dashboard.folderName || folderName,
+        }),
+      ),
+    [createStudyPackDashboard],
   )
 
   const openTemplateDashboard = useCallback(
@@ -705,6 +738,7 @@ export const useWorkspaceActions = () => {
     openCreateDashboard,
     openCreateStudyPack,
     createStudyPackDashboard,
+    createStudyPackDashboards,
     openOperationsExample,
     openMathExample,
     openTutorialExample,

--- a/apps/aquamesh/src/studyPack/ai/gemini.ts
+++ b/apps/aquamesh/src/studyPack/ai/gemini.ts
@@ -115,6 +115,70 @@ const removeUnrequestedHeavyResources = (
   }
 }
 
+const hasUsefulLessonNotes = (value: string): boolean =>
+  value.trim().split(/\s+/).filter(Boolean).length >= 80
+
+const studyObjectToLessonNote = (object: StudyObject): string => {
+  switch (object.kind) {
+    case 'markdown':
+      return object.markdown
+    case 'note':
+      return object.body
+    case 'term':
+      return `Definition — ${object.term}: ${object.definition}`
+    case 'qa':
+      return `Flashcard — ${object.question}\nAnswer: ${object.answer}`
+    case 'quiz':
+      return `Quiz concept — ${object.question}\nAnswer: ${object.answer}. ${object.explanation}`
+    case 'list':
+      return `${object.title || 'Key list'}:\n${object.items
+        .map((item) => `- ${item}`)
+        .join('\n')}`
+    case 'sequence':
+      return `${object.title || 'Steps'}:\n${object.steps
+        .map((step, index) => `${index + 1}. ${step}`)
+        .join('\n')}`
+    case 'comparison':
+      return `${object.title || 'Comparison'}: ${object.columns.join(' vs ')}`
+    case 'table':
+      return `${object.title || 'Table'}: ${object.headers.join(', ')}`
+    case 'reviewPrompt':
+      return `Review prompt — ${object.prompt}${
+        object.reason ? ` (${object.reason})` : ''
+      }`
+    case 'code':
+      return `${object.caption || object.title || 'Code note'}\n${object.code}`
+    case 'resource':
+      return `${object.label}: ${object.url}`
+    case 'reveal':
+      return `${object.prompt}: ${object.hiddenText}`
+    default:
+      return ''
+  }
+}
+
+const buildStudyPathLessonNotes = (
+  title: string,
+  summary: string,
+  rawNotes: string,
+  objects: StudyObject[],
+): string => {
+  if (hasUsefulLessonNotes(rawNotes)) {
+    return rawNotes.trim()
+  }
+
+  const objectNotes = objects
+    .map(studyObjectToLessonNote)
+    .map((note) => note.trim())
+    .filter(Boolean)
+    .join('\n\n')
+
+  return [`# ${title}`, objectNotes, summary, rawNotes]
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join('\n\n')
+}
+
 export interface ExtractRawNotesWithAiOptions {
   apiToken: string
   model: string
@@ -535,14 +599,16 @@ Return exactly this structure:
   "title": "Path title",
   "folderName": "Folder name for all dashboards",
   "dashboards": [
-    { "title": "01 - Introduction", "summary": "One sentence preview", "rawNotes": "Short source notes for this lesson", "objects": [...] }
+    { "title": "01 - Introduction", "summary": "One sentence preview", "rawNotes": "Complete lesson notes for this dashboard", "objects": [...] }
   ]
 }
 
 Rules:
 - Create exactly 5 dashboards unless the topic is tiny. Use these ordered lessons: ${stepNames.join(' → ')}.
-- Each dashboard must be useful by itself and contain 4-10 objects.
-- Start each dashboard with a markdown or note object containing the teaching explanation for that lesson.
+- Each dashboard must be useful by itself and contain 6-12 objects.
+- rawNotes must be real lesson notes for that dashboard, not a one-line summary. Write 250-600 words with explanations, examples, key points, and common mistakes when relevant.
+- Start each dashboard with a markdown object containing the full teaching explanation for that lesson. Use the "markdown" field, not "body".
+- Practice questions must be specific to the lesson content. Never create generic questions like "What do the notes say about <dashboard title>?".
 - Include practice in later dashboards: quizzes, flashcards as "qa", review prompts, lists, sequences, code, or tables when relevant.
 - Every dashboard needs a short "summary" sentence so the review screen can preview it.
 - Do not wrap JSON in markdown. Do not add commentary outside JSON.
@@ -576,6 +642,10 @@ ${prompt}`,
         typeof input.title === 'string' && input.title.trim()
           ? input.title.trim()
           : `${index + 1}. ${stepNames[index] || 'Lesson'}`
+      const dashboardSummary =
+        typeof input.summary === 'string' && input.summary.trim()
+          ? input.summary.trim()
+          : 'Generated lesson dashboard.'
       const packId = `${title}-${index + 1}`
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, '-')
@@ -588,11 +658,16 @@ ${prompt}`,
         packId,
       )
       const safeDraft = removeUnrequestedHeavyResources(draft.objects, prompt)
+      const lessonNotes = buildStudyPathLessonNotes(
+        dashboardTitle,
+        dashboardSummary,
+        typeof input.rawNotes === 'string' ? input.rawNotes : '',
+        safeDraft.objects,
+      )
       const augmented = augmentStudyPackPracticeObjects(safeDraft.objects, {
         packId,
         title: dashboardTitle,
-        rawNotes:
-          typeof input.rawNotes === 'string' ? input.rawNotes : prompt,
+        rawNotes: lessonNotes,
         generationTargets: [
           'summaries',
           'definitions',
@@ -613,11 +688,8 @@ ${prompt}`,
       return {
         ...draft,
         title: dashboardTitle,
-        summary:
-          typeof input.summary === 'string' && input.summary.trim()
-            ? input.summary.trim()
-            : 'Generated lesson dashboard.',
-        rawNotes: typeof input.rawNotes === 'string' ? input.rawNotes : prompt,
+        summary: dashboardSummary,
+        rawNotes: lessonNotes,
         objects: augmented.objects,
         warnings: [],
         sourceFormat: 'text' as StudyPackSourceFormat,

--- a/apps/aquamesh/src/studyPack/ai/gemini.ts
+++ b/apps/aquamesh/src/studyPack/ai/gemini.ts
@@ -118,6 +118,63 @@ const removeUnrequestedHeavyResources = (
 const hasUsefulLessonNotes = (value: string): boolean =>
   value.trim().split(/\s+/).filter(Boolean).length >= 80
 
+const hasReadableLessonStructure = (value: string): boolean =>
+  /(^|\n)#{1,3}\s+\S/.test(value) ||
+  /(^|\n)\s*[-*]\s+\S/.test(value) ||
+  /(^|\n)\s*\d+[.)]\s+\S/.test(value)
+
+const splitIntoSentences = (value: string): string[] =>
+  value
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean)
+
+const formatLessonNotesForReading = (
+  title: string,
+  summary: string,
+  rawNotes: string,
+): string => {
+  const trimmed = rawNotes.trim()
+  if (!trimmed || hasReadableLessonStructure(trimmed)) {
+    return trimmed
+  }
+
+  const sentences = splitIntoSentences(trimmed)
+  if (sentences.length < 5) {
+    return [`# ${title}`, summary, trimmed]
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .join('\n\n')
+  }
+
+  const overview = sentences.slice(0, 2)
+  const conceptCount = Math.max(3, Math.ceil((sentences.length - 2) * 0.45))
+  const keyConcepts = sentences.slice(2, 2 + conceptCount)
+  const remaining = sentences.slice(2 + conceptCount)
+  const examples = remaining.slice(0, Math.max(2, Math.floor(remaining.length / 2)))
+  const tips = remaining.slice(examples.length)
+
+  return [
+    `# ${title}`,
+    summary ? `## Goal\n${summary}` : '',
+    overview.length > 0 ? `## Overview\n${overview.join(' ')}` : '',
+    keyConcepts.length > 0
+      ? `## Key points\n${keyConcepts.map((sentence) => `- ${sentence}`).join('\n')}`
+      : '',
+    examples.length > 0
+      ? `## Examples and usage\n${examples.map((sentence) => `- ${sentence}`).join('\n')}`
+      : '',
+    tips.length > 0
+      ? `## Remember\n${tips.map((sentence) => `- ${sentence}`).join('\n')}`
+      : '',
+  ]
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join('\n\n')
+}
+
 const studyObjectToLessonNote = (object: StudyObject): string => {
   switch (object.kind) {
     case 'markdown':
@@ -164,7 +221,7 @@ const buildStudyPathLessonNotes = (
   objects: StudyObject[],
 ): string => {
   if (hasUsefulLessonNotes(rawNotes)) {
-    return rawNotes.trim()
+    return formatLessonNotesForReading(title, summary, rawNotes)
   }
 
   const objectNotes = objects
@@ -607,8 +664,9 @@ Rules:
 - Create exactly 5 dashboards unless the topic is tiny. Use these ordered lessons: ${stepNames.join(' → ')}.
 - Each dashboard must be useful by itself and contain 6-12 objects.
 - rawNotes must be real lesson notes for that dashboard, not a one-line summary. Write 250-600 words with explanations, examples, key points, and common mistakes when relevant.
+- Format rawNotes as readable Markdown, not one long paragraph. Use short sections like "## Goal", "## Key points", "## Examples", "## Common mistakes", and bullet lists where helpful.
 - Start each dashboard with a markdown object containing the full teaching explanation for that lesson. Use the "markdown" field, not "body".
-- Practice questions must be specific to the lesson content. Never create generic questions like "What do the notes say about <dashboard title>?".
+- Practice questions must be specific to the lesson content. Never create generic questions like "What do the notes say about <dashboard title>?" or "Which statement matches the notes about <dashboard title>?".
 - Include practice in later dashboards: quizzes, flashcards as "qa", review prompts, lists, sequences, code, or tables when relevant.
 - Every dashboard needs a short "summary" sentence so the review screen can preview it.
 - Do not wrap JSON in markdown. Do not add commentary outside JSON.

--- a/apps/aquamesh/src/studyPack/ai/gemini.ts
+++ b/apps/aquamesh/src/studyPack/ai/gemini.ts
@@ -35,6 +35,8 @@ const GEMINI_TIMEOUT_MESSAGE =
   'Gemini took longer than 5 minutes, so AquaMesh stopped the request. Try again with shorter notes, fewer generated blocks, or Basic fallback.'
 const GEMINI_RATE_LIMIT_MESSAGE =
   'Gemini rate limit reached for today. Try again later, use Basic fallback, or check your Gemini API quota.'
+const GEMINI_OUTPUT_FORMAT_MESSAGE =
+  'Gemini could not follow the requested output format. AquaMesh retried with a simpler JSON prompt, but the response was still unusable.'
 
 const generationTargetLabels: Record<string, string> = {
   quizzes: 'multiple-choice quizzes',
@@ -233,6 +235,12 @@ const parseGeminiJson = (text: string): unknown => {
   }
 }
 
+const isGeminiOutputFormatError = (error: unknown): boolean =>
+  error instanceof Error &&
+  /wrong output format|invalid json|output format|response format|malformed/i.test(
+    error.message,
+  )
+
 const fileToBase64 = (file: File): Promise<string> =>
   new Promise((resolve, reject) => {
     const reader = new FileReader()
@@ -375,12 +383,7 @@ export const generateStudyPackWithAi = async ({
     ? 'Organize the material as a Study Path progression. Use titles/tags that clearly fit: Introduction, Theory, Examples, Practice, Final Review.'
     : 'Organize the material as a single Study Pack.'
 
-  const text = await callGemini(
-    apiToken,
-    model,
-    [
-      {
-        text: `Create a study pack JSON object ${
+  const promptText = `Create a study pack JSON object ${
           promptMode
             ? 'from this learning prompt'
             : 'from these raw notes'
@@ -411,7 +414,11 @@ Rules:
 - Prefer useful learning widgets from the selected target types: quizzes, flashcards as "qa", term definitions, lists, comparisons, sequences, code notes, tables, and review prompts.
 - For multiple-choice quizzes, include 3-4 options and correctIndex. Vary the correct answer position across questions; do not always put the correct answer first.
 - Prefer multiple-choice quizzes. Use short-answer quizzes only when a grounded multiple-choice question would be misleading.
-- Do not invent outside facts or practice content requiring unstated knowledge.
+- ${
+          promptMode
+            ? 'Do not fabricate facts. If unsure, keep explanations broad and safe.'
+            : 'Do not invent outside facts or practice content requiring unstated knowledge.'
+        }
 - Do not create or reference heavy resources such as PDFs or images unless the user explicitly asks for PDFs, images, screenshots, diagrams, or visual resources.
 - Keep objects concise and student-friendly.
 - ${targetInstruction}
@@ -422,13 +429,58 @@ Rules:
 Pack title: ${title}
 
 Raw notes:
-${rawNotes}`,
-      },
-    ],
-    objectSchema,
-  )
+${rawNotes}`
 
-  const parsed = parseGeminiJson(text)
+  const callPromptModeFallback = () =>
+    callGemini(apiToken, model, [
+      {
+        text: `${promptText}
+
+The previous response failed JSON formatting. Retry with a simpler response:
+- Return plain JSON only.
+- Use only: markdown, qa, quiz, term, list, reviewPrompt.
+- Do not use markdown code fences.
+- Do not include comments, trailing commas, undefined, NaN, or extra text.`,
+      },
+    ])
+
+  let text: string
+  let usedPromptModeFallback = false
+  try {
+    text = await callGemini(
+      apiToken,
+      model,
+      [{ text: promptText }],
+      objectSchema,
+    )
+  } catch (error) {
+    if (!promptMode || !isGeminiOutputFormatError(error)) {
+      throw error
+    }
+
+    usedPromptModeFallback = true
+    text = await callPromptModeFallback()
+  }
+
+  let parsed: unknown
+  try {
+    parsed = parseGeminiJson(text)
+  } catch (error) {
+    if (!promptMode) {
+      throw error
+    }
+
+    if (!usedPromptModeFallback) {
+      try {
+        text = await callPromptModeFallback()
+        parsed = parseGeminiJson(text)
+      } catch {
+        throw new Error(GEMINI_OUTPUT_FORMAT_MESSAGE)
+      }
+    } else {
+      throw new Error(GEMINI_OUTPUT_FORMAT_MESSAGE)
+    }
+  }
 
   const draft = normalizeAiStudyPackDraft(parsed, packId)
   const safeDraft = removeUnrequestedHeavyResources(draft.objects, rawNotes)

--- a/apps/aquamesh/src/studyPack/ai/gemini.ts
+++ b/apps/aquamesh/src/studyPack/ai/gemini.ts
@@ -142,6 +142,7 @@ const objectSchema = {
           kind: {
             type: 'STRING',
             enum: [
+              'markdown',
               'note',
               'term',
               'qa',
@@ -157,6 +158,7 @@ const objectSchema = {
           },
           title: { type: 'STRING' },
           tags: { type: 'ARRAY', items: { type: 'STRING' } },
+          markdown: { type: 'STRING' },
           body: { type: 'STRING' },
           term: { type: 'STRING' },
           definition: { type: 'STRING' },
@@ -367,7 +369,7 @@ export const generateStudyPackWithAi = async ({
       ? `Use an active-practice mix: ${practiceProfile.targetQuizzes} quizzes, ${practiceProfile.targetFlashcards} flashcards, and about ${practiceProfile.targetSupport} summaries/definitions/review prompts. Quizzes should be 50-60% of the pack and flashcards 20-30%.`
       : 'Use the selected non-practice targets and still create the requested number of useful reviewable items.'
   const sourceInstruction = promptMode
-    ? 'The raw input is a learning prompt, not notes. First create concise source notes that teach the requested topic, then generate practice grounded in those generated notes. Include explanation/theory objects before exercises.'
+    ? 'The raw input is a learning prompt, not notes. Teach the requested topic from scratch. Because the input is not source notes, you may use accurate general knowledge for this topic. First create concise source notes/explanations, then generate practice grounded in those generated explanations. Include explanation/theory objects before exercises.'
     : 'The raw input is source notes. Stay grounded in those notes.'
   const pathInstruction = studyPathMode
     ? 'Organize the material as a Study Path progression. Use titles/tags that clearly fit: Introduction, Theory, Examples, Practice, Final Review.'
@@ -378,12 +380,33 @@ export const generateStudyPackWithAi = async ({
     model,
     [
       {
-        text: `Create a study pack JSON object from these raw notes.
+        text: `Create a study pack JSON object ${
+          promptMode
+            ? 'from this learning prompt'
+            : 'from these raw notes'
+        }.
+
+Return exactly one JSON object with this shape:
+{
+  "title": "Short study pack title",
+  "sourceFormat": "text",
+  "objects": [
+    { "kind": "markdown", "title": "Explanation", "markdown": "..." },
+    { "kind": "quiz", "question": "...", "quizMode": "multipleChoice", "options": ["...", "...", "..."], "correctIndex": 0, "answer": "...", "explanation": "..." }
+  ]
+}
+
+Do not wrap the JSON in markdown fences. Do not add commentary outside JSON.
 
 Rules:
-- Use only facts answerable from the notes.
+- ${
+          promptMode
+            ? 'Use accurate general knowledge to teach the requested topic; do not pretend the prompt is source notes.'
+            : 'Use only facts answerable from the notes.'
+        }
 - ${sourceInstruction}
 - ${pathInstruction}
+- In AI Tutor mode, include at least one markdown explanation object as the first object. Use the "markdown" field for markdown objects, not "body".
 - Generate exercises even from short notes. A single wiki paragraph should still produce multiple grounded quizzes and flashcards.
 - Prefer useful learning widgets from the selected target types: quizzes, flashcards as "qa", term definitions, lists, comparisons, sequences, code notes, tables, and review prompts.
 - For multiple-choice quizzes, include 3-4 options and correctIndex. Vary the correct answer position across questions; do not always put the correct answer first.

--- a/apps/aquamesh/src/studyPack/ai/gemini.ts
+++ b/apps/aquamesh/src/studyPack/ai/gemini.ts
@@ -1,4 +1,5 @@
 import { StudyPackSourceFormat } from '../types'
+import { StudyObject } from '../types'
 import {
   augmentStudyPackPracticeObjects,
   createStudyPackPracticeProfile,
@@ -58,6 +59,38 @@ export interface GenerateStudyPackWithAiOptions {
   packId: string
   generationTargets?: string[]
   generationAmount?: 'few' | 'medium' | 'many'
+  promptMode?: boolean
+  studyPathMode?: boolean
+}
+
+const asksForHeavyResource = (text: string): boolean =>
+  /\b(pdf|image|images|picture|pictures|diagram|diagrams|visual|visuals|photo|photos|screenshot|screenshots)\b/i.test(
+    text,
+  )
+
+const removeUnrequestedHeavyResources = (
+  objects: StudyObject[],
+  rawNotes: string,
+): { objects: StudyObject[]; warnings: string[] } => {
+  if (asksForHeavyResource(rawNotes)) {
+    return { objects, warnings: [] }
+  }
+
+  const filtered = objects.filter(
+    (object) =>
+      object.kind !== 'resource' ||
+      (object.resourceType !== 'pdf' && object.resourceType !== 'image'),
+  )
+
+  return {
+    objects: filtered,
+    warnings:
+      filtered.length === objects.length
+        ? []
+        : [
+            'Skipped AI-generated PDF/image resources because the source did not explicitly ask for heavy media.',
+          ],
+  }
 }
 
 export interface ExtractRawNotesWithAiOptions {
@@ -256,6 +289,8 @@ export const generateStudyPackWithAi = async ({
   packId,
   generationTargets = [],
   generationAmount = 'medium',
+  promptMode = false,
+  studyPathMode = false,
 }: GenerateStudyPackWithAiOptions): Promise<AiStudyPackDraft> => {
   const effectiveTargets = getEffectiveGenerationTargets(generationTargets)
   const practiceProfile = createStudyPackPracticeProfile(
@@ -270,6 +305,12 @@ export const generateStudyPackWithAi = async ({
     practiceProfile.enforceQuizzes || practiceProfile.enforceFlashcards
       ? `Use an active-practice mix: ${practiceProfile.targetQuizzes} quizzes, ${practiceProfile.targetFlashcards} flashcards, and about ${practiceProfile.targetSupport} summaries/definitions/review prompts. Quizzes should be 50-60% of the pack and flashcards 20-30%.`
       : 'Use the selected non-practice targets and still create the requested number of useful reviewable items.'
+  const sourceInstruction = promptMode
+    ? 'The raw input is a learning prompt, not notes. First create concise source notes that teach the requested topic, then generate practice grounded in those generated notes. Include explanation/theory objects before exercises.'
+    : 'The raw input is source notes. Stay grounded in those notes.'
+  const pathInstruction = studyPathMode
+    ? 'Organize the material as a Study Path progression. Use titles/tags that clearly fit: Introduction, Theory, Examples, Practice, Final Review.'
+    : 'Organize the material as a single Study Pack.'
 
   const text = await callGemini(
     apiToken,
@@ -280,11 +321,14 @@ export const generateStudyPackWithAi = async ({
 
 Rules:
 - Use only facts answerable from the notes.
+- ${sourceInstruction}
+- ${pathInstruction}
 - Generate exercises even from short notes. A single wiki paragraph should still produce multiple grounded quizzes and flashcards.
 - Prefer useful learning widgets from the selected target types: quizzes, flashcards as "qa", term definitions, lists, comparisons, sequences, code notes, tables, and review prompts.
 - For multiple-choice quizzes, include 3-4 options and correctIndex. Vary the correct answer position across questions; do not always put the correct answer first.
 - Prefer multiple-choice quizzes. Use short-answer quizzes only when a grounded multiple-choice question would be misleading.
 - Do not invent outside facts or practice content requiring unstated knowledge.
+- Do not create or reference heavy resources such as PDFs or images unless the user explicitly asks for PDFs, images, screenshots, diagrams, or visual resources.
 - Keep objects concise and student-friendly.
 - ${targetInstruction}
 - ${amountInstruction}
@@ -308,7 +352,8 @@ ${rawNotes}`,
   }
 
   const draft = normalizeAiStudyPackDraft(parsed, packId)
-  const augmented = augmentStudyPackPracticeObjects(draft.objects, {
+  const safeDraft = removeUnrequestedHeavyResources(draft.objects, rawNotes)
+  const augmented = augmentStudyPackPracticeObjects(safeDraft.objects, {
     packId,
     title: draft.title || title,
     rawNotes,
@@ -319,7 +364,7 @@ ${rawNotes}`,
   return {
     ...draft,
     objects: augmented.objects,
-    warnings: [...draft.warnings, ...augmented.warnings],
+    warnings: [...draft.warnings, ...safeDraft.warnings, ...augmented.warnings],
     title: draft.title || title,
     sourceFormat: draft.sourceFormat || ('text' as StudyPackSourceFormat),
   }

--- a/apps/aquamesh/src/studyPack/ai/gemini.ts
+++ b/apps/aquamesh/src/studyPack/ai/gemini.ts
@@ -63,6 +63,26 @@ export interface GenerateStudyPackWithAiOptions {
   studyPathMode?: boolean
 }
 
+export interface AiStudyPathDashboardDraft extends AiStudyPackDraft {
+  summary: string
+}
+
+export interface AiStudyPathDraft {
+  title: string
+  folderName: string
+  dashboards: AiStudyPathDashboardDraft[]
+  warnings: string[]
+}
+
+export interface GenerateStudyPathWithAiOptions {
+  apiToken: string
+  model: string
+  title: string
+  prompt: string
+  folderName: string
+  generationAmount?: 'few' | 'medium' | 'many'
+}
+
 const asksForHeavyResource = (text: string): boolean =>
   /\b(pdf|image|images|picture|pictures|diagram|diagrams|visual|visuals|photo|photos|screenshot|screenshots)\b/i.test(
     text,
@@ -168,6 +188,47 @@ const objectSchema = {
     },
   },
   required: ['objects'],
+}
+
+const studyPathSchema = {
+  type: 'OBJECT',
+  properties: {
+    title: { type: 'STRING' },
+    folderName: { type: 'STRING' },
+    dashboards: {
+      type: 'ARRAY',
+      items: {
+        type: 'OBJECT',
+        properties: {
+          title: { type: 'STRING' },
+          summary: { type: 'STRING' },
+          rawNotes: { type: 'STRING' },
+          objects: objectSchema.properties.objects,
+        },
+        required: ['title', 'summary', 'objects'],
+      },
+    },
+  },
+  required: ['title', 'folderName', 'dashboards'],
+}
+
+const parseGeminiJson = (text: string): unknown => {
+  try {
+    return JSON.parse(text)
+  } catch {
+    const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1]
+    if (fenced) {
+      return JSON.parse(fenced)
+    }
+
+    const firstObject = text.indexOf('{')
+    const lastObject = text.lastIndexOf('}')
+    if (firstObject >= 0 && lastObject > firstObject) {
+      return JSON.parse(text.slice(firstObject, lastObject + 1))
+    }
+
+    throw new Error('Gemini returned invalid JSON.')
+  }
 }
 
 const fileToBase64 = (file: File): Promise<string> =>
@@ -344,12 +405,7 @@ ${rawNotes}`,
     objectSchema,
   )
 
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(text)
-  } catch {
-    throw new Error('Gemini returned invalid JSON.')
-  }
+  const parsed = parseGeminiJson(text)
 
   const draft = normalizeAiStudyPackDraft(parsed, packId)
   const safeDraft = removeUnrequestedHeavyResources(draft.objects, rawNotes)
@@ -367,5 +423,149 @@ ${rawNotes}`,
     warnings: [...draft.warnings, ...safeDraft.warnings, ...augmented.warnings],
     title: draft.title || title,
     sourceFormat: draft.sourceFormat || ('text' as StudyPackSourceFormat),
+  }
+}
+
+export const generateStudyPathWithAi = async ({
+  apiToken,
+  model,
+  title,
+  prompt,
+  folderName,
+  generationAmount = 'medium',
+}: GenerateStudyPathWithAiOptions): Promise<AiStudyPathDraft> => {
+  const stepNames = [
+    'Introduction',
+    'Theory',
+    'Examples',
+    'Practice',
+    'Final Review',
+  ]
+  const practiceProfile = createStudyPackPracticeProfile(generationAmount, [
+    'summaries',
+    'definitions',
+    'flashcards',
+    'quizzes',
+    'exercises',
+  ])
+  const text = await callGemini(
+    apiToken,
+    model,
+    [
+      {
+        text: `Create a Study Path JSON object. A Study Path is NOT one dashboard. It is a folder containing multiple ordered dashboards/study packs.
+
+Return exactly this structure:
+{
+  "title": "Path title",
+  "folderName": "Folder name for all dashboards",
+  "dashboards": [
+    { "title": "01 - Introduction", "summary": "One sentence preview", "rawNotes": "Short source notes for this lesson", "objects": [...] }
+  ]
+}
+
+Rules:
+- Create exactly 5 dashboards unless the topic is tiny. Use these ordered lessons: ${stepNames.join(' → ')}.
+- Each dashboard must be useful by itself and contain 4-10 objects.
+- Start each dashboard with a markdown or note object containing the teaching explanation for that lesson.
+- Include practice in later dashboards: quizzes, flashcards as "qa", review prompts, lists, sequences, code, or tables when relevant.
+- Every dashboard needs a short "summary" sentence so the review screen can preview it.
+- Do not wrap JSON in markdown. Do not add commentary outside JSON.
+- Do not create PDFs/images/resources unless the user explicitly asks for heavy media.
+- For multiple-choice quizzes, include 3-4 options, correctIndex, answer, and explanation.
+- Keep content concise, beginner-friendly, and appropriate for the requested topic.
+- Aim for about ${practiceProfile.minTotal}-${practiceProfile.maxTotal} reviewable items across the whole path.
+
+Path title: ${title}
+Folder name: ${folderName}
+User request/topic:
+${prompt}`,
+      },
+    ],
+    studyPathSchema,
+  )
+
+  const parsed = parseGeminiJson(text)
+  const record =
+    parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {}
+  const rawDashboards = Array.isArray(record.dashboards)
+    ? record.dashboards
+    : []
+  const warnings: string[] = []
+  const dashboards = rawDashboards
+    .slice(0, 8)
+    .map((item, index): AiStudyPathDashboardDraft | null => {
+      const input =
+        item && typeof item === 'object' ? (item as Record<string, unknown>) : {}
+      const dashboardTitle =
+        typeof input.title === 'string' && input.title.trim()
+          ? input.title.trim()
+          : `${index + 1}. ${stepNames[index] || 'Lesson'}`
+      const packId = `${title}-${index + 1}`
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+      const draft = normalizeAiStudyPackDraft(
+        {
+          ...input,
+          title: dashboardTitle,
+          sourceFormat: 'text',
+        },
+        packId,
+      )
+      const safeDraft = removeUnrequestedHeavyResources(draft.objects, prompt)
+      const augmented = augmentStudyPackPracticeObjects(safeDraft.objects, {
+        packId,
+        title: dashboardTitle,
+        rawNotes:
+          typeof input.rawNotes === 'string' ? input.rawNotes : prompt,
+        generationTargets: [
+          'summaries',
+          'definitions',
+          'flashcards',
+          'quizzes',
+          'exercises',
+        ],
+        generationAmount,
+      })
+
+      warnings.push(...draft.warnings, ...safeDraft.warnings, ...augmented.warnings)
+
+      if (augmented.objects.length === 0) {
+        warnings.push(`Skipped ${dashboardTitle}: no usable study objects.`)
+        return null
+      }
+
+      return {
+        ...draft,
+        title: dashboardTitle,
+        summary:
+          typeof input.summary === 'string' && input.summary.trim()
+            ? input.summary.trim()
+            : 'Generated lesson dashboard.',
+        rawNotes: typeof input.rawNotes === 'string' ? input.rawNotes : prompt,
+        objects: augmented.objects,
+        warnings: [],
+        sourceFormat: 'text' as StudyPackSourceFormat,
+      }
+    })
+    .filter((dashboard): dashboard is AiStudyPathDashboardDraft =>
+      Boolean(dashboard),
+    )
+
+  if (dashboards.length === 0) {
+    throw new Error('Gemini did not return any usable Study Path dashboards.')
+  }
+
+  return {
+    title:
+      typeof record.title === 'string' && record.title.trim()
+        ? record.title.trim()
+        : title,
+    folderName:
+      typeof record.folderName === 'string' && record.folderName.trim()
+        ? record.folderName.trim()
+        : folderName,
+    dashboards,
+    warnings,
   }
 }

--- a/apps/aquamesh/src/studyPack/ai/index.ts
+++ b/apps/aquamesh/src/studyPack/ai/index.ts
@@ -8,10 +8,17 @@ export {
   saveStudyPackAiSettings,
 } from './settings'
 export type { StudyPackAiSettings } from './settings'
-export { extractRawNotesWithAi, generateStudyPackWithAi } from './gemini'
+export {
+  extractRawNotesWithAi,
+  generateStudyPackWithAi,
+  generateStudyPathWithAi,
+} from './gemini'
 export type {
+  AiStudyPathDashboardDraft,
+  AiStudyPathDraft,
   ExtractRawNotesWithAiOptions,
   GenerateStudyPackWithAiOptions,
+  GenerateStudyPathWithAiOptions,
 } from './gemini'
 export { normalizeAiStudyPackDraft } from './normalizer'
 export type { AiStudyPackDraft } from './normalizer'

--- a/apps/aquamesh/src/studyPack/practice.ts
+++ b/apps/aquamesh/src/studyPack/practice.ts
@@ -286,6 +286,29 @@ const extractConcept = (fact: string, title: string): string => {
   return words.slice(0, 8).join(' ') || title || 'this topic'
 }
 
+const isUsefulPracticeFact = (fact: string, title: string): boolean => {
+  const words = fact.split(/\s+/).filter(Boolean)
+  const normalizedFact = fact.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim()
+  const normalizedTitle = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+
+  if (words.length < 8) {
+    return false
+  }
+
+  if (normalizedTitle && normalizedFact === normalizedTitle) {
+    return false
+  }
+
+  if (/^(introduction|theory|examples|practice|final review|next steps)\b/i.test(fact)) {
+    return words.length >= 14
+  }
+
+  return true
+}
+
 const createQuiz = (
   packId: string,
   index: number,
@@ -479,7 +502,9 @@ export const augmentStudyPackPracticeObjects = (
   const objects = inputObjects
     .filter((object) => objectMatchesTargets(object, targets))
     .map(shuffleStudyObjectQuizOptions)
-  const facts = splitIntoFacts(options.rawNotes)
+  const facts = splitIntoFacts(options.rawNotes).filter((fact) =>
+    isUsefulPracticeFact(fact, options.title),
+  )
   const warnings: string[] = []
 
   if (facts.length === 0) {

--- a/apps/aquamesh/src/studyPack/practice.ts
+++ b/apps/aquamesh/src/studyPack/practice.ts
@@ -236,6 +236,9 @@ const sanitizeIdPart = (value: string): string => {
 const normalizeSpaces = (value: string): string =>
   value.replace(/\s+/g, ' ').trim()
 
+const normalizeForCompare = (value: string): string =>
+  value.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim()
+
 const stripMarkdown = (value: string): string =>
   value
     .replace(/```[\s\S]*?```/g, ' ')
@@ -272,10 +275,11 @@ const splitIntoFacts = (rawNotes: string): string[] => {
 }
 
 const extractConcept = (fact: string, title: string): string => {
+  const quotedConcept = fact.match(/["'“‘]([^"'”’]{2,60})["'”’]/)?.[1]
   const definitionMatch = fact.match(
     /^(.{2,80}?)\s+(?:is|are|was|were|means|refers to|es|son|fue|era|significa|consiste en)\s+/i,
   )
-  const rawConcept = definitionMatch?.[1] || title || fact
+  const rawConcept = quotedConcept || definitionMatch?.[1] || fact
   const concept = normalizeSpaces(
     rawConcept
       .replace(/^(?:the|a|an|el|la|los|las|un|una)\s+/i, '')
@@ -283,16 +287,27 @@ const extractConcept = (fact: string, title: string): string => {
   )
   const words = concept.split(/\s+/).filter(Boolean)
 
-  return words.slice(0, 8).join(' ') || title || 'this topic'
+  const shortened = words.slice(0, 8).join(' ')
+  const normalizedConcept = normalizeForCompare(shortened)
+  const normalizedTitle = normalizeForCompare(title)
+
+  if (
+    !shortened ||
+    (normalizedTitle &&
+      (normalizedConcept === normalizedTitle ||
+        normalizedTitle.includes(normalizedConcept) ||
+        normalizedConcept.includes(normalizedTitle)))
+  ) {
+    return 'this lesson point'
+  }
+
+  return shortened
 }
 
 const isUsefulPracticeFact = (fact: string, title: string): boolean => {
   const words = fact.split(/\s+/).filter(Boolean)
-  const normalizedFact = fact.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim()
-  const normalizedTitle = title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, ' ')
-    .trim()
+  const normalizedFact = normalizeForCompare(fact)
+  const normalizedTitle = normalizeForCompare(title)
 
   if (words.length < 8) {
     return false
@@ -335,7 +350,7 @@ const createQuiz = (
     tags: ['study-pack', 'practice'],
     quizMode: 'multipleChoice',
     question: useFactOptions
-      ? `Which statement matches the notes about ${concept}?`
+      ? `Which statement is correct about ${concept}?`
       : `According to the notes, is this statement supported: "${fact}"?`,
     options,
     correctIndex: 0,
@@ -358,7 +373,10 @@ const createFlashcard = (
     title: `${concept} flashcard`,
     sourceLine: index + 1,
     tags: ['study-pack', 'practice'],
-    question: `What do the notes say about ${concept}?`,
+    question:
+      concept === 'this lesson point'
+        ? 'What is the key idea in this note?'
+        : `What should you remember about ${concept}?`,
     answer: fact,
   }
 }


### PR DESCRIPTION
## Summary
- add Study task and Output selectors to Study Pack creation
- add AI Prompt mode for generating lessons directly from goals like "teach me past simple"
- add Study Path output that organizes generated material into ordered Introduction, Theory, Examples, Practice, and Final Review steps
- guide Gemini away from unrequested heavy PDF/image resources and filter them if returned
- keep the Vercel webpack-cli build fix and missing SettingsDialog Alert import

## Verification
- git diff --check
- clean-build install + npm run build from archived checkout passed
- served production build locally and verified /workspace renders
- opened Create Study Pack modal in production build and verified new controls render