### PR TITLE
Polish Interactive Study Path UI

### DIFF
--- a/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/aquamesh/src/components/Dasboard/Dashboard.tsx
@@ -36,13 +36,18 @@ import FolderOpenIcon from '@mui/icons-material/FolderOpen'
 import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser'
 import DashboardLayoutView from '../Layout/Layout'
 import { useLayout } from '../Layout/LayoutProvider'
-import { DashboardLayout, StudyPathDashboardItem } from '../../state/store'
+import { DashboardLayout } from '../../state/store'
 import { useDashboards } from './DashboardProvider'
 import SavedDashboardsDialog from './DashboardLibrary'
 import StudyPathWorkspaceView from './StudyPathWorkspaceView'
+import {
+  createStudyPathContainerState,
+  getStudyPathMetaFromLayout,
+} from './studyPathContainer'
 import useTopNavBarWidgets from '../../customHooks/useTopNavBarWidgets'
 import {
   ensureStarterDashboards,
+  STARTER_STUDY_PATH_FOLDER_NAME,
   OPEN_DASHBOARD_EDITOR_EVENT,
   OPEN_WIDGET_EDITOR_EVENT,
 } from '../../customHooks/useWorkspaceActions'
@@ -101,6 +106,7 @@ interface SavedDashboard {
 }
 
 const DEFAULT_DASHBOARD_NAME = 'New Dashboard'
+const DEFAULT_STUDY_PATH_OPENED_KEY = 'aquamesh-default-study-path-opened-v1'
 const USER_ROLE_CHANGED_EVENT = 'aquamesh-user-role-changed'
 const OPEN_SAVED_DASHBOARDS_EVENT = 'aquamesh-open-saved-dashboards'
 
@@ -465,6 +471,7 @@ const Dashboards = () => {
     reorderDashboard,
     addDashboard,
     addDashboards,
+    addStudyPathContainer,
     updateStudyPathContainer,
     replaceDashboard,
     updateLayout,
@@ -657,15 +664,6 @@ const Dashboards = () => {
       dashboardId: dashboard.id,
       dashboardName: dashboard.name,
     })
-  }
-
-  const openAllStudyPathLessons = (lessons: StudyPathDashboardItem[]) => {
-    addDashboards(
-      lessons.map((lesson) => ({
-        name: lesson.name,
-        layout: lesson.layout,
-      })),
-    )
   }
 
   const openSavedDashboardFromLibrary = (dashboard: SavedDashboard) => {
@@ -873,6 +871,48 @@ const Dashboards = () => {
   }, [])
 
   useEffect(() => {
+    if (openDashboards.length === 0) {
+      return
+    }
+
+    if (window.localStorage.getItem(DEFAULT_STUDY_PATH_OPENED_KEY) === 'true') {
+      return
+    }
+
+    if (
+      openDashboards.some(
+        (dashboard) => dashboard.kind === 'studyPathContainer',
+      )
+    ) {
+      window.localStorage.setItem(DEFAULT_STUDY_PATH_OPENED_KEY, 'true')
+      return
+    }
+
+    const selectedDashboardRecord = openDashboards[selectedDashboard]
+    if (
+      !selectedDashboardRecord ||
+      hasDashboardContent(selectedDashboardRecord.layout)
+    ) {
+      window.localStorage.setItem(DEFAULT_STUDY_PATH_OPENED_KEY, 'true')
+      return
+    }
+
+    ensureStarterDashboards()
+    const starterStudyPathDashboards = DashboardStorage.getAll().filter(
+      (dashboard) => dashboard.folder === STARTER_STUDY_PATH_FOLDER_NAME,
+    )
+    const studyPath = createStudyPathContainerState(starterStudyPathDashboards)
+
+    if (!studyPath) {
+      return
+    }
+
+    addStudyPathContainer(studyPath)
+    window.localStorage.setItem(DEFAULT_STUDY_PATH_OPENED_KEY, 'true')
+    loadDashboardOptions()
+  }, [addStudyPathContainer, openDashboards, selectedDashboard])
+
+  useEffect(() => {
     if (!isEditingDashboardEditorTitle) {
       setDashboardEditorTitleInput(dashboardEditorDashboard?.name || '')
     }
@@ -937,6 +977,58 @@ const Dashboards = () => {
       }
 
       loadDashboardOptions()
+
+      const reviewMeta = getStudyPathMetaFromLayout(dashboard.layout)
+      const openStudyPathIndex = reviewMeta
+        ? openDashboards.findIndex(
+            (openDashboard) =>
+              openDashboard.kind === 'studyPathContainer' &&
+              openDashboard.studyPath?.pathId === reviewMeta.studyPathId,
+          )
+        : -1
+
+      if (reviewMeta && openStudyPathIndex >= 0) {
+        const openStudyPathDashboard = openDashboards[openStudyPathIndex]
+
+        updateStudyPathContainer(openStudyPathDashboard.id, (studyPath) => {
+          const reviewItem = {
+            id: dashboard.id,
+            name: dashboard.name,
+            layout: dashboard.layout,
+            dashboardKey: reviewMeta.dashboardKey,
+            dashboardIndex: reviewMeta.dashboardIndex,
+            dashboardCount: reviewMeta.dashboardCount,
+            folderName: reviewMeta.folderName,
+          }
+          const existingReviewIndex = studyPath.dashboards.findIndex(
+            (lesson) => lesson.dashboardKey === reviewItem.dashboardKey,
+          )
+          const nextDashboards =
+            existingReviewIndex >= 0
+              ? studyPath.dashboards.map((lesson, index) =>
+                  index === existingReviewIndex ? reviewItem : lesson,
+                )
+              : [...studyPath.dashboards, reviewItem]
+          const orderedDashboards = [...nextDashboards].sort(
+            (first, second) => first.dashboardIndex - second.dashboardIndex,
+          )
+          const selectedIndex = Math.max(
+            0,
+            orderedDashboards.findIndex(
+              (lesson) => lesson.dashboardKey === reviewItem.dashboardKey,
+            ),
+          )
+
+          return {
+            ...studyPath,
+            dashboards: orderedDashboards,
+            selectedIndex,
+          }
+        })
+        setSelectedDashboard(openStudyPathIndex)
+        return
+      }
+
       addDashboard({
         name: dashboard.name,
         layout: dashboard.layout,
@@ -954,7 +1046,12 @@ const Dashboards = () => {
         handleOpenStudyPathReviewDashboard,
       )
     }
-  }, [addDashboard])
+  }, [
+    addDashboard,
+    openDashboards,
+    setSelectedDashboard,
+    updateStudyPathContainer,
+  ])
 
   // Check if current dashboards have changes compared to saved dashboards
   useEffect(() => {
@@ -1437,7 +1534,9 @@ const Dashboards = () => {
   return (
     <Box>
       <Tabs
-        className={`react-tabs ${selectedDashboardIsEmpty ? 'react-tabs--empty-selected' : ''}`.trim()}
+        className={`react-tabs ${
+          selectedDashboardIsEmpty ? 'react-tabs--empty-selected' : ''
+        }`.trim()}
         selectedIndex={selectedDashboard}
         onSelect={(index) => setSelectedDashboard(index)}
         style={{ position: 'relative' }}
@@ -1600,11 +1699,6 @@ const Dashboards = () => {
                       studyPath={dashboard.studyPath}
                       onStudyPathChange={(studyPath) =>
                         updateStudyPathContainer(dashboard.id, () => studyPath)
-                      }
-                      onOpenAll={() =>
-                        openAllStudyPathLessons(
-                          dashboard.studyPath?.dashboards || [],
-                        )
                       }
                     />
                   ) : isEmptyDashboard ? (

--- a/apps/aquamesh/src/components/Dasboard/DashboardOptionsMenu.tsx
+++ b/apps/aquamesh/src/components/Dasboard/DashboardOptionsMenu.tsx
@@ -10,7 +10,6 @@ import {
   Tooltip,
   useTheme,
   useMediaQuery,
-  ListItemIcon,
   ListItemText,
 } from '@mui/material'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
@@ -19,9 +18,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import DashboardIcon from '@mui/icons-material/Dashboard'
 import EditIcon from '@mui/icons-material/Edit'
 import AutoStoriesIcon from '@mui/icons-material/AutoStories'
-import MoreVertIcon from '@mui/icons-material/MoreVert'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
-import ViewListIcon from '@mui/icons-material/ViewList'
 import { DashboardLayout, StudyPathContainerState } from '../../state/store'
 import { useDashboards } from './DashboardProvider'
 import {
@@ -63,10 +60,6 @@ interface StudyPathMenuGroup {
   dashboards: SavedDashboard[]
   studyPath: StudyPathContainerState
 }
-
-type PowerMenuTarget =
-  | { type: 'studyPath'; group: StudyPathMenuGroup }
-  | { type: 'lesson'; group: StudyPathMenuGroup; lessonIndex: number }
 
 // Button with label component
 interface ButtonWithLabelProps {
@@ -132,10 +125,6 @@ const DashboardOptionsMenu: React.FC = () => {
   const [expandedStudyPathFolders, setExpandedStudyPathFolders] = useState<
     string[]
   >([])
-  const [powerMenuAnchorEl, setPowerMenuAnchorEl] =
-    useState<null | HTMLElement>(null)
-  const [powerMenuTarget, setPowerMenuTarget] =
-    useState<PowerMenuTarget | null>(null)
   // Track admin status to filter dashboards
   const [isAdmin, setIsAdmin] = useState(false)
 
@@ -296,8 +285,8 @@ const DashboardOptionsMenu: React.FC = () => {
         (folderName === 'Mathematics'
           ? '#1976D2'
           : folderName === 'Tutorial'
-          ? DEFAULT_FOLDER_COLOR
-          : undefined),
+            ? DEFAULT_FOLDER_COLOR
+            : undefined),
     )
 
   // Handle opening and closing dropdown
@@ -311,13 +300,6 @@ const DashboardOptionsMenu: React.FC = () => {
   const handleClose = () => {
     setAnchorEl(null)
     setExpandedDashboardFolders([])
-    setPowerMenuAnchorEl(null)
-    setPowerMenuTarget(null)
-  }
-
-  const closePowerMenu = () => {
-    setPowerMenuAnchorEl(null)
-    setPowerMenuTarget(null)
   }
 
   // Create a dashboard with predefined layout
@@ -327,7 +309,11 @@ const DashboardOptionsMenu: React.FC = () => {
   ) => {
     const focusedDashboard = openDashboards[selectedDashboard]
 
-    if (focusedDashboard && !hasDashboardContent(focusedDashboard.layout)) {
+    if (
+      focusedDashboard &&
+      focusedDashboard.kind !== 'studyPathContainer' &&
+      !hasDashboardContent(focusedDashboard.layout)
+    ) {
       replaceDashboard(selectedDashboard, {
         name: dashboardName,
         layout,
@@ -441,26 +427,7 @@ const DashboardOptionsMenu: React.FC = () => {
     }
 
     createDashboardWithLayout(lesson.name, lesson.layout)
-  }
-
-  const openAllStudyPathDashboards = (group: StudyPathMenuGroup) => {
-    addDashboards(
-      group.studyPath.dashboards.map((lesson) => ({
-        name: lesson.name,
-        layout: lesson.layout,
-      })),
-      { replaceEmptySelected: true },
-    )
     handleClose()
-  }
-
-  const openStudyPathInLibrary = (folderName: string) => {
-    handleClose()
-    window.dispatchEvent(
-      new CustomEvent(OPEN_SAVED_DASHBOARDS_EVENT, {
-        detail: { folderFilter: folderName },
-      }),
-    )
   }
 
   const toggleStudyPathExpanded = (
@@ -473,15 +440,6 @@ const DashboardOptionsMenu: React.FC = () => {
         ? currentFolders.filter((currentFolder) => currentFolder !== folderName)
         : [...currentFolders, folderName],
     )
-  }
-
-  const openPowerMenu = (
-    event: React.MouseEvent<HTMLElement>,
-    target: PowerMenuTarget,
-  ) => {
-    event.stopPropagation()
-    setPowerMenuAnchorEl(event.currentTarget)
-    setPowerMenuTarget(target)
   }
 
   const openSavedDashboardsForFolder = (
@@ -672,16 +630,16 @@ const DashboardOptionsMenu: React.FC = () => {
                         {studyPath.dashboards.length} lessons
                       </Typography>
                     </Box>
-                    <Tooltip title="Study Path actions">
+                    <Tooltip title={`Manage ${folderName} in Library`}>
                       <IconButton
                         size="small"
-                        aria-label={`${folderName} Study Path actions`}
+                        aria-label={`Manage ${folderName} in Library`}
                         onClick={(event) =>
-                          openPowerMenu(event, { type: 'studyPath', group })
+                          openSavedDashboardsForFolder(event, folderName)
                         }
                         sx={{ color: folderColor, p: 0.5 }}
                       >
-                        <MoreVertIcon fontSize="small" />
+                        <EditIcon fontSize="small" />
                       </IconButton>
                     </Tooltip>
                   </Box>
@@ -720,22 +678,6 @@ const DashboardOptionsMenu: React.FC = () => {
                             sx={{ ml: 0.5 }}
                           >
                             <OpenInNewIcon fontSize="small" />
-                          </IconButton>
-                        </Tooltip>
-                        <Tooltip title="Lesson actions">
-                          <IconButton
-                            size="small"
-                            aria-label={`${lesson.name} actions`}
-                            onClick={(event) =>
-                              openPowerMenu(event, {
-                                type: 'lesson',
-                                group,
-                                lessonIndex: index,
-                              })
-                            }
-                            sx={{ ml: 0.25 }}
-                          >
-                            <MoreVertIcon fontSize="small" />
                           </IconButton>
                         </Tooltip>
                       </MenuItem>
@@ -1073,78 +1015,6 @@ const DashboardOptionsMenu: React.FC = () => {
           >
             No study packs or dashboards yet
           </MenuItem>
-        )}
-      </Menu>
-
-      <Menu
-        anchorEl={powerMenuAnchorEl}
-        open={Boolean(powerMenuAnchorEl)}
-        onClose={closePowerMenu}
-        PaperProps={{
-          sx: {
-            bgcolor: 'background.paper',
-            color: 'text.primary',
-            minWidth: 220,
-          },
-        }}
-      >
-        {powerMenuTarget && (
-          <>
-            <MenuItem
-              onClick={() => {
-                openStudyPathGroup(
-                  powerMenuTarget.group,
-                  powerMenuTarget.type === 'lesson'
-                    ? powerMenuTarget.lessonIndex
-                    : 0,
-                )
-              }}
-            >
-              <ListItemIcon>
-                <AutoStoriesIcon fontSize="small" />
-              </ListItemIcon>
-              <ListItemText
-                primary={
-                  powerMenuTarget.type === 'lesson'
-                    ? 'Open lesson in Study Path'
-                    : 'Open Study Path'
-                }
-              />
-            </MenuItem>
-            {powerMenuTarget.type === 'lesson' && (
-              <MenuItem
-                onClick={() =>
-                  openStudyPathLessonInNewTab(
-                    powerMenuTarget.group,
-                    powerMenuTarget.lessonIndex,
-                  )
-                }
-              >
-                <ListItemIcon>
-                  <OpenInNewIcon fontSize="small" />
-                </ListItemIcon>
-                <ListItemText primary="Open lesson in new tab" />
-              </MenuItem>
-            )}
-            <MenuItem
-              onClick={() => openAllStudyPathDashboards(powerMenuTarget.group)}
-            >
-              <ListItemIcon>
-                <ViewListIcon fontSize="small" />
-              </ListItemIcon>
-              <ListItemText primary="Open all dashboards" />
-            </MenuItem>
-            <MenuItem
-              onClick={() =>
-                openStudyPathInLibrary(powerMenuTarget.group.folderName)
-              }
-            >
-              <ListItemIcon>
-                <EditIcon fontSize="small" />
-              </ListItemIcon>
-              <ListItemText primary="Open in Library / Manage" />
-            </MenuItem>
-          </>
         )}
       </Menu>
     </>

--- a/apps/aquamesh/src/components/Dasboard/DashboardProvider.tsx
+++ b/apps/aquamesh/src/components/Dasboard/DashboardProvider.tsx
@@ -71,6 +71,13 @@ const DashboardProvider: React.FC<DashboardProviderProps> = (props) => {
     return Boolean(layout.children?.some((child) => hasDashboardContent(child)))
   }
 
+  const isReplaceableEmptyDashboard = (dashboard?: StateDashboard): boolean =>
+    Boolean(
+      dashboard &&
+        dashboard.kind !== 'studyPathContainer' &&
+        !hasDashboardContent(dashboard.layout),
+    )
+
   const setDashboardEditing = (id: string, isEditing: boolean) => {
     setEditingDashboardIds((currentIds) => {
       if (isEditing) {
@@ -195,8 +202,7 @@ const DashboardProvider: React.FC<DashboardProviderProps> = (props) => {
     const focusedDashboard = newOpenDashboards[selectedDashboard]
     const shouldReplaceSelected = Boolean(
       options.replaceEmptySelected &&
-        focusedDashboard &&
-        !hasDashboardContent(focusedDashboard.layout),
+        isReplaceableEmptyDashboard(focusedDashboard),
     )
     const replacedDashboardId = shouldReplaceSelected
       ? focusedDashboard?.id
@@ -244,9 +250,7 @@ const DashboardProvider: React.FC<DashboardProviderProps> = (props) => {
     }
     const newOpenDashboards = [...openDashboards]
     const focusedDashboard = newOpenDashboards[selectedDashboard]
-    const shouldReplaceSelected = Boolean(
-      focusedDashboard && !hasDashboardContent(focusedDashboard.layout),
-    )
+    const shouldReplaceSelected = isReplaceableEmptyDashboard(focusedDashboard)
 
     if (shouldReplaceSelected) {
       newOpenDashboards[selectedDashboard] = containerDashboard

--- a/apps/aquamesh/src/components/Dasboard/StudyPathWorkspaceView.tsx
+++ b/apps/aquamesh/src/components/Dasboard/StudyPathWorkspaceView.tsx
@@ -15,7 +15,7 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import AutoStoriesIcon from '@mui/icons-material/AutoStories'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
-import PushPinIcon from '@mui/icons-material/PushPin'
+import CloseIcon from '@mui/icons-material/Close'
 import DashboardLayoutView from '../Layout/Layout'
 import {
   DashboardLayout,
@@ -24,15 +24,15 @@ import {
 } from '../../state/store'
 import { getStudyPathDashboardProgress } from '../../studyPack/progress'
 
-const STUDY_PATH_NAV_COLLAPSED_STORAGE_KEY =
-  'aquamesh-study-path-navigator-collapsed-v1'
-const NAVIGATOR_EXPANDED_WIDTH = 340
-const NAVIGATOR_COLLAPSED_WIDTH = 72
+const STUDY_PATH_NAV_OPEN_STORAGE_KEY = 'aquamesh-study-path-navigator-open-v2'
+const STUDY_PATH_NAV_DOCK_STORAGE_KEY = 'aquamesh-study-path-navigator-dock-v1'
+const NAVIGATOR_PANEL_WIDTH = 318
+
+type NavigatorDock = 'left' | 'right'
 
 interface StudyPathWorkspaceViewProps {
   studyPath: StudyPathContainerState
   onStudyPathChange: (studyPath: StudyPathContainerState) => void
-  onOpenAll: () => void
 }
 
 const getProgressForLesson = (
@@ -126,15 +126,14 @@ const sanitizeStudentLayout = (
 const StudyPathWorkspaceView: React.FC<StudyPathWorkspaceViewProps> = ({
   studyPath,
   onStudyPathChange,
-  onOpenAll,
 }) => {
-  const [navigatorCollapsed, setNavigatorCollapsed] = useState(false)
+  const [navigatorOpen, setNavigatorOpen] = useState(false)
+  const [navigatorDock, setNavigatorDock] = useState<NavigatorDock>('left')
   const selectedIndex = Math.min(
     Math.max(studyPath.selectedIndex || 0, 0),
     Math.max(studyPath.dashboards.length - 1, 0),
   )
   const currentLesson = studyPath.dashboards[selectedIndex]
-  const pinnedDashboardKeys = studyPath.pinnedDashboardKeys || []
   const progressByKey = useMemo(
     () =>
       Object.fromEntries(
@@ -155,10 +154,17 @@ const StudyPathWorkspaceView: React.FC<StudyPathWorkspaceViewProps> = ({
 
   useEffect(() => {
     try {
-      const storedState = localStorage.getItem(
-        `${STUDY_PATH_NAV_COLLAPSED_STORAGE_KEY}:${studyPath.pathId}`,
+      const storedOpenState = localStorage.getItem(
+        `${STUDY_PATH_NAV_OPEN_STORAGE_KEY}:${studyPath.pathId}`,
       )
-      setNavigatorCollapsed(storedState === 'true')
+      const storedDock = localStorage.getItem(
+        `${STUDY_PATH_NAV_DOCK_STORAGE_KEY}:${studyPath.pathId}`,
+      )
+
+      setNavigatorOpen(storedOpenState === 'true')
+      if (storedDock === 'left' || storedDock === 'right') {
+        setNavigatorDock(storedDock)
+      }
     } catch (error) {
       console.error('Failed to load Study Path navigator state', error)
     }
@@ -167,13 +173,24 @@ const StudyPathWorkspaceView: React.FC<StudyPathWorkspaceViewProps> = ({
   useEffect(() => {
     try {
       localStorage.setItem(
-        `${STUDY_PATH_NAV_COLLAPSED_STORAGE_KEY}:${studyPath.pathId}`,
-        String(navigatorCollapsed),
+        `${STUDY_PATH_NAV_OPEN_STORAGE_KEY}:${studyPath.pathId}`,
+        String(navigatorOpen),
       )
     } catch (error) {
       console.error('Failed to save Study Path navigator state', error)
     }
-  }, [navigatorCollapsed, studyPath.pathId])
+  }, [navigatorOpen, studyPath.pathId])
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        `${STUDY_PATH_NAV_DOCK_STORAGE_KEY}:${studyPath.pathId}`,
+        navigatorDock,
+      )
+    } catch (error) {
+      console.error('Failed to save Study Path navigator dock', error)
+    }
+  }, [navigatorDock, studyPath.pathId])
 
   const selectLesson = (index: number) => {
     onStudyPathChange({ ...studyPath, selectedIndex: index })
@@ -190,10 +207,6 @@ const StudyPathWorkspaceView: React.FC<StudyPathWorkspaceViewProps> = ({
         index === selectedIndex ? { ...lesson, layout } : lesson,
       ),
     })
-  }
-
-  const toggleNavigatorCollapsed = () => {
-    setNavigatorCollapsed((currentState) => !currentState)
   }
 
   if (!currentLesson) {
@@ -213,110 +226,88 @@ const StudyPathWorkspaceView: React.FC<StudyPathWorkspaceViewProps> = ({
     studyPath.dashboards.length > 0
       ? Math.round((completedCount / studyPath.dashboards.length) * 100)
       : 0
-  const navigatorWidth = navigatorCollapsed
-    ? NAVIGATOR_COLLAPSED_WIDTH
-    : NAVIGATOR_EXPANDED_WIDTH
+  const panelHorizontalSx =
+    navigatorDock === 'left'
+      ? { left: { xs: 8, md: 14 } }
+      : { right: { xs: 8, md: 14 } }
+  const pillHorizontalSx =
+    navigatorDock === 'left'
+      ? { left: { xs: 10, md: 16 } }
+      : { right: { xs: 10, md: 16 } }
 
   return (
     <Box
+      data-testid="study-path-workspace"
       sx={{
-        display: 'flex',
-        flexDirection: { xs: 'column', lg: 'row' },
-        alignItems: 'stretch',
-        width: '100%',
-        maxWidth: '100%',
-        '& > .study-path-navigator': {
-          width: { xs: '100%', lg: navigatorWidth },
-          flex: { xs: '0 0 auto', lg: `0 0 ${navigatorWidth}px` },
-          maxWidth: { xs: '100%', lg: navigatorWidth },
-          height: { xs: 'auto', lg: '100%' },
-          maxHeight: { xs: 'none', lg: '100%' },
-          minHeight: 0,
-          boxSizing: 'border-box',
-        },
-        '& > .study-path-content': {
-          width: { xs: '100%', lg: `calc(100% - ${navigatorWidth}px)` },
-          flex: { xs: '1 1 auto', lg: '1 1 auto' },
-          maxWidth: { xs: '100%', lg: `calc(100% - ${navigatorWidth}px)` },
-          minHeight: 0,
-        },
         height: '100%',
-        maxHeight: '100%',
         minHeight: 0,
-        overflow: 'hidden',
-        boxSizing: 'border-box',
-        background:
-          'linear-gradient(135deg, rgba(0,124,102,0.12), rgba(25,118,210,0.08))',
-        border: 1,
-        borderColor: 'primary.main',
-        borderRadius: { xs: 0, md: 2 },
+        width: '100%',
+        position: 'relative',
+        overflow: 'visible',
+        backgroundColor: 'background.default',
       }}
     >
-      <Paper
-        className="study-path-navigator"
-        square
-        elevation={0}
+      <Box
+        data-testid="study-path-dashboard-content"
         sx={{
-          borderRight: { lg: 1 },
-          borderBottom: { xs: 1, lg: 0 },
-          borderColor: 'divider',
-          background:
-            'linear-gradient(180deg, rgba(0,124,102,0.18), rgba(0,16,38,0.02)), var(--background-paper)',
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
-          position: 'relative',
-          zIndex: 2,
-          p: navigatorCollapsed ? 1 : 2.25,
+          height: '100%',
+          minHeight: 0,
+          overflow: 'visible',
+          p: { xs: 0.5, md: 1 },
+          boxSizing: 'border-box',
         }}
       >
-        {navigatorCollapsed ? (
-          <Stack
-            spacing={1.5}
-            alignItems="center"
-            sx={{ height: '100%', minHeight: { lg: 0 } }}
+        <DashboardLayoutView
+          key={currentLesson.dashboardKey}
+          layout={studentLayout}
+          readOnly
+          updateLayout={(model) => updateCurrentLayout(model.toJson().layout)}
+        />
+      </Box>
+
+      <Box
+        aria-label="Study Path navigator overlay"
+        data-testid="study-path-navigator-overlay"
+        sx={{
+          position: 'absolute',
+          inset: 0,
+          zIndex: 8,
+          pointerEvents: 'none',
+        }}
+      >
+        {!navigatorOpen && (
+          <Paper
+            data-testid="study-path-navigator-pill"
+            elevation={3}
+            sx={{
+              position: 'absolute',
+              top: { xs: 10, md: 14 },
+              ...pillHorizontalSx,
+              pointerEvents: 'auto',
+              borderRadius: 999,
+              border: 1,
+              borderColor: 'divider',
+              bgcolor: 'background.paper',
+              overflow: 'hidden',
+            }}
           >
-            <Tooltip title="Expand Course navigator">
-              <IconButton
-                aria-label="Expand Course navigator"
-                onClick={toggleNavigatorCollapsed}
-                color="primary"
-                sx={{
-                  bgcolor: 'background.paper',
-                  color: 'primary.main',
-                  border: 1,
-                  borderColor: 'divider',
-                  boxShadow: 1,
-                  '&:hover': {
-                    bgcolor: 'action.hover',
-                  },
-                }}
-              >
-                <ChevronRightIcon />
-              </IconButton>
-            </Tooltip>
-            <AutoStoriesIcon color="primary" />
-            <Typography
-              variant="caption"
-              sx={{
-                fontWeight: 900,
-                writingMode: { xs: 'horizontal-tb', lg: 'vertical-rl' },
-                transform: { lg: 'rotate(180deg)' },
-                textAlign: 'center',
-                letterSpacing: '.08em',
-                textTransform: 'uppercase',
-                color: 'text.secondary',
-              }}
-            >
-              Course navigator
-            </Typography>
-            <Chip
-              size="small"
-              color="primary"
-              label={`${selectedIndex + 1}/${studyPath.dashboards.length}`}
-              sx={{ mt: 'auto' }}
-            />
-            <Stack spacing={1} alignItems="center">
+            <Stack direction="row" alignItems="center" spacing={0.25}>
+              <Tooltip title="Open Course navigator">
+                <Button
+                  size="small"
+                  onClick={() => setNavigatorOpen(true)}
+                  startIcon={<AutoStoriesIcon fontSize="small" />}
+                  sx={{
+                    px: 1.25,
+                    minHeight: 34,
+                    borderRadius: 999,
+                    textTransform: 'none',
+                    fontWeight: 800,
+                  }}
+                >
+                  {selectedIndex + 1}/{studyPath.dashboards.length}
+                </Button>
+              </Tooltip>
               <Tooltip title="Previous lesson">
                 <span>
                   <IconButton
@@ -324,11 +315,6 @@ const StudyPathWorkspaceView: React.FC<StudyPathWorkspaceViewProps> = ({
                     aria-label="Previous lesson"
                     disabled={!canGoPrevious}
                     onClick={() => selectLesson(selectedIndex - 1)}
-                    sx={{
-                      bgcolor: 'background.paper',
-                      border: 1,
-                      borderColor: 'divider',
-                    }}
                   >
                     <ChevronLeftIcon fontSize="small" />
                   </IconButton>
@@ -341,227 +327,303 @@ const StudyPathWorkspaceView: React.FC<StudyPathWorkspaceViewProps> = ({
                     aria-label="Next lesson"
                     disabled={!canGoNext}
                     onClick={() => selectLesson(selectedIndex + 1)}
-                    sx={{
-                      bgcolor: 'background.paper',
-                      border: 1,
-                      borderColor: 'divider',
-                    }}
                   >
                     <ChevronRightIcon fontSize="small" />
                   </IconButton>
                 </span>
               </Tooltip>
             </Stack>
-          </Stack>
-        ) : (
-          <Stack
-            spacing={2.25}
-            sx={{ height: '100%', minHeight: 0, overflow: 'hidden' }}
+          </Paper>
+        )}
+
+        {navigatorOpen && (
+          <Paper
+            data-testid="study-path-navigator-panel"
+            elevation={8}
+            sx={{
+              position: 'absolute',
+              top: { xs: 8, md: 14 },
+              bottom: { xs: 'auto', md: 14 },
+              ...panelHorizontalSx,
+              width: {
+                xs: 'min(288px, calc(100% - 20px))',
+                sm: NAVIGATOR_PANEL_WIDTH,
+              },
+              maxWidth: { xs: 288, sm: NAVIGATOR_PANEL_WIDTH },
+              maxHeight: { xs: 'calc(100% - 16px)', md: 'none' },
+              pointerEvents: 'auto',
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              borderRadius: 3,
+              border: 1,
+              borderColor: 'divider',
+              bgcolor: 'background.paper',
+              backdropFilter: 'blur(10px)',
+              boxShadow: '0 16px 44px rgba(0, 0, 0, 0.22)',
+            }}
           >
-            <Stack direction="row" spacing={1.25} alignItems="flex-start">
-              <Box
-                sx={{
-                  width: 42,
-                  height: 42,
-                  borderRadius: 2,
-                  display: 'grid',
-                  placeItems: 'center',
-                  color: 'primary.contrastText',
-                  bgcolor: 'primary.main',
-                  boxShadow: 2,
-                  flex: '0 0 auto',
-                }}
-              >
-                <AutoStoriesIcon />
-              </Box>
-              <Box sx={{ minWidth: 0, flex: 1 }}>
-                <Stack
-                  direction="row"
-                  spacing={1}
-                  alignItems="center"
-                  justifyContent="space-between"
+            <Stack
+              spacing={{ xs: 0.75, sm: 1.25 }}
+              sx={{ p: { xs: 1, sm: 1.5 }, pb: { xs: 0.75, sm: 1.25 } }}
+            >
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Box
+                  sx={{
+                    width: { xs: 28, sm: 34 },
+                    height: { xs: 28, sm: 34 },
+                    borderRadius: { xs: 1.5, sm: 2 },
+                    display: 'grid',
+                    placeItems: 'center',
+                    color: 'primary.contrastText',
+                    bgcolor: 'primary.main',
+                    flex: '0 0 auto',
+                  }}
                 >
+                  <AutoStoriesIcon fontSize="small" />
+                </Box>
+                <Box sx={{ minWidth: 0, flex: 1 }}>
                   <Typography
                     variant="overline"
                     color="primary.main"
-                    sx={{ fontWeight: 900, letterSpacing: '.08em' }}
+                    sx={{
+                      fontWeight: 900,
+                      letterSpacing: '.08em',
+                      fontSize: { xs: '0.62rem', sm: '0.75rem' },
+                      lineHeight: 1.1,
+                    }}
                   >
-                    Course navigator
+                    Course helper
                   </Typography>
-                  <Tooltip title="Collapse Course navigator">
-                    <IconButton
-                      size="small"
-                      aria-label="Collapse Course navigator"
-                      onClick={toggleNavigatorCollapsed}
-                      sx={{
-                        bgcolor: 'background.paper',
-                        color: 'primary.main',
-                        border: 1,
-                        borderColor: 'divider',
-                        boxShadow: 1,
-                        '&:hover': {
-                          bgcolor: 'action.hover',
-                        },
-                      }}
-                    >
-                      <ChevronLeftIcon fontSize="small" />
-                    </IconButton>
-                  </Tooltip>
-                </Stack>
-                <Typography variant="h6" sx={{ lineHeight: 1.18 }}>
-                  {studyPath.title}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  One Study Path tab · switch lessons below
-                </Typography>
-              </Box>
-            </Stack>
+                  <Typography
+                    variant="subtitle2"
+                    noWrap
+                    fontWeight={800}
+                    sx={{ fontSize: { xs: '0.82rem', sm: '0.875rem' } }}
+                  >
+                    {studyPath.title}
+                  </Typography>
+                </Box>
+                <Tooltip title="Collapse Course navigator">
+                  <IconButton
+                    size="small"
+                    aria-label="Collapse Course navigator"
+                    onClick={() => setNavigatorOpen(false)}
+                  >
+                    <CloseIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              </Stack>
 
-            <Paper
-              variant="outlined"
-              sx={{ p: 1.5, borderRadius: 2, bgcolor: 'background.default' }}
-            >
-              <Typography variant="h6" sx={{ lineHeight: 1.2 }}>
-                Step {selectedIndex + 1}/{studyPath.dashboards.length}
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                {currentLesson.name}
-              </Typography>
-            </Paper>
-
-            <Box>
-              <Stack direction="row" justifyContent="space-between" spacing={1}>
-                <Typography variant="caption" color="text.secondary">
+              <Stack
+                direction="row"
+                spacing={{ xs: 0.5, sm: 0.75 }}
+                alignItems="center"
+              >
+                <Chip
+                  size="small"
+                  color="primary"
+                  variant="outlined"
+                  sx={{
+                    height: { xs: 22, sm: 24 },
+                    fontSize: { xs: '0.68rem', sm: '0.75rem' },
+                  }}
+                  label={`Lesson ${selectedIndex + 1}/${
+                    studyPath.dashboards.length
+                  }`}
+                />
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  noWrap
+                  sx={{ fontSize: { xs: '0.68rem', sm: '0.75rem' } }}
+                >
                   {completedCount}/{studyPath.dashboards.length} completed
                 </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  {completionPercent}%
-                </Typography>
               </Stack>
+
               <LinearProgress
                 variant="determinate"
                 value={completionPercent}
-                sx={{ mt: 0.75, borderRadius: 999 }}
+                sx={{ borderRadius: 999, height: { xs: 4, sm: 5 } }}
               />
-            </Box>
 
-            <Typography variant="subtitle2" sx={{ fontWeight: 900 }}>
-              Lessons
-            </Typography>
+              <Paper
+                variant="outlined"
+                sx={{
+                  px: { xs: 1, sm: 1.25 },
+                  py: { xs: 0.65, sm: 1 },
+                  borderRadius: 2,
+                  bgcolor: 'action.hover',
+                }}
+              >
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ fontSize: { xs: '0.68rem', sm: '0.75rem' } }}
+                >
+                  Current lesson
+                </Typography>
+                <Typography
+                  variant="body2"
+                  fontWeight={800}
+                  noWrap
+                  sx={{ fontSize: { xs: '0.78rem', sm: '0.875rem' } }}
+                >
+                  {currentLesson.name}
+                </Typography>
+              </Paper>
 
-            <Box sx={{ flex: 1, minHeight: 0, overflowY: 'auto', pr: 0.5 }}>
-              <Stack spacing={1.1}>
+              <Stack direction="row" spacing={0.75}>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  disabled={!canGoPrevious}
+                  onClick={() => selectLesson(selectedIndex - 1)}
+                  startIcon={<ChevronLeftIcon fontSize="small" />}
+                  sx={{
+                    flex: 1,
+                    textTransform: 'none',
+                    fontSize: { xs: '0.72rem', sm: '0.8125rem' },
+                    py: { xs: 0.35, sm: 0.5 },
+                  }}
+                >
+                  Previous
+                </Button>
+                <Button
+                  size="small"
+                  variant="contained"
+                  disabled={!canGoNext}
+                  onClick={() => selectLesson(selectedIndex + 1)}
+                  endIcon={<ChevronRightIcon fontSize="small" />}
+                  sx={{
+                    flex: 1,
+                    textTransform: 'none',
+                    fontSize: { xs: '0.72rem', sm: '0.8125rem' },
+                    py: { xs: 0.35, sm: 0.5 },
+                  }}
+                >
+                  Next
+                </Button>
+              </Stack>
+
+              <Stack
+                direction="row"
+                spacing={0.75}
+                sx={{ display: { xs: 'none', sm: 'flex' } }}
+              >
+                <Button
+                  size="small"
+                  variant={navigatorDock === 'left' ? 'contained' : 'text'}
+                  onClick={() => setNavigatorDock('left')}
+                  sx={{ flex: 1, textTransform: 'none' }}
+                >
+                  Dock left
+                </Button>
+                <Button
+                  size="small"
+                  variant={navigatorDock === 'right' ? 'contained' : 'text'}
+                  onClick={() => setNavigatorDock('right')}
+                  sx={{ flex: 1, textTransform: 'none' }}
+                >
+                  Dock right
+                </Button>
+              </Stack>
+            </Stack>
+
+            <Divider />
+
+            <Box
+              sx={{
+                flex: 1,
+                minHeight: 0,
+                overflowY: 'auto',
+                p: { xs: 0.75, sm: 1 },
+              }}
+            >
+              <Stack spacing={{ xs: 0.4, sm: 0.65 }}>
                 {studyPath.dashboards.map((lesson, index) => {
                   const progress = progressByKey[lesson.dashboardKey]
                   const active = index === selectedIndex
-                  const pinned = pinnedDashboardKeys.includes(
-                    lesson.dashboardKey,
-                  )
 
                   return (
                     <Button
                       key={lesson.dashboardKey}
                       onClick={() => selectLesson(index)}
-                      variant={active ? 'contained' : 'text'}
-                      color={active ? 'primary' : 'inherit'}
+                      variant="text"
+                      color="inherit"
                       sx={{
                         justifyContent: 'flex-start',
                         textAlign: 'left',
-                        alignItems: 'stretch',
-                        borderRadius: 2.5,
-                        py: 1.15,
-                        px: 1.25,
+                        alignItems: 'center',
+                        borderRadius: 2,
+                        py: { xs: 0.5, sm: 0.75 },
+                        px: { xs: 0.75, sm: 1 },
                         border: 1,
-                        borderColor: active ? 'primary.main' : 'divider',
-                        bgcolor: active ? 'primary.main' : 'background.paper',
-                        boxShadow: active ? 2 : 0,
+                        borderColor: active ? 'primary.main' : 'transparent',
+                        bgcolor: active ? 'primary.main' : 'transparent',
+                        color: active ? 'primary.contrastText' : 'text.primary',
+                        boxShadow: active ? 1 : 0,
                         '&:hover': {
                           bgcolor: active ? 'primary.dark' : 'action.hover',
                         },
                       }}
                     >
-                      <Stack
-                        direction="row"
-                        spacing={1.2}
-                        sx={{ width: '100%' }}
-                      >
+                      <Stack direction="row" spacing={1} sx={{ width: '100%' }}>
                         <Box
                           sx={{
-                            width: 32,
-                            height: 32,
+                            width: { xs: 22, sm: 26 },
+                            height: { xs: 22, sm: 26 },
                             borderRadius: '50%',
                             display: 'grid',
                             placeItems: 'center',
                             flex: '0 0 auto',
+                            fontSize: { xs: 11, sm: 12 },
                             fontWeight: 900,
                             bgcolor: active
-                              ? 'rgba(255,255,255,0.22)'
+                              ? 'rgba(255,255,255,0.2)'
                               : 'action.hover',
                           }}
                         >
-                          {String(index + 1).padStart(2, '0')}
+                          {progress?.completedAt ? (
+                            <CheckCircleIcon sx={{ fontSize: 16 }} />
+                          ) : (
+                            index + 1
+                          )}
                         </Box>
-                        <Stack spacing={0.3} sx={{ minWidth: 0, flex: 1 }}>
-                          <Stack
-                            direction="row"
-                            spacing={1}
-                            alignItems="center"
+                        <Box sx={{ minWidth: 0, flex: 1 }}>
+                          <Typography
+                            variant="body2"
+                            fontWeight={800}
+                            noWrap
+                            sx={{
+                              fontSize: { xs: '0.76rem', sm: '0.875rem' },
+                            }}
                           >
-                            <Typography variant="body2" fontWeight={700} noWrap>
-                              {lesson.name}
-                            </Typography>
-                            {pinned && <PushPinIcon sx={{ fontSize: 14 }} />}
-                            {progress?.completedAt && (
-                              <CheckCircleIcon sx={{ fontSize: 15 }} />
-                            )}
-                          </Stack>
-                          <Typography variant="caption" sx={{ opacity: 0.78 }}>
+                            {lesson.name}
+                          </Typography>
+                          <Typography
+                            variant="caption"
+                            sx={{
+                              opacity: active ? 0.84 : 0.66,
+                              fontSize: { xs: '0.66rem', sm: '0.75rem' },
+                            }}
+                            noWrap
+                          >
                             Step {lesson.dashboardIndex}/{lesson.dashboardCount}
                             {progress?.score
                               ? ` · Score ${progress.score}%`
                               : ''}
                           </Typography>
-                        </Stack>
+                        </Box>
                       </Stack>
                     </Button>
                   )
                 })}
               </Stack>
             </Box>
-
-            <Divider />
-
-            <Button
-              size="small"
-              variant="outlined"
-              onClick={onOpenAll}
-              fullWidth
-            >
-              Open all dashboards
-            </Button>
-          </Stack>
+          </Paper>
         )}
-      </Paper>
-
-      <Box
-        className="study-path-content"
-        sx={{
-          minWidth: 0,
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
-          position: 'relative',
-          p: { xs: 1, md: 1.5 },
-        }}
-      >
-        <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
-          <DashboardLayoutView
-            key={`${currentLesson.dashboardKey}-${navigatorWidth}`}
-            layout={studentLayout}
-            readOnly
-            updateLayout={(model) => updateCurrentLayout(model.toJson().layout)}
-          />
-        </Box>
       </Box>
     </Box>
   )

--- a/apps/aquamesh/src/components/Dasboard/StudyPathWorkspaceView.tsx
+++ b/apps/aquamesh/src/components/Dasboard/StudyPathWorkspaceView.tsx
@@ -253,8 +253,6 @@ const StudyPathWorkspaceView: React.FC<StudyPathWorkspaceViewProps> = ({
           height: '100%',
           minHeight: 0,
           overflow: 'visible',
-          p: { xs: 0.5, md: 1 },
-          boxSizing: 'border-box',
         }}
       >
         <DashboardLayoutView

--- a/apps/aquamesh/src/components/Layout/Layout.tsx
+++ b/apps/aquamesh/src/components/Layout/Layout.tsx
@@ -104,7 +104,7 @@ const DashboardLayoutView: React.FC<DashboardLayoutViewProps> = ({
         width: '100%',
         minWidth: 0,
         position: 'relative',
-        overflow: 'hidden',
+        overflow: 'visible',
       }}
     >
       <Layout

--- a/apps/aquamesh/src/components/Layout/layout.scss
+++ b/apps/aquamesh/src/components/Layout/layout.scss
@@ -63,8 +63,11 @@
   }
 
   &:has(.flexlayout__tabset-selected) {
+    border-color: var(--primary-main);
     outline: 2px solid var(--primary-main);
-    // outline-offset: -1px;
+    outline-offset: 0;
+    position: relative;
+    z-index: 1;
   }
 }
 

--- a/apps/aquamesh/src/components/Layout/layout.scss
+++ b/apps/aquamesh/src/components/Layout/layout.scss
@@ -63,7 +63,6 @@
   }
 
   &:has(.flexlayout__tabset-selected) {
-    border-color: var(--primary-main);
     outline: 2px solid var(--primary-main);
     outline-offset: 0;
     position: relative;

--- a/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
+++ b/apps/aquamesh/src/customHooks/useWorkspaceActions.ts
@@ -44,8 +44,13 @@ interface SavedDashboardRecord {
 }
 
 const STARTER_DASHBOARDS_SEEDED_KEY = 'aquamesh-starter-dashboards-seeded-v12'
+export const STARTER_STUDY_PATH_FOLDER_NAME = 'AquaMesh Starter Study Path'
+const STARTER_STUDY_PATH_ID = 'aquamesh-starter-study-path'
 
 const STARTER_DASHBOARD_NAMES = [
+  'AquaMesh Starter 1 - Learn the Workspace',
+  'AquaMesh Starter 2 - Practice Interactivity',
+  'AquaMesh Starter 3 - Build Your Own',
   'Mathematics 1 - Derivatives',
   'AquaMesh Tutorial',
   'AquaMesh Interactivity',
@@ -71,6 +76,50 @@ const createLayoutWithComponent = (
           config: componentConfig.customProps
             ? { customProps: componentConfig.customProps }
             : undefined,
+        },
+      ],
+    },
+  ],
+})
+
+const createStarterStudyPathLayout = ({
+  dashboardName,
+  dashboardKey,
+  dashboardIndex,
+  dashboardCount,
+  components,
+}: {
+  dashboardName: string
+  dashboardKey: string
+  dashboardIndex: number
+  dashboardCount: number
+  components: ComponentData[]
+}): DashboardLayout => ({
+  type: 'row',
+  weight: 100,
+  children: [
+    {
+      type: 'tabset',
+      weight: 100,
+      active: true,
+      children: [
+        {
+          type: 'tab',
+          name: dashboardName,
+          component: 'CustomWidget',
+          config: {
+            customProps: {
+              widgetId: dashboardKey,
+              studyPathId: STARTER_STUDY_PATH_ID,
+              studyPathTitle: 'AquaMesh Starter Study Path',
+              studyPathDashboardKey: dashboardKey,
+              studyPathDashboardName: dashboardName,
+              studyPathDashboardIndex: dashboardIndex,
+              studyPathDashboardCount: dashboardCount,
+              studyPathFolderName: STARTER_STUDY_PATH_FOLDER_NAME,
+              components,
+            },
+          },
         },
       ],
     },
@@ -362,6 +411,166 @@ export const ensureStarterDashboards = () => {
   ) {
     return
   }
+
+  const starterStudyPathDashboards = [
+    {
+      name: 'AquaMesh Starter 1 - Learn the Workspace',
+      key: `${STARTER_STUDY_PATH_ID}-lesson-1`,
+      components: [
+        {
+          id: 'starter-path-1-title',
+          type: 'Label',
+          props: {
+            text: 'Welcome to your AquaMesh Study Path',
+            variant: 'h4',
+            fontWeight: 800,
+            gutterBottom: true,
+          },
+        },
+        {
+          id: 'starter-path-1-summary',
+          type: 'ListBlock',
+          props: {
+            __blockType: 'ListBlock',
+            title: 'What this guided course shows',
+            items:
+              'Study Paths keep multiple lesson dashboards in one workspace tab.\nUse the floating Course helper to move between lessons.\nEach lesson can still be opened standalone from the Study Paths menu.',
+            ordered: false,
+            interactiveChecklist: false,
+          },
+        },
+        {
+          id: 'starter-path-1-progress',
+          type: 'StudyPathProgressBlock',
+          props: {
+            studyPathId: STARTER_STUDY_PATH_ID,
+            studyPathTitle: 'AquaMesh Starter Study Path',
+            studyPathDashboardKey: `${STARTER_STUDY_PATH_ID}-lesson-1`,
+            studyPathDashboardName: 'AquaMesh Starter 1 - Learn the Workspace',
+            studyPathDashboardIndex: 1,
+            studyPathDashboardCount: 3,
+            studyPathFolderName: STARTER_STUDY_PATH_FOLDER_NAME,
+          },
+        },
+      ],
+    },
+    {
+      name: 'AquaMesh Starter 2 - Practice Interactivity',
+      key: `${STARTER_STUDY_PATH_ID}-lesson-2`,
+      components: [
+        {
+          id: 'starter-path-2-title',
+          type: 'Label',
+          props: {
+            text: 'Try interactive study blocks',
+            variant: 'h4',
+            fontWeight: 800,
+            gutterBottom: true,
+          },
+        },
+        {
+          id: 'starter-path-2-quiz',
+          type: 'QuizBlock',
+          props: {
+            __blockType: 'QuizBlock',
+            studyPathId: STARTER_STUDY_PATH_ID,
+            studyPathTitle: 'AquaMesh Starter Study Path',
+            studyPathDashboardKey: `${STARTER_STUDY_PATH_ID}-lesson-2`,
+            studyPathDashboardName:
+              'AquaMesh Starter 2 - Practice Interactivity',
+            studyPathDashboardIndex: 2,
+            studyPathDashboardCount: 3,
+            studyPathFolderName: STARTER_STUDY_PATH_FOLDER_NAME,
+            quizMode: 'multipleChoice',
+            question: 'What should the Course helper do in a Study Path?',
+            options: [
+              'Open every lesson as a top-level tab',
+              'Navigate lessons inside one Study Path tab',
+              'Hide the dashboard content',
+            ],
+            correctIndex: 1,
+            answer: 'Navigate lessons inside one Study Path tab',
+            explanation:
+              'The Study Path is a guided course mode: one top-level tab, internal lesson navigation.',
+          },
+        },
+        {
+          id: 'starter-path-2-progress',
+          type: 'StudyPathProgressBlock',
+          props: {
+            studyPathId: STARTER_STUDY_PATH_ID,
+            studyPathTitle: 'AquaMesh Starter Study Path',
+            studyPathDashboardKey: `${STARTER_STUDY_PATH_ID}-lesson-2`,
+            studyPathDashboardName:
+              'AquaMesh Starter 2 - Practice Interactivity',
+            studyPathDashboardIndex: 2,
+            studyPathDashboardCount: 3,
+            studyPathFolderName: STARTER_STUDY_PATH_FOLDER_NAME,
+          },
+        },
+      ],
+    },
+    {
+      name: 'AquaMesh Starter 3 - Build Your Own',
+      key: `${STARTER_STUDY_PATH_ID}-lesson-3`,
+      components: [
+        {
+          id: 'starter-path-3-title',
+          type: 'Label',
+          props: {
+            text: 'Create your own Study Path next',
+            variant: 'h4',
+            fontWeight: 800,
+            gutterBottom: true,
+          },
+        },
+        {
+          id: 'starter-path-3-steps',
+          type: 'ListBlock',
+          props: {
+            __blockType: 'ListBlock',
+            title: 'Next steps',
+            items:
+              'Open the Study Path creator from the top bar.\nPaste notes, a topic, or a learning prompt.\nGenerate a multi-lesson course and refine it in Library / Manage.',
+            ordered: true,
+            interactiveChecklist: true,
+          },
+        },
+        {
+          id: 'starter-path-3-progress',
+          type: 'StudyPathProgressBlock',
+          props: {
+            studyPathId: STARTER_STUDY_PATH_ID,
+            studyPathTitle: 'AquaMesh Starter Study Path',
+            studyPathDashboardKey: `${STARTER_STUDY_PATH_ID}-lesson-3`,
+            studyPathDashboardName: 'AquaMesh Starter 3 - Build Your Own',
+            studyPathDashboardIndex: 3,
+            studyPathDashboardCount: 3,
+            studyPathFolderName: STARTER_STUDY_PATH_FOLDER_NAME,
+          },
+        },
+      ],
+    },
+  ]
+
+  starterStudyPathDashboards.forEach((dashboard, index) => {
+    saveStarterDashboard({
+      name: dashboard.name,
+      folder: STARTER_STUDY_PATH_FOLDER_NAME,
+      folderColor: '#007C66',
+      layout: createStarterStudyPathLayout({
+        dashboardName: dashboard.name,
+        dashboardKey: dashboard.key,
+        dashboardIndex: index + 1,
+        dashboardCount: starterStudyPathDashboards.length,
+        components: dashboard.components,
+      }),
+      description:
+        'A default guided Study Path that demonstrates the AquaMesh course experience.',
+      tags: ['study-pack', 'study-path', 'starter'],
+      isPublic: true,
+    })
+  })
 
   const mathWidgets = [
     saveTemplateWidget({

--- a/apps/aquamesh/src/studyPack/progress.ts
+++ b/apps/aquamesh/src/studyPack/progress.ts
@@ -314,6 +314,13 @@ const createReviewDashboard = (
             config: {
               customProps: {
                 widgetId: `${reviewDashboardId}-widget`,
+                studyPathId: path.pathId,
+                studyPathTitle: path.title,
+                studyPathDashboardKey: reviewDashboardId,
+                studyPathDashboardName: 'Review missed exercises',
+                studyPathDashboardIndex: path.dashboardCount + 1,
+                studyPathDashboardCount: path.dashboardCount + 1,
+                studyPathFolderName: path.folderName,
                 components,
               },
             },

--- a/apps/aquamesh/tests/unit/components/dashboard/Dashboard.test.tsx
+++ b/apps/aquamesh/tests/unit/components/dashboard/Dashboard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
 import Dashboards from '../../../../src/components/Dasboard/Dashboard'
 import * as DashboardProviderModule from '../../../../src/components/Dasboard/DashboardProvider'
 import * as WorkspaceActionsModule from '../../../../src/customHooks/useWorkspaceActions'
@@ -17,6 +17,7 @@ vi.mock('../../../../src/customHooks/useWorkspaceActions', () => ({
   OPEN_DASHBOARD_EDITOR_EVENT: 'aquamesh-open-dashboard-editor',
   OPEN_WIDGET_EDITOR_EVENT: 'aquamesh-open-widget-editor',
   OPEN_STUDY_PACK_EVENT: 'aquamesh-open-study-pack',
+  STARTER_STUDY_PATH_FOLDER_NAME: 'AquaMesh Starter Study Path',
   ensureStarterDashboards: vi.fn(),
   useWorkspaceActions: vi.fn(),
 }))
@@ -58,6 +59,48 @@ const openCreateDashboardMock = vi.fn()
 const openOperationsExampleMock = vi.fn()
 const openWidgetMenuMock = vi.fn()
 
+const createStarterStudyPathDashboard = (index: number) => ({
+  id: `starter-lesson-${index}`,
+  name: `AquaMesh Starter ${index}`,
+  folder: 'AquaMesh Starter Study Path',
+  layout: {
+    type: 'row',
+    children: [
+      {
+        type: 'tabset',
+        children: [
+          {
+            type: 'tab',
+            name: `AquaMesh Starter ${index}`,
+            component: 'CustomWidget',
+            config: {
+              customProps: {
+                components: [
+                  {
+                    id: `starter-progress-${index}`,
+                    type: 'StudyPathProgressBlock',
+                    props: {
+                      studyPathId: 'aquamesh-starter-study-path',
+                      studyPathTitle: 'AquaMesh Starter Study Path',
+                      studyPathDashboardKey: `starter-${index}`,
+                      studyPathDashboardName: `AquaMesh Starter ${index}`,
+                      studyPathDashboardIndex: index,
+                      studyPathDashboardCount: 2,
+                      studyPathFolderName: 'AquaMesh Starter Study Path',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+  createdAt: `2026-05-15T10:0${index}:00.000Z`,
+  updatedAt: `2026-05-15T10:0${index}:00.000Z`,
+})
+
 const mockPhoneViewport = () => {
   vi.mocked(window.matchMedia).mockImplementation((query) => ({
     matches: query.includes('max-width'),
@@ -89,6 +132,12 @@ const mockDashboardProvider = (
     setSelectedDashboard: vi.fn(),
     removeDashboard: vi.fn(),
     addDashboard: vi.fn(),
+    addDashboards: vi.fn(),
+    addStudyPathContainer: vi.fn(),
+    updateStudyPathContainer: vi.fn(),
+    closeAllDashboards: vi.fn(),
+    closeDashboardsToRight: vi.fn(),
+    reorderDashboard: vi.fn(),
     replaceDashboard: vi.fn(),
     updateLayout: vi.fn(),
     updateDashboardLayout: vi.fn(),
@@ -184,6 +233,50 @@ describe('Dashboards', () => {
     expect(navigateMock).not.toHaveBeenCalled()
   })
 
+  it('opens the default starter Study Path on first empty workspace load', async () => {
+    const addStudyPathContainer = vi.fn()
+    const starterDashboards = [
+      createStarterStudyPathDashboard(1),
+      createStarterStudyPathDashboard(2),
+    ]
+
+    localStorage.getItem.mockImplementation((key: string) => {
+      if (key === 'userData') {
+        return JSON.stringify({
+          id: 'admin',
+          name: 'Admin User',
+          role: 'ADMIN_ROLE',
+        })
+      }
+
+      if (key === 'customDashboards') {
+        return JSON.stringify(starterDashboards)
+      }
+
+      return null
+    })
+
+    mockDashboardProvider({ addStudyPathContainer })
+
+    render(<Dashboards />)
+
+    await waitFor(() => expect(addStudyPathContainer).toHaveBeenCalled())
+    expect(addStudyPathContainer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathId: 'aquamesh-starter-study-path',
+        title: 'AquaMesh Starter Study Path',
+        dashboards: expect.arrayContaining([
+          expect.objectContaining({ name: 'AquaMesh Starter 1' }),
+          expect.objectContaining({ name: 'AquaMesh Starter 2' }),
+        ]),
+      }),
+    )
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'aquamesh-default-study-path-opened-v1',
+      'true',
+    )
+  })
+
   it('keeps Create Dashboard builder actions reachable on phones', () => {
     mockPhoneViewport()
     mockDashboardProvider({
@@ -205,6 +298,117 @@ describe('Dashboards', () => {
     expect(
       screen.getByRole('button', { name: /close dashboard editor/i }),
     ).toBeInTheDocument()
+  })
+
+  it('adds generated Study Path review dashboards to the open Course navigator', () => {
+    const addDashboard = vi.fn()
+    const setSelectedDashboard = vi.fn()
+    const updateStudyPathContainer = vi.fn()
+    const reviewLayout = {
+      type: 'row',
+      children: [
+        {
+          type: 'tabset',
+          children: [
+            {
+              type: 'tab',
+              name: 'Review missed exercises',
+              component: 'CustomWidget',
+              config: {
+                customProps: {
+                  studyPathId: 'french-b1',
+                  studyPathTitle: 'French B1',
+                  studyPathDashboardKey: 'study-path-review-french-b1',
+                  studyPathDashboardName: 'Review missed exercises',
+                  studyPathDashboardIndex: 6,
+                  studyPathDashboardCount: 6,
+                  studyPathFolderName: 'French B1',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    mockDashboardProvider({
+      addDashboard,
+      setSelectedDashboard,
+      updateStudyPathContainer,
+      openDashboards: [
+        {
+          id: 'study-path-tab',
+          name: 'French B1',
+          kind: 'studyPathContainer',
+          studyPath: {
+            pathId: 'french-b1',
+            title: 'French B1',
+            folderName: 'French B1',
+            selectedIndex: 4,
+            dashboards: [1, 2, 3, 4, 5].map((index) => ({
+              id: `lesson-${index}`,
+              name: `Lesson ${index}`,
+              layout: { type: 'row', children: [] },
+              dashboardKey: `french-b1-${index}`,
+              dashboardIndex: index,
+              dashboardCount: 5,
+              folderName: 'French B1',
+            })),
+          },
+        },
+      ],
+      selectedDashboard: 0,
+    })
+
+    render(<Dashboards />)
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('aquamesh-open-study-path-review-dashboard', {
+          detail: {
+            dashboard: {
+              id: 'study-path-review-french-b1',
+              name: 'French B1 - Review missed exercises',
+              layout: reviewLayout,
+              createdAt: '2026-05-15T00:00:00.000Z',
+              updatedAt: '2026-05-15T00:00:00.000Z',
+            },
+          },
+        }),
+      )
+    })
+
+    expect(addDashboard).not.toHaveBeenCalled()
+    expect(setSelectedDashboard).toHaveBeenCalledWith(0)
+    expect(updateStudyPathContainer).toHaveBeenCalledWith(
+      'study-path-tab',
+      expect.any(Function),
+    )
+
+    const updater = updateStudyPathContainer.mock.calls[0][1]
+    const updatedStudyPath = updater({
+      pathId: 'french-b1',
+      title: 'French B1',
+      folderName: 'French B1',
+      selectedIndex: 4,
+      dashboards: [1, 2, 3, 4, 5].map((index) => ({
+        id: `lesson-${index}`,
+        name: `Lesson ${index}`,
+        layout: { type: 'row', children: [] },
+        dashboardKey: `french-b1-${index}`,
+        dashboardIndex: index,
+        dashboardCount: 5,
+        folderName: 'French B1',
+      })),
+    })
+
+    expect(updatedStudyPath.selectedIndex).toBe(5)
+    expect(updatedStudyPath.dashboards).toHaveLength(6)
+    expect(updatedStudyPath.dashboards[5]).toMatchObject({
+      dashboardKey: 'study-path-review-french-b1',
+      name: 'French B1 - Review missed exercises',
+      dashboardIndex: 6,
+    })
   })
 
   it('disables Update in Create Dashboard when the saved dashboard has no changes', () => {

--- a/apps/aquamesh/tests/unit/dashboard/studyPathUx.test.tsx
+++ b/apps/aquamesh/tests/unit/dashboard/studyPathUx.test.tsx
@@ -223,7 +223,6 @@ describe('Interactive Study Path UX', () => {
     })
     expect(screen.getByTestId('study-path-dashboard-content')).toHaveStyle({
       overflow: 'visible',
-      boxSizing: 'border-box',
     })
 
     const overlay = screen.getByTestId('study-path-navigator-overlay')

--- a/apps/aquamesh/tests/unit/dashboard/studyPathUx.test.tsx
+++ b/apps/aquamesh/tests/unit/dashboard/studyPathUx.test.tsx
@@ -1,0 +1,322 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import DashboardOptionsMenu from '../../../src/components/Dasboard/DashboardOptionsMenu'
+import DashboardProvider, {
+  useDashboards,
+} from '../../../src/components/Dasboard/DashboardProvider'
+import StudyPathWorkspaceView from '../../../src/components/Dasboard/StudyPathWorkspaceView'
+import {
+  DashboardLayout,
+  StudyPathContainerState,
+} from '../../../src/state/store'
+import { useStore } from '../../../src/state/store'
+
+vi.mock('../../../src/customHooks/useWorkspaceActions', () => ({
+  ensureStarterDashboards: vi.fn(),
+  OPEN_SAVED_DASHBOARDS_EVENT: 'aquamesh-open-saved-dashboards',
+}))
+
+vi.mock('../../../src/components/onboarding/onboardingEvents', () => ({
+  dispatchWorkspaceOnboardingEvent: vi.fn(),
+}))
+
+vi.mock('../../../src/components/Layout/Layout', () => ({
+  default: ({ layout }: { layout?: DashboardLayout }) => (
+    <div data-testid="mock-dashboard-layout">
+      <div data-testid="mock-selected-widget-border">
+        Selected widget border
+      </div>
+      <span>{layout?.name}</span>
+    </div>
+  ),
+}))
+
+const createMemoryStorage = () => {
+  const store = new Map<string, string>()
+  vi.mocked(localStorage.getItem).mockImplementation((key: string) =>
+    store.has(key) ? store.get(key)! : null,
+  )
+  vi.mocked(localStorage.setItem).mockImplementation(
+    (key: string, value: string) => {
+      store.set(key, value)
+    },
+  )
+  vi.mocked(localStorage.removeItem).mockImplementation((key: string) => {
+    store.delete(key)
+  })
+  vi.mocked(localStorage.clear).mockImplementation(() => {
+    store.clear()
+  })
+  return store
+}
+
+const createLessonLayout = (index: number): DashboardLayout => ({
+  type: 'row',
+  name: `Lesson ${index}`,
+  children: [
+    {
+      type: 'tabset',
+      children: [
+        {
+          type: 'tab',
+          name: `Lesson ${index}`,
+          component: 'CustomWidget',
+          config: {
+            customProps: {
+              components: [
+                {
+                  id: `progress-${index}`,
+                  type: 'StudyProgress',
+                  props: {
+                    studyPathId: 'german-b1-grammar',
+                    studyPathTitle: 'German B1 Grammar',
+                    studyPathDashboardKey: `german-b1-grammar-${index}`,
+                    studyPathDashboardName: `Lesson ${index}`,
+                    studyPathDashboardIndex: index,
+                    studyPathDashboardCount: 5,
+                    studyPathFolderName: 'German B1 Grammar',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  ],
+})
+
+const createStudyPath = (): StudyPathContainerState => ({
+  pathId: 'german-b1-grammar',
+  title: 'German B1 Grammar',
+  folderName: 'German B1 Grammar',
+  selectedIndex: 0,
+  dashboards: Array.from({ length: 5 }, (_, lessonIndex) => ({
+    id: `lesson-${lessonIndex + 1}`,
+    name: `Lesson ${lessonIndex + 1}`,
+    layout: createLessonLayout(lessonIndex + 1),
+    dashboardKey: `german-b1-grammar-${lessonIndex + 1}`,
+    dashboardIndex: lessonIndex + 1,
+    dashboardCount: 5,
+    folderName: 'German B1 Grammar',
+  })),
+  pinnedDashboardKeys: [],
+})
+
+const seedStudyPathDashboards = (storage: Map<string, string>) => {
+  const dashboards = createStudyPath().dashboards.map((lesson, index) => ({
+    id: lesson.id,
+    name: lesson.name,
+    folder: 'German B1 Grammar',
+    folderColor: '#007C66',
+    layout: lesson.layout,
+    tags: ['study-pack'],
+    isPublic: true,
+    createdAt: `2026-05-15T10:0${index}:00.000Z`,
+    updatedAt: `2026-05-15T10:0${index}:00.000Z`,
+  }))
+
+  storage.set('customDashboards', JSON.stringify(dashboards))
+}
+
+const StateProbe = () => {
+  const {
+    openDashboards,
+    selectedDashboard,
+    addStudyPathContainer,
+    updateStudyPathContainer,
+  } = useDashboards()
+  const selected = openDashboards[selectedDashboard]
+
+  return (
+    <div>
+      <button onClick={() => addStudyPathContainer(createStudyPath())}>
+        open-study-path
+      </button>
+      <button
+        onClick={() => {
+          const studyPathDashboard = openDashboards.find(
+            (dashboard) => dashboard.kind === 'studyPathContainer',
+          )
+          if (studyPathDashboard?.studyPath) {
+            updateStudyPathContainer(studyPathDashboard.id, (studyPath) => ({
+              ...studyPath,
+              selectedIndex: 3,
+            }))
+          }
+        }}
+      >
+        go-lesson-4
+      </button>
+      <output data-testid="dashboard-count">{openDashboards.length}</output>
+      <output data-testid="selected-kind">
+        {selected?.kind || 'dashboard'}
+      </output>
+      <output data-testid="selected-lesson">
+        {selected?.studyPath?.selectedIndex ?? 'none'}
+      </output>
+      <output data-testid="dashboard-names">
+        {openDashboards.map((dashboard) => dashboard.name).join('|')}
+      </output>
+    </div>
+  )
+}
+
+const renderWithDashboardProvider = (ui: React.ReactNode) =>
+  render(<DashboardProvider>{ui}</DashboardProvider>)
+
+describe('Interactive Study Path UX', () => {
+  beforeEach(() => {
+    createMemoryStorage()
+    useStore.setState({
+      selectedDashboard: 0,
+      openDashboards: [
+        {
+          id: 'existing-dashboard',
+          name: 'Existing dashboard',
+          layout: createLessonLayout(99),
+        },
+      ],
+    })
+  })
+
+  it('opens a multi-lesson Study Path as one top-level tab and internal navigation does not add tabs', () => {
+    renderWithDashboardProvider(<StateProbe />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'open-study-path' }))
+
+    expect(screen.getByTestId('dashboard-count')).toHaveTextContent('2')
+    expect(screen.getByTestId('selected-kind')).toHaveTextContent(
+      'studyPathContainer',
+    )
+    expect(screen.getByTestId('selected-lesson')).toHaveTextContent('0')
+
+    fireEvent.click(screen.getByRole('button', { name: 'go-lesson-4' }))
+
+    expect(screen.getByTestId('dashboard-count')).toHaveTextContent('2')
+    expect(screen.getByTestId('selected-lesson')).toHaveTextContent('3')
+  })
+
+  it('uses a subtle floating navigator that overlays the dashboard and can be collapsed', () => {
+    const onStudyPathChange = vi.fn()
+
+    render(
+      <StudyPathWorkspaceView
+        studyPath={createStudyPath()}
+        onStudyPathChange={onStudyPathChange}
+      />,
+    )
+
+    expect(screen.getByTestId('mock-dashboard-layout')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('mock-selected-widget-border'),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('study-path-navigator-pill')).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('study-path-navigator-panel'),
+    ).not.toBeInTheDocument()
+
+    expect(screen.getByTestId('study-path-workspace')).toHaveStyle({
+      overflow: 'visible',
+    })
+    expect(screen.getByTestId('study-path-dashboard-content')).toHaveStyle({
+      overflow: 'visible',
+      boxSizing: 'border-box',
+    })
+
+    const overlay = screen.getByTestId('study-path-navigator-overlay')
+    expect(overlay).toHaveStyle({ pointerEvents: 'none' })
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /open course navigator/i }),
+    )
+
+    expect(screen.getByTestId('study-path-navigator-panel')).toBeInTheDocument()
+    expect(screen.getByText('Course helper')).toBeInTheDocument()
+    expect(screen.getByText('0/5 completed')).toBeInTheDocument()
+    expect(screen.getByText('Lesson 1/5')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('mock-selected-widget-border'),
+    ).toBeInTheDocument()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /collapse course navigator/i }),
+    )
+
+    expect(
+      screen.queryByTestId('study-path-navigator-panel'),
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId('study-path-navigator-pill')).toBeInTheDocument()
+  })
+
+  it('keeps Study Paths dropdown actions focused and preserves standalone lesson opening', async () => {
+    const storage = createMemoryStorage()
+    seedStudyPathDashboards(storage)
+
+    renderWithDashboardProvider(
+      <>
+        <DashboardOptionsMenu />
+        <StateProbe />
+      </>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /study paths/i }))
+
+    expect(await screen.findByText('German B1 Grammar')).toBeInTheDocument()
+    expect(screen.getByText('5 lessons')).toBeInTheDocument()
+    expect(
+      screen.getByLabelText('Manage German B1 Grammar in Library'),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByLabelText(/Study Path actions/i),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Lesson actions/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Open all dashboards/i)).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Expand German B1 Grammar lessons'))
+
+    expect(await screen.findByText('01 Lesson 1')).toBeInTheDocument()
+    expect(
+      screen.getByLabelText('Open Lesson 1 in new tab'),
+    ).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Lesson actions/i)).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('German B1 Grammar'))
+    expect(screen.getByTestId('dashboard-count')).toHaveTextContent('2')
+    expect(screen.getByTestId('selected-kind')).toHaveTextContent(
+      'studyPathContainer',
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /study paths/i }))
+    const expandForNavigation = screen.queryByLabelText(
+      'Expand German B1 Grammar lessons',
+    )
+    if (expandForNavigation) {
+      fireEvent.click(expandForNavigation)
+    }
+    fireEvent.click(await screen.findByText('03 Lesson 3'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-count')).toHaveTextContent('2')
+      expect(screen.getByTestId('selected-lesson')).toHaveTextContent('2')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /study paths/i }))
+    const expandForStandalone = screen.queryByLabelText(
+      'Expand German B1 Grammar lessons',
+    )
+    if (expandForStandalone) {
+      fireEvent.click(expandForStandalone)
+    }
+    fireEvent.click(await screen.findByLabelText('Open Lesson 2 in new tab'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-count')).toHaveTextContent('3')
+      expect(screen.getByTestId('dashboard-names')).toHaveTextContent(
+        'Existing dashboard|German B1 Grammar|Lesson 2',
+      )
+    })
+  })
+})

--- a/apps/aquamesh/tests/unit/studyPack/studyPathProgress.test.ts
+++ b/apps/aquamesh/tests/unit/studyPack/studyPathProgress.test.ts
@@ -78,6 +78,17 @@ describe('study path progress', () => {
       folder: 'French B1',
       tags: ['study-pack', 'study-path', 'review-mistakes'],
     })
+    expect(
+      dashboards[0].layout.children[0].children[0].config.customProps,
+    ).toMatchObject({
+      studyPathId: 'french-b1',
+      studyPathTitle: 'French B1',
+      studyPathDashboardKey: 'study-path-review-french-b1',
+      studyPathDashboardName: 'Review missed exercises',
+      studyPathDashboardIndex: 8,
+      studyPathDashboardCount: 8,
+      studyPathFolderName: 'French B1',
+    })
     expect(JSON.stringify(dashboards[0].layout)).toContain(
       'When is the subjunctive used?',
     )


### PR DESCRIPTION
## Summary
- replace the fixed Study Path sidebar with a subtle floating Course Navigator pill and overlay drawer
- remove the Study Path dashboard wrapper so the dashboard keeps normal layout/pointer behavior
- simplify Study Paths dropdown actions: parent manage pen only, lesson row navigation plus standalone-open icon
- make the Course helper overlay more compact on phones with a narrower panel, smaller typography, tighter spacing, and hidden dock controls
- keep the selected FlexLayout tabset indicator visible by drawing the active border inside the tabset instead of relying on an outward outline that can be clipped by the React Tabs panel
- keep generated “review missed exercises” dashboards inside the active Study Path container/Course Navigator instead of opening them as separate top-level React Tabs
- seed and open an AquaMesh Starter Study Path by default on first empty workspace load
- add regression tests for one-tab Study Path behavior, internal lesson navigation, standalone lesson opening, dropdown menu cleanup, navigator overlay behavior, review-dashboard insertion, and default starter Study Path opening

## Try it now
- Vercel preview: https://aqua-mesh-git-pichikachu-study-pat-e116c8-cosmevaleras-projects.vercel.app

## Verification
- npx vitest --run --config ./vitest.config.ts tests/unit/studyPack/studyPathProgress.test.ts tests/unit/components/dashboard/Dashboard.test.tsx tests/unit/dashboard/studyPathUx.test.tsx
- npm --workspace apps/aquamesh run build

## Notes
- Stacked on #32 / `pichikachu/study-path-container-nav` because the Interactive Study Path base PR is still unmerged.
- Targeted Study Path UX/review tests pass.
- Full `npm --workspace apps/aquamesh run test:unit` still has pre-existing unrelated failures in `Login.test.tsx`, `accentColors.test.ts`, and `ThemeModeContext.test.tsx`; the new Study Path UX tests pass inside that run.
- Build passes with existing warnings: missing `./.env`, outdated Browserslist data, Sass deprecation warnings, and asset size warnings.

