### PR TITLE
StudyMesh: add mobile dashboard view

### DIFF
--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -512,6 +512,7 @@ const DashboardEmptyState = ({
 const Dashboards = () => {
   const theme = useTheme()
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'))
+  const isMobileDashboardView = useMediaQuery('(max-width:768px)')
   const {
     openDashboards,
     selectedDashboard,
@@ -1562,14 +1563,16 @@ const Dashboards = () => {
       <Tabs
         className={`react-tabs ${
           selectedDashboardIsEmpty ? 'react-tabs--empty-selected' : ''
-        }`.trim()}
+        } ${isMobileDashboardView ? 'react-tabs--mobile-dashboard' : ''}`.trim()}
         selectedIndex={selectedDashboard}
         onSelect={(index) => setSelectedDashboard(index)}
         style={{ position: 'relative' }}
       >
         <TabList
-          onDragOver={allowDashboardTabListDrop}
-          onDrop={dropDashboardTabAtEnd}
+          onDragOver={
+            isMobileDashboardView ? undefined : allowDashboardTabListDrop
+          }
+          onDrop={isMobileDashboardView ? undefined : dropDashboardTabAtEnd}
         >
           {openDashboards.map((dashboard, index) => {
             const isOnlyEmptyDashboard =
@@ -1580,13 +1583,20 @@ const Dashboards = () => {
             return (
               <Tab
                 key={dashboard.id}
-                draggable
-                onDragStart={(event) => startDashboardTabDrag(event, index)}
+                draggable={!isMobileDashboardView}
+                onDragStart={(event) =>
+                  !isMobileDashboardView && startDashboardTabDrag(event, index)
+                }
                 onDragOver={(event) => {
+                  if (isMobileDashboardView) {
+                    return
+                  }
                   event.preventDefault()
                   event.dataTransfer.dropEffect = 'move'
                 }}
-                onDrop={(event) => dropDashboardTab(event, index)}
+                onDrop={(event) =>
+                  !isMobileDashboardView && dropDashboardTab(event, index)
+                }
                 onDragEnd={() => setDraggedDashboardIndex(null)}
                 onContextMenu={(event) => openDashboardTabMenu(event, index)}
               >
@@ -1610,7 +1620,8 @@ const Dashboards = () => {
                   </Typography>
                 </TooltipStyled>
                 <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                  {isAdmin &&
+                  {!isMobileDashboardView &&
+                    isAdmin &&
                     dashboard.layout?.children &&
                     dashboard.layout.children.length > 0 && (
                       <TooltipStyled title="Edit Dashboard">
@@ -1709,7 +1720,8 @@ const Dashboards = () => {
                 sx={{
                   display: 'flex',
                   flexDirection: 'column',
-                  height: '100%',
+                  height: isMobileDashboardView ? 'auto' : '100%',
+                  minHeight: isMobileDashboardView ? '100dvh' : undefined,
                   backgroundColor: 'background.default',
                 }}
               >
@@ -1727,6 +1739,7 @@ const Dashboards = () => {
                       onStudyPathChange={(studyPath) =>
                         updateStudyPathContainer(dashboard.id, () => studyPath)
                       }
+                      mobileView={isMobileDashboardView}
                     />
                   ) : isEmptyDashboard ? (
                     <DashboardEmptyState
@@ -1741,6 +1754,8 @@ const Dashboards = () => {
                   ) : (
                     <DashboardLayoutView
                       layout={dashboard.layout}
+                      mobileView={isMobileDashboardView}
+                      readOnly={isMobileDashboardView}
                       updateLayout={(model) => {
                         updateLayout(model)
                         // Mark this dashboard as having changes after layout update

--- a/apps/studymesh/src/components/Dasboard/StudyPathWorkspaceView.tsx
+++ b/apps/studymesh/src/components/Dasboard/StudyPathWorkspaceView.tsx
@@ -38,6 +38,7 @@ type NavigatorDock = 'left' | 'right'
 interface StudyPathWorkspaceViewProps {
   studyPath: StudyPathContainerState
   onStudyPathChange: (studyPath: StudyPathContainerState) => void
+  mobileView?: boolean
 }
 
 const getProgressForLesson = (
@@ -131,6 +132,7 @@ const sanitizeStudentLayout = (
 const StudyPathWorkspaceView: React.FC<StudyPathWorkspaceViewProps> = ({
   studyPath,
   onStudyPathChange,
+  mobileView = false,
 }) => {
   const [navigatorOpen, setNavigatorOpen] = useState(false)
   const [navigatorDock, setNavigatorDock] = useState<NavigatorDock>('right')
@@ -272,6 +274,7 @@ const StudyPathWorkspaceView: React.FC<StudyPathWorkspaceViewProps> = ({
           key={currentLesson.dashboardKey}
           layout={studentLayout}
           readOnly
+          mobileView={mobileView}
           updateLayout={(model) => updateCurrentLayout(model.toJson().layout)}
         />
       </Box>
@@ -619,11 +622,7 @@ const StudyPathWorkspaceView: React.FC<StudyPathWorkspaceViewProps> = ({
                 </Button>
               </Stack>
 
-              <Stack
-                direction="row"
-                spacing={0.75}
-                sx={{ display: 'flex' }}
-              >
+              <Stack direction="row" spacing={0.75} sx={{ display: 'flex' }}>
                 <Button
                   size="small"
                   variant={navigatorDock === 'left' ? 'contained' : 'text'}

--- a/apps/studymesh/src/components/Dasboard/tabs.scss
+++ b/apps/studymesh/src/components/Dasboard/tabs.scss
@@ -113,3 +113,37 @@
     }
   }
 }
+
+.react-tabs--mobile-dashboard {
+  margin: -48px 0 0 0;
+  background-color: var(--background-default, #f4f7f8);
+
+  .react-tabs__tab-list {
+    align-items: center;
+    gap: 8px;
+    padding: 0 12px 8px;
+    scroll-snap-type: x proximity;
+  }
+
+  .react-tabs__tab {
+    width: auto;
+    min-width: min(72vw, 260px);
+    max-width: 82vw;
+    border: 1px solid var(--surface-border, var(--other-divider));
+    border-radius: 999px;
+    padding: 8px 10px 8px 12px;
+    scroll-snap-align: start;
+    box-shadow: none !important;
+  }
+
+  .react-tabs__tab--selected {
+    background: var(--primary-main, #00a878) !important;
+    color: var(--primary-contrast-text, #fff) !important;
+  }
+
+  .react-tabs__tab-panel {
+    height: auto;
+    min-height: calc(100dvh - 96px);
+    overflow: visible;
+  }
+}

--- a/apps/studymesh/src/components/Layout/Layout.tsx
+++ b/apps/studymesh/src/components/Layout/Layout.tsx
@@ -22,6 +22,38 @@ interface DashboardLayoutViewProps {
   layout?: DashboardLayout
   updateLayout: (model: Model) => void
   readOnly?: boolean
+  mobileView?: boolean
+}
+
+interface MobileWidgetNode {
+  id: string
+  name: string
+  component: string
+  customProps?: Record<string, unknown>
+}
+
+const collectMobileWidgetNodes = (
+  node: DashboardLayout | undefined,
+  path: string[] = [],
+): MobileWidgetNode[] => {
+  if (!node) {
+    return []
+  }
+
+  if (node.component) {
+    return [
+      {
+        id: node.id || path.join('-') || node.name || node.component,
+        name: node.name || node.component,
+        component: node.component,
+        customProps: node.config?.customProps,
+      },
+    ]
+  }
+
+  return (node.children || []).flatMap((child, index) =>
+    collectMobileWidgetNodes(child, [...path, String(index)]),
+  )
 }
 
 const CONFIG = {
@@ -54,6 +86,7 @@ const DashboardLayoutView: React.FC<DashboardLayoutViewProps> = ({
   layout,
   updateLayout,
   readOnly = false,
+  mobileView = false,
 }) => {
   const { ref } = useLayout()
 
@@ -96,6 +129,37 @@ const DashboardLayoutView: React.FC<DashboardLayoutViewProps> = ({
     })
     return Model.fromJson(config)
   }, [layout, readOnly])
+
+  const mobileWidgets = useMemo(
+    () => collectMobileWidgetNodes(layout),
+    [layout],
+  )
+
+  if (mobileView) {
+    return (
+      <div className="studymesh-mobile-dashboard-layout">
+        {mobileWidgets.length === 0 ? (
+          <div className="studymesh-mobile-dashboard-empty">
+            <EmptyWidget />
+          </div>
+        ) : (
+          mobileWidgets.map((widget) => (
+            <section key={widget.id} className="studymesh-mobile-widget-card">
+              <DynamicMicrofrontend
+                name={widget.name}
+                component={widget.component}
+                width={
+                  typeof window !== 'undefined' ? window.innerWidth - 32 : 360
+                }
+                height={0}
+                customProps={widget.customProps}
+              />
+            </section>
+          ))
+        )}
+      </div>
+    )
+  }
 
   return (
     <div

--- a/apps/studymesh/src/components/Layout/layout.scss
+++ b/apps/studymesh/src/components/Layout/layout.scss
@@ -63,7 +63,7 @@
   }
 
   &:has(.flexlayout__tabset-selected) {
-     outline: 2px solid var(--primary-main);
+    outline: 2px solid var(--primary-main);
     outline-offset: 0px;
   }
 }
@@ -231,5 +231,34 @@
   visibility: visible;
   svg {
     color: var(--foreground-primary);
+  }
+}
+
+.studymesh-mobile-dashboard-layout {
+  width: 100%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 12px;
+  overflow: visible;
+}
+
+.studymesh-mobile-widget-card {
+  width: 100%;
+  min-width: 0;
+  overflow: visible;
+}
+
+.studymesh-mobile-dashboard-empty {
+  min-height: 220px;
+  border-radius: 16px;
+  background: var(--surface-card, #fff);
+}
+
+@media (max-width: 768px) {
+  .studymesh-mobile-widget-card > * {
+    width: 100% !important;
+    max-width: 100% !important;
   }
 }


### PR DESCRIPTION
## Summary\n- Add a mobile-only dashboard rendering path that stacks widgets full-width instead of squeezing FlexLayout panels\n- Keep desktop/tablet FlexLayout behavior unchanged, including drag/resize controls\n- Disable dashboard tab dragging/edit controls in the mobile dashboard selector\n- Pass mobile view mode through Study Path lessons so lesson dashboards stack cleanly on phones\n\n## Validation\n- NODE_OPTIONS=--max-old-space-size=1536 npm run build --workspace studymesh\n