### PR TITLE
Improve study material side panel flows

### DIFF
--- a/apps/studymesh/src/components/WidgetEditor/components/dialogs/SettingsDialog.tsx
+++ b/apps/studymesh/src/components/WidgetEditor/components/dialogs/SettingsDialog.tsx
@@ -17,8 +17,6 @@ import {
   Alert,
   LinearProgress,
   Checkbox,
-  Avatar,
-  Stack,
 } from '@mui/material'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
@@ -35,7 +33,6 @@ import DashboardIcon from '@mui/icons-material/Dashboard'
 import SearchIcon from '@mui/icons-material/Search'
 import ReplayIcon from '@mui/icons-material/Replay'
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome'
-import PhotoCameraIcon from '@mui/icons-material/PhotoCamera'
 
 import {
   STUDYMESH_ONBOARDING_RESET_EVENT,
@@ -50,11 +47,6 @@ import {
   testLocalLanguageModel,
 } from '../../../../studyPack/ai'
 import { seedStudyMeshGuideStudyPath } from '../../../../studyPack/studyMeshGuideSeed'
-import {
-  readUserAvatar,
-  removeUserAvatar,
-  saveUserAvatar,
-} from '../../../../userProfile'
 
 const WORKSPACE_ONBOARDING_KEY = 'studymesh-workspace-onboarding-v1'
 const LOCAL_AI_ESTIMATE_COPY =
@@ -67,49 +59,6 @@ const aiProviderLabels: Record<StudyPackAiProvider, string> = {
 }
 const normalizeExportFolderName = (folder?: unknown) =>
   typeof folder === 'string' && folder.trim() ? folder.trim() : 'Default'
-
-const readCurrentUserData = () => {
-  try {
-    const storedUserData = localStorage.getItem('userData')
-    return storedUserData
-      ? JSON.parse(storedUserData)
-      : { id: 'admin', name: 'Admin', role: 'ADMIN_ROLE' }
-  } catch (error) {
-    console.error('Failed to read user data', error)
-    return { id: 'admin', name: 'Admin', role: 'ADMIN_ROLE' }
-  }
-}
-
-const createSquareAvatarDataUrl = (file: File) =>
-  new Promise<string>((resolve, reject) => {
-    const objectUrl = URL.createObjectURL(file)
-    const image = new Image()
-
-    image.onload = () => {
-      const size = Math.min(image.naturalWidth, image.naturalHeight)
-      const sourceX = (image.naturalWidth - size) / 2
-      const sourceY = (image.naturalHeight - size) / 2
-      const canvas = document.createElement('canvas')
-      const context = canvas.getContext('2d')
-
-      URL.revokeObjectURL(objectUrl)
-
-      if (!context) {
-        reject(new Error('Could not prepare profile picture.'))
-        return
-      }
-
-      canvas.width = 256
-      canvas.height = 256
-      context.drawImage(image, sourceX, sourceY, size, size, 0, 0, 256, 256)
-      resolve(canvas.toDataURL('image/png'))
-    }
-    image.onerror = () => {
-      URL.revokeObjectURL(objectUrl)
-      reject(new Error('Could not read profile picture.'))
-    }
-    image.src = objectUrl
-  })
 
 interface ExportDashboardItem {
   dashboard: unknown
@@ -248,11 +197,6 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
   const [selectedExportIndexes, setSelectedExportIndexes] = React.useState<
     Set<number>
   >(new Set())
-  const [profileUser, setProfileUser] = React.useState(readCurrentUserData)
-  const [profileAvatar, setProfileAvatar] = React.useState(() =>
-    readUserAvatar(readCurrentUserData().id),
-  )
-  const [profileAvatarStatus, setProfileAvatarStatus] = React.useState('')
   const hasEnvToken = Boolean(getEnvGeminiApiKey())
 
   const exportDashboardGroups = React.useMemo<ExportDashboardGroup[]>(() => {
@@ -268,8 +212,8 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
         typeof record.name === 'string' && record.name.trim()
           ? record.name.trim()
           : typeof record.title === 'string' && record.title.trim()
-          ? record.title.trim()
-          : `Dashboard ${index + 1}`
+            ? record.title.trim()
+            : `Dashboard ${index + 1}`
       const items = groups.get(folderName) || []
 
       items.push({ dashboard, index, folderName, name })
@@ -292,11 +236,6 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
     }
 
     const settings = readStudyPackAiSettings()
-    const currentUser = readCurrentUserData()
-
-    setProfileUser(currentUser)
-    setProfileAvatar(readUserAvatar(currentUser.id))
-    setProfileAvatarStatus('')
     setAiProvider(settings.provider || 'basic')
     setAiApiToken(settings.apiToken)
     setAiModel(settings.model)
@@ -365,42 +304,6 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
       apiToken: '',
       model: aiModel,
     })
-  }
-
-  const handleProfileAvatarUpload = async (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
-    const file = event.target.files?.[0]
-    event.target.value = ''
-
-    if (!file) {
-      return
-    }
-
-    if (!['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) {
-      setProfileAvatarStatus('Use a PNG, JPG, or WebP image.')
-      return
-    }
-
-    try {
-      setProfileAvatarStatus('Preparing profile picture...')
-      const avatarDataUrl = await createSquareAvatarDataUrl(file)
-      saveUserAvatar(profileUser.id, avatarDataUrl)
-      setProfileAvatar(avatarDataUrl)
-      setProfileAvatarStatus('Profile picture updated.')
-    } catch (error) {
-      setProfileAvatarStatus(
-        error instanceof Error
-          ? error.message
-          : 'Could not update profile picture.',
-      )
-    }
-  }
-
-  const handleRemoveProfileAvatar = () => {
-    removeUserAvatar(profileUser.id)
-    setProfileAvatar('')
-    setProfileAvatarStatus('Profile picture removed.')
   }
 
   const handleTestLocalAi = async () => {
@@ -638,89 +541,6 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
               }}
             >
               <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
-                <PhotoCameraIcon sx={{ mr: 1.5, color: 'primary.main' }} />
-                <Box sx={{ minWidth: 0, flex: 1 }}>
-                  <Typography fontWeight="medium" color="text.primary">
-                    Profile Picture
-                  </Typography>
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    sx={{ mb: 1.5 }}
-                  >
-                    Customize the avatar shown in the workspace navigation.
-                  </Typography>
-                  <Stack
-                    direction={{ xs: 'column', sm: 'row' }}
-                    spacing={1.5}
-                    alignItems={{ xs: 'flex-start', sm: 'center' }}
-                  >
-                    <Avatar
-                      src={profileAvatar || undefined}
-                      sx={{
-                        width: 56,
-                        height: 56,
-                        bgcolor: 'primary.main',
-                        fontWeight: 800,
-                      }}
-                    >
-                      {String(profileUser.id || 'ad')
-                        .substring(0, 2)
-                        .toUpperCase()}
-                    </Avatar>
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        gap: 1,
-                        alignItems: 'center',
-                        flexWrap: 'wrap',
-                      }}
-                    >
-                      <Button component="label" variant="outlined" size="small">
-                        Upload picture
-                        <input
-                          hidden
-                          type="file"
-                          accept="image/png,image/jpeg,image/webp"
-                          onChange={handleProfileAvatarUpload}
-                        />
-                      </Button>
-                      <Button
-                        variant="outlined"
-                        size="small"
-                        startIcon={<DeleteOutlineIcon />}
-                        onClick={handleRemoveProfileAvatar}
-                        disabled={!profileAvatar}
-                      >
-                        Remove
-                      </Button>
-                    </Box>
-                  </Stack>
-                  {profileAvatarStatus && (
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      sx={{ display: 'block', mt: 1 }}
-                    >
-                      {profileAvatarStatus}
-                    </Typography>
-                  )}
-                </Box>
-              </Box>
-            </Paper>
-          )}
-
-          {showGlobalSettings && (
-            <Paper
-              elevation={0}
-              sx={{
-                p: 2,
-                mb: 2,
-                bgcolor: 'background.default',
-                borderRadius: 2,
-              }}
-            >
-              <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
                 <AutoAwesomeIcon sx={{ mr: 1.5, color: 'primary.main' }} />
                 <Box sx={{ minWidth: 0, flex: 1 }}>
                   <Typography fontWeight="medium" color="text.primary">
@@ -827,8 +647,8 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({
                         aiApiToken.trim()
                           ? 'Settings key active'
                           : hasEnvToken
-                          ? '.env key available'
-                          : 'No key configured'
+                            ? '.env key available'
+                            : 'No key configured'
                       }
                       color={
                         aiApiToken.trim() || hasEnvToken ? 'primary' : 'default'

--- a/apps/studymesh/src/components/studyPack/CreateStudyPackModal.tsx
+++ b/apps/studymesh/src/components/studyPack/CreateStudyPackModal.tsx
@@ -1427,14 +1427,23 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                   placeholder={`# Derivatives\n\nDefinition:: A derivative measures instantaneous rate of change.\n\nQ: What is the power rule?\nA: d/dx x^n = nx^(n-1)`}
                 />
                 <Stack
-                  direction={{ xs: 'column', sm: 'row' }}
+                  direction={
+                    presentation === 'embedded'
+                      ? 'column'
+                      : { xs: 'column', sm: 'row' }
+                  }
                   spacing={1}
-                  alignItems={{ xs: 'stretch', sm: 'center' }}
+                  alignItems={
+                    presentation === 'embedded'
+                      ? 'stretch'
+                      : { xs: 'stretch', sm: 'center' }
+                  }
                 >
                   <Button
                     component="label"
                     variant="outlined"
                     startIcon={<UploadFileIcon />}
+                    fullWidth={presentation === 'embedded'}
                     sx={{ alignSelf: { sm: 'flex-start' } }}
                   >
                     Upload text files
@@ -1486,6 +1495,7 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                             elevation={0}
                             sx={{
                               width: 116,
+                              maxWidth: 116,
                               p: 0.75,
                               border: 1,
                               borderColor: 'divider',
@@ -1508,7 +1518,13 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                               variant="caption"
                               color="text.secondary"
                               noWrap
-                              sx={{ display: 'block', mt: 0.5 }}
+                              sx={{
+                                display: 'block',
+                                mt: 0.5,
+                                maxWidth: '100%',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                              }}
                             >
                               {preview.name}
                             </Typography>
@@ -1547,6 +1563,7 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                       component="label"
                       variant="outlined"
                       startIcon={<UploadFileIcon />}
+                      fullWidth={presentation === 'embedded'}
                     >
                       Select images
                       <input
@@ -1628,6 +1645,7 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                       variant="outlined"
                       startIcon={<UploadFileIcon />}
                       disabled={isExtractingDocument}
+                      fullWidth={presentation === 'embedded'}
                     >
                       Select PDFs
                       <input
@@ -1692,6 +1710,7 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                       variant="outlined"
                       startIcon={<UploadFileIcon />}
                       disabled={isExtractingDocument}
+                      fullWidth={presentation === 'embedded'}
                     >
                       Select PPTX files
                       <input

--- a/apps/studymesh/src/components/studyPack/CreateStudyPackModal.tsx
+++ b/apps/studymesh/src/components/studyPack/CreateStudyPackModal.tsx
@@ -941,18 +941,21 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
         } else if (aiProvider === 'local') {
           try {
             setOcrStatus('Extracting notes with Google Local AI')
-            text = await extractNotesFromImageWithLocalLanguageModel(imageFile, {
-              timeoutMs: 90 * 1000,
-              signal: extractionController.signal,
-              onProgress: (progress) => {
-                if (extractionController.signal.aborted) {
-                  return
-                }
+            text = await extractNotesFromImageWithLocalLanguageModel(
+              imageFile,
+              {
+                timeoutMs: 90 * 1000,
+                signal: extractionController.signal,
+                onProgress: (progress) => {
+                  if (extractionController.signal.aborted) {
+                    return
+                  }
 
-                setOcrProgress(progress)
-                setOcrStatus(`Downloading local model ${progress}%`)
+                  setOcrProgress(progress)
+                  setOcrStatus(`Downloading local model ${progress}%`)
+                },
               },
-            })
+            )
           } catch (error) {
             if (
               extractionController.signal.aborted ||
@@ -1324,8 +1327,8 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                 Create from notes
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                Paste notes or start from an image. StudyMesh will build a
-                ready-to-use dashboard.
+                Turn notes, images, PDFs, or slides into a clean study
+                dashboard.
               </Typography>
             </Box>
           </Stack>
@@ -1405,7 +1408,7 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                   onChange={(event) => setSourceText(event.target.value)}
                   fullWidth
                   multiline
-                  minRows={14}
+                  minRows={presentation === 'embedded' ? 8 : 14}
                   placeholder={`# Derivatives\n\nDefinition:: A derivative measures instantaneous rate of change.\n\nQ: What is the power rule?\nA: d/dx x^n = nx^(n-1)`}
                 />
                 <Stack
@@ -1748,7 +1751,8 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                     <>
                       <Stack direction="row" justifyContent="space-between">
                         <Typography variant="caption" color="text.secondary">
-                          Elapsed {formatGeminiDuration(geminiProgress.elapsedMs)}
+                          Elapsed{' '}
+                          {formatGeminiDuration(geminiProgress.elapsedMs)}
                         </Typography>
                         <Typography variant="caption" color="text.secondary">
                           {geminiProgress.percent}%
@@ -1886,7 +1890,9 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
           <Button
             variant="contained"
             onClick={parseCurrentSource}
-            disabled={isExtractingImage || isGeneratingAi || isExtractingDocument}
+            disabled={
+              isExtractingImage || isGeneratingAi || isExtractingDocument
+            }
           >
             {isGeneratingAi
               ? 'Creating...'

--- a/apps/studymesh/src/components/studyPack/CreateStudyPackModal.tsx
+++ b/apps/studymesh/src/components/studyPack/CreateStudyPackModal.tsx
@@ -317,14 +317,14 @@ const getSourceOptionTitle = (value: SourceInputType) => {
 const getSourceOptionDescription = (value: SourceInputType) => {
   switch (value) {
     case 'image':
-      return 'Upload screenshots, slides, or photos.'
+      return 'Screenshots or photos'
     case 'pdf':
-      return 'Extract selectable PDF text.'
+      return 'Selectable PDF text'
     case 'powerpoint':
-      return 'Extract PPTX slide text.'
+      return 'PPTX slide text'
     case 'text':
     default:
-      return 'Paste notes or upload text files.'
+      return 'Paste or upload files'
   }
 }
 
@@ -1351,7 +1351,7 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
         )}
 
         {step === 'source' ? (
-          <Stack spacing={2.5}>
+          <Stack spacing={presentation === 'embedded' ? 1.5 : 2.5}>
             <TextField
               label="Dashboard name"
               value={packTitle}
@@ -1359,7 +1359,16 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
               fullWidth
             />
 
-            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns:
+                  presentation === 'embedded'
+                    ? 'repeat(2, minmax(0, 1fr))'
+                    : { xs: '1fr', sm: 'repeat(4, minmax(0, 1fr))' },
+                gap: 1,
+              }}
+            >
               {sourceOptions.map((option) => {
                 const selected = sourceInputType === option.value
                 const Icon = getSourceOptionIcon(option.value)
@@ -1371,8 +1380,7 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                     onClick={() => handleSourceInputTypeChange(option.value)}
                     elevation={0}
                     sx={{
-                      flex: 1,
-                      p: 2,
+                      p: presentation === 'embedded' ? 1.25 : 1.5,
                       textAlign: 'left',
                       cursor: 'pointer',
                       border: 1,
@@ -1384,13 +1392,20 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                       '&:hover': { borderColor: 'primary.main' },
                     }}
                   >
-                    <Stack direction="row" spacing={1.25} alignItems="center">
-                      <Icon color={selected ? 'primary' : 'action'} />
-                      <Box>
-                        <Typography variant="subtitle2" fontWeight={900}>
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <Icon
+                        color={selected ? 'primary' : 'action'}
+                        fontSize="small"
+                      />
+                      <Box sx={{ minWidth: 0 }}>
+                        <Typography variant="subtitle2" fontWeight={900} noWrap>
                           {getSourceOptionTitle(option.value)}
                         </Typography>
-                        <Typography variant="body2" color="text.secondary">
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          noWrap
+                        >
                           {getSourceOptionDescription(option.value)}
                         </Typography>
                       </Box>
@@ -1398,7 +1413,7 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                   </Paper>
                 )
               })}
-            </Stack>
+            </Box>
 
             {sourceInputType === 'text' && (
               <Stack spacing={1.25}>

--- a/apps/studymesh/src/components/studyPack/CreateStudyPackModal.tsx
+++ b/apps/studymesh/src/components/studyPack/CreateStudyPackModal.tsx
@@ -1444,7 +1444,13 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                     variant="outlined"
                     startIcon={<UploadFileIcon />}
                     fullWidth={presentation === 'embedded'}
-                    sx={{ alignSelf: { sm: 'flex-start' } }}
+                    sx={{
+                      alignSelf:
+                        presentation === 'embedded'
+                          ? 'stretch'
+                          : { sm: 'flex-start' },
+                      width: presentation === 'embedded' ? '100%' : undefined,
+                    }}
                   >
                     Upload text files
                     <input
@@ -1496,11 +1502,13 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                             sx={{
                               width: 116,
                               maxWidth: 116,
+                              minWidth: 0,
                               p: 0.75,
                               border: 1,
                               borderColor: 'divider',
                               borderRadius: 1,
                               position: 'relative',
+                              overflow: 'hidden',
                             }}
                           >
                             <Box
@@ -1547,7 +1555,7 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                     ) : (
                       <ImageIcon color="primary" sx={{ fontSize: 48 }} />
                     )}
-                    <Box>
+                    <Box sx={{ width: '100%', minWidth: 0 }}>
                       <Typography variant="subtitle1" fontWeight={900}>
                         {imageFiles.length > 0
                           ? `${imageFiles.length} image${
@@ -1564,6 +1572,9 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                       variant="outlined"
                       startIcon={<UploadFileIcon />}
                       fullWidth={presentation === 'embedded'}
+                      sx={{
+                        width: presentation === 'embedded' ? '100%' : undefined,
+                      }}
                     >
                       Select images
                       <input
@@ -1632,7 +1643,7 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                 >
                   <Stack spacing={1.5} alignItems="center" textAlign="center">
                     <PictureAsPdfIcon color="primary" sx={{ fontSize: 48 }} />
-                    <Box>
+                    <Box sx={{ width: '100%', minWidth: 0 }}>
                       <Typography variant="subtitle1" fontWeight={900}>
                         Upload PDF notes
                       </Typography>
@@ -1646,6 +1657,9 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                       startIcon={<UploadFileIcon />}
                       disabled={isExtractingDocument}
                       fullWidth={presentation === 'embedded'}
+                      sx={{
+                        width: presentation === 'embedded' ? '100%' : undefined,
+                      }}
                     >
                       Select PDFs
                       <input
@@ -1697,7 +1711,7 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                 >
                   <Stack spacing={1.5} alignItems="center" textAlign="center">
                     <SlideshowIcon color="primary" sx={{ fontSize: 48 }} />
-                    <Box>
+                    <Box sx={{ width: '100%', minWidth: 0 }}>
                       <Typography variant="subtitle1" fontWeight={900}>
                         Upload PowerPoint notes
                       </Typography>
@@ -1711,6 +1725,9 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
                       startIcon={<UploadFileIcon />}
                       disabled={isExtractingDocument}
                       fullWidth={presentation === 'embedded'}
+                      sx={{
+                        width: presentation === 'embedded' ? '100%' : undefined,
+                      }}
                     >
                       Select PPTX files
                       <input

--- a/apps/studymesh/src/components/studyPack/CreateStudyPathModal.tsx
+++ b/apps/studymesh/src/components/studyPack/CreateStudyPathModal.tsx
@@ -10,7 +10,9 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  Divider,
   FormControlLabel,
+  IconButton,
   LinearProgress,
   MenuItem,
   Paper,
@@ -21,6 +23,7 @@ import {
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome'
 import RouteIcon from '@mui/icons-material/Route'
 import TuneIcon from '@mui/icons-material/Tune'
+import CloseIcon from '@mui/icons-material/Close'
 import {
   createStudyPackOrchestratorWidgets,
   StudyObject,
@@ -754,19 +757,50 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
 
   const content = (
     <>
-      <DialogTitle>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <RouteIcon color="primary" />
-          <Box>
-            <Typography variant="h6">Create Study Path</Typography>
-            <Typography variant="body2" color="text.secondary">
-              Generate several ordered Study Pack dashboards in one folder.
-            </Typography>
-          </Box>
+      <DialogTitle sx={{ pb: 1.5 }}>
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+          gap={2}
+        >
+          <Stack direction="row" spacing={1.5} alignItems="center" minWidth={0}>
+            <Box
+              sx={{
+                width: 40,
+                height: 40,
+                borderRadius: 2,
+                display: 'grid',
+                placeItems: 'center',
+                bgcolor: 'primary.main',
+                color: 'primary.contrastText',
+                flex: '0 0 auto',
+              }}
+            >
+              <RouteIcon />
+            </Box>
+            <Box sx={{ minWidth: 0 }}>
+              <Typography variant="h6" fontWeight={900} noWrap>
+                Create Study Path
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Build an ordered lesson path from one clear prompt.
+              </Typography>
+            </Box>
+          </Stack>
+          <IconButton
+            aria-label="Close Create Study Path"
+            onClick={handleClose}
+          >
+            <CloseIcon />
+          </IconButton>
         </Stack>
       </DialogTitle>
-      <DialogContent dividers>
-        <Stack spacing={2.5} sx={{ pt: 1 }}>
+      <Divider />
+      <DialogContent
+        sx={{ bgcolor: 'background.default', p: { xs: 2, md: 3 } }}
+      >
+        <Stack spacing={2}>
           {error && <Alert severity="error">{error}</Alert>}
           {step === 'prompt' ? (
             <>
@@ -786,7 +820,7 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
                     onChange={(event) => setPrompt(event.target.value)}
                     placeholder="Example: Teach me Spanish vocabulary level B2."
                     multiline
-                    minRows={5}
+                    minRows={presentation === 'embedded' ? 4 : 5}
                     fullWidth
                   />
                   <Stack
@@ -861,9 +895,8 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
                             setMustInclude(event.target.value)
                           }
                           placeholder="Example: include irregular verbs, common mistakes, exam-style examples..."
-                          helperText="Optional. StudyMesh will prioritize these in the planner."
                           multiline
-                          minRows={3}
+                          minRows={presentation === 'embedded' ? 2 : 3}
                           fullWidth
                         />
                         <TextField
@@ -873,9 +906,8 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
                             setAvoidTopics(event.target.value)
                           }
                           placeholder="Example: skip basic greetings, avoid beginner grammar, no PDF resources..."
-                          helperText="Optional. StudyMesh will avoid making these the focus when planning."
                           multiline
-                          minRows={3}
+                          minRows={presentation === 'embedded' ? 2 : 3}
                           fullWidth
                         />
                       </Stack>
@@ -883,10 +915,6 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
                   </Box>
                 </Stack>
               </Paper>
-              <Alert severity="info">
-                Study Path uses the AI provider selected in Settings. The next
-                screen previews each dashboard before saving anything.
-              </Alert>
               {aiProvider === 'local' && (
                 <Alert
                   severity={generationAmount === 'deep' ? 'error' : 'info'}
@@ -1173,7 +1201,6 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
                 label="Folder name"
                 value={reviewFolderName}
                 onChange={(event) => setReviewFolderName(event.target.value)}
-                helperText="The selected provider chose this folder for the generated dashboards. You can change it before creating the path."
                 fullWidth
               />
               <FormControlLabel
@@ -1227,7 +1254,9 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
                 ))}
               </Stack>
               {draft?.warnings.length ? (
-                <Alert severity="warning">{draft.warnings.join(' ')}</Alert>
+                <Alert severity="warning">
+                  {draft.warnings.slice(0, 2).join(' ')}
+                </Alert>
               ) : null}
               {debugTrace ? (
                 <Paper
@@ -1311,7 +1340,7 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
           )}
         </Stack>
       </DialogContent>
-      <DialogActions sx={{ flexShrink: 0 }}>
+      <DialogActions sx={{ p: 2, flexShrink: 0 }}>
         <Button onClick={handleClose}>Cancel</Button>
         {step === 'review' && (
           <Button onClick={() => setStep('prompt')}>Back</Button>
@@ -1359,7 +1388,19 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
   }
 
   return (
-    <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="md"
+      fullWidth
+      PaperProps={{
+        sx: {
+          bgcolor: 'background.paper',
+          borderRadius: 3,
+          minHeight: { xs: '100dvh', md: 620 },
+        },
+      }}
+    >
       {content}
     </Dialog>
   )

--- a/apps/studymesh/src/components/studyPack/CreateStudyPathModal.tsx
+++ b/apps/studymesh/src/components/studyPack/CreateStudyPathModal.tsx
@@ -114,6 +114,7 @@ const GEMINI_STUDY_PATH_ESTIMATES_MS: Record<
   average: 60 * 1000,
   deep: 90 * 1000,
 }
+const BASIC_FALLBACK_STUDY_PATH_DELAY_MS = 10 * 1000
 
 interface GeminiTimedProgress {
   startedAt: number
@@ -186,6 +187,25 @@ const makeGeminiTimedProgress = (
     ),
   }
 }
+
+const waitForBasicFallbackDelay = (signal: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'))
+      return
+    }
+
+    const timeoutId = window.setTimeout(
+      resolve,
+      BASIC_FALLBACK_STUDY_PATH_DELAY_MS,
+    )
+    const abortDelay = () => {
+      window.clearTimeout(timeoutId)
+      reject(new DOMException('Aborted', 'AbortError'))
+    }
+
+    signal.addEventListener('abort', abortDelay, { once: true })
+  })
 
 type LocalPipelineStep = NonNullable<
   LocalAiProgressEvent['studyPathPipeline']
@@ -607,6 +627,10 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
     setError('')
 
     try {
+      if (aiProvider === 'basic') {
+        await waitForBasicFallbackDelay(generationController.signal)
+      }
+
       const nextDraft = await generateStudyPathWithAi({
         provider: aiProvider,
         apiToken: credentials.apiToken,

--- a/apps/studymesh/src/components/studyPack/CreateStudyPathModal.tsx
+++ b/apps/studymesh/src/components/studyPack/CreateStudyPathModal.tsx
@@ -800,7 +800,7 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
       <DialogContent
         sx={{ bgcolor: 'background.default', p: { xs: 2, md: 3 } }}
       >
-        <Stack spacing={2}>
+        <Stack spacing={presentation === 'embedded' ? 1.5 : 2}>
           {error && <Alert severity="error">{error}</Alert>}
           {step === 'prompt' ? (
             <>
@@ -823,11 +823,7 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
                     minRows={presentation === 'embedded' ? 4 : 5}
                     fullWidth
                   />
-                  <Stack
-                    direction={{ xs: 'column', sm: 'row' }}
-                    spacing={2}
-                    alignItems={{ xs: 'stretch', sm: 'flex-start' }}
-                  >
+                  <Stack spacing={presentation === 'embedded' ? 1.25 : 2}>
                     <TextField
                       select
                       label="Path depth"
@@ -837,7 +833,13 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
                           event.target.value as GenerationAmount,
                         )
                       }
-                      sx={{ maxWidth: { xs: '100%', sm: 320 }, flex: 1 }}
+                      helperText={getGenerationAmountHelper(
+                        generationAmountOptions.find(
+                          (option) => option.value === generationAmount,
+                        ) || generationAmountOptions[0],
+                        aiProvider,
+                      )}
+                      fullWidth
                     >
                       {generationAmountOptions.map((option) => (
                         <MenuItem
@@ -847,8 +849,7 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
                             aiProvider === 'local' && option.value === 'deep'
                           }
                         >
-                          {option.label} -{' '}
-                          {getGenerationAmountHelper(option, aiProvider)}
+                          {option.label}
                         </MenuItem>
                       ))}
                     </TextField>

--- a/apps/studymesh/src/components/topnavbar/TopNavBar.tsx
+++ b/apps/studymesh/src/components/topnavbar/TopNavBar.tsx
@@ -569,7 +569,7 @@ const TopNavBar: React.FC<TopNavBarProps> = ({ creationHost = 'navbar' }) => {
               <ButtonWithLabel
                 icon={<RouteIcon />}
                 label="Create Study Path"
-                onClick={() => openCreateStudyPath()}
+                onClick={() => openCreateStudyPath({ toggle: true })}
                 disabled={!canCreateStudyPath}
                 title={
                   !isAdmin
@@ -588,7 +588,7 @@ const TopNavBar: React.FC<TopNavBarProps> = ({ creationHost = 'navbar' }) => {
               />
             ) : (
               <Button
-                onClick={() => openCreateStudyPath()}
+                onClick={() => openCreateStudyPath({ toggle: true })}
                 disabled={!canCreateStudyPath}
                 sx={{
                   color: 'foreground.contrastPrimary',
@@ -618,7 +618,7 @@ const TopNavBar: React.FC<TopNavBarProps> = ({ creationHost = 'navbar' }) => {
               <ButtonWithLabel
                 icon={<AutoStoriesIcon />}
                 label="Create From Notes"
-                onClick={() => openCreateStudyPack()}
+                onClick={() => openCreateStudyPack({ toggle: true })}
                 data-tutorial-id="create-study-pack-button"
                 disabled={!canCreateFromNotes}
                 title={
@@ -636,7 +636,7 @@ const TopNavBar: React.FC<TopNavBarProps> = ({ creationHost = 'navbar' }) => {
               />
             ) : (
               <Button
-                onClick={() => openCreateStudyPack()}
+                onClick={() => openCreateStudyPack({ toggle: true })}
                 disabled={!canCreateFromNotes}
                 sx={{
                   color: 'foreground.contrastPrimary',

--- a/apps/studymesh/src/components/topnavbar/TopNavBar.tsx
+++ b/apps/studymesh/src/components/topnavbar/TopNavBar.tsx
@@ -10,8 +10,13 @@ import {
   Divider,
   Avatar,
   Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   IconButton,
   ListItemIcon,
+  Stack,
+  TextField,
   useMediaQuery,
   useTheme,
 } from '@mui/material'
@@ -29,6 +34,9 @@ import CloseIcon from '@mui/icons-material/Close'
 import SettingsIcon from '@mui/icons-material/Settings'
 import SwitchAccountIcon from '@mui/icons-material/SwitchAccount'
 import RouteIcon from '@mui/icons-material/Route'
+import PersonIcon from '@mui/icons-material/Person'
+import PhotoCameraIcon from '@mui/icons-material/PhotoCamera'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 
 import AccentColorPicker from '../../theme/AccentColorPicker'
 import DashboardOptionsMenu from '../Dasboard/DashboardOptionsMenu'
@@ -52,7 +60,10 @@ import {
   StudyPackAiProvider,
 } from '../../studyPack/ai'
 import {
+  createSquareAvatarDataUrl,
   readUserAvatar,
+  removeUserAvatar,
+  saveUserAvatar,
   USER_PROFILE_AVATAR_CHANGED_EVENT,
 } from '../../userProfile'
 
@@ -195,6 +206,9 @@ const TopNavBar: React.FC<TopNavBarProps> = ({ creationHost = 'navbar' }) => {
   )
   const [isHelpOpen, setIsHelpOpen] = useState(false)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+  const [isUserSettingsOpen, setIsUserSettingsOpen] = useState(false)
+  const [userSettingsName, setUserSettingsName] = useState('')
+  const [userSettingsAvatarStatus, setUserSettingsAvatarStatus] = useState('')
   const [studyPackOpen, setStudyPackOpen] = useState(false)
   const [studyPathOpen, setStudyPathOpen] = useState(false)
   const [studyPackAiProvider, setStudyPackAiProvider] =
@@ -439,6 +453,63 @@ const TopNavBar: React.FC<TopNavBarProps> = ({ creationHost = 'navbar' }) => {
       new CustomEvent(USER_ROLE_CHANGED_EVENT, { detail: nextUser }),
     )
     handleClose()
+  }
+
+  const openUserSettings = () => {
+    setUserSettingsName(userData.name)
+    setUserSettingsAvatarStatus('')
+    setIsUserSettingsOpen(true)
+    handleClose()
+  }
+
+  const saveUserSettings = () => {
+    const nextUser = {
+      ...userData,
+      name: userSettingsName.trim() || userData.name,
+    }
+
+    localStorage.setItem('userData', JSON.stringify(nextUser))
+    setUserData(nextUser)
+    window.dispatchEvent(
+      new CustomEvent(USER_ROLE_CHANGED_EVENT, { detail: nextUser }),
+    )
+    setIsUserSettingsOpen(false)
+  }
+
+  const handleUserAvatarUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+
+    if (!file) {
+      return
+    }
+
+    if (!['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) {
+      setUserSettingsAvatarStatus('Use a PNG, JPG, or WebP image.')
+      return
+    }
+
+    try {
+      setUserSettingsAvatarStatus('Preparing profile picture...')
+      const avatarDataUrl = await createSquareAvatarDataUrl(file)
+      saveUserAvatar(userData.id, avatarDataUrl)
+      setAvatarSrc(avatarDataUrl)
+      setUserSettingsAvatarStatus('Profile picture updated.')
+    } catch (error) {
+      setUserSettingsAvatarStatus(
+        error instanceof Error
+          ? error.message
+          : 'Could not update profile picture.',
+      )
+    }
+  }
+
+  const handleRemoveUserAvatar = () => {
+    removeUserAvatar(userData.id)
+    setAvatarSrc('')
+    setUserSettingsAvatarStatus('Profile picture removed.')
   }
 
   return (
@@ -808,6 +879,19 @@ const TopNavBar: React.FC<TopNavBarProps> = ({ creationHost = 'navbar' }) => {
               </Box>
               <Divider sx={{ borderColor: 'divider' }} />
               <MenuItem
+                onClick={openUserSettings}
+                sx={{ color: 'text.primary' }}
+              >
+                <ListItemIcon>
+                  <PersonIcon
+                    fontSize="small"
+                    sx={{ color: 'text.secondary' }}
+                  />
+                </ListItemIcon>
+                User settings
+              </MenuItem>
+              <Divider sx={{ borderColor: 'divider' }} />
+              <MenuItem
                 onClick={() => {
                   setIsSettingsOpen(true)
                   handleClose()
@@ -875,6 +959,73 @@ const TopNavBar: React.FC<TopNavBarProps> = ({ creationHost = 'navbar' }) => {
         open={isHelpOpen}
         onClose={() => setIsHelpOpen(false)}
       />
+      <Dialog
+        open={isUserSettingsOpen}
+        onClose={() => setIsUserSettingsOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>User settings</DialogTitle>
+        <DialogContent dividers>
+          <Stack spacing={2} sx={{ pt: 1 }}>
+            <Stack direction="row" spacing={2} alignItems="center">
+              <Avatar
+                src={avatarSrc || undefined}
+                sx={{
+                  width: 64,
+                  height: 64,
+                  bgcolor: 'primary.main',
+                  fontWeight: 800,
+                }}
+              >
+                {userData.id.substring(0, 2).toUpperCase()}
+              </Avatar>
+              <Stack spacing={1} direction="row" useFlexGap flexWrap="wrap">
+                <Button
+                  component="label"
+                  variant="outlined"
+                  size="small"
+                  startIcon={<PhotoCameraIcon />}
+                >
+                  Upload image
+                  <input
+                    hidden
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp"
+                    onChange={handleUserAvatarUpload}
+                  />
+                </Button>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  startIcon={<DeleteOutlineIcon />}
+                  onClick={handleRemoveUserAvatar}
+                  disabled={!avatarSrc}
+                >
+                  Remove
+                </Button>
+              </Stack>
+            </Stack>
+            {userSettingsAvatarStatus && (
+              <Typography variant="caption" color="text.secondary">
+                {userSettingsAvatarStatus}
+              </Typography>
+            )}
+            <TextField
+              label="User name"
+              value={userSettingsName}
+              onChange={(event) => setUserSettingsName(event.target.value)}
+              fullWidth
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setIsUserSettingsOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={saveUserSettings}>
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
       <SettingsDialog
         open={isSettingsOpen}
         onClose={() => setIsSettingsOpen(false)}

--- a/apps/studymesh/src/components/topnavbar/TopNavBar.tsx
+++ b/apps/studymesh/src/components/topnavbar/TopNavBar.tsx
@@ -106,7 +106,7 @@ const isAdminUser = (userData: UserData) =>
 const canOpenStudyPathForCurrentState = (userData: UserData) => {
   const provider = readStudyPackAiSettings().provider || 'basic'
 
-  return isAdminUser(userData) && provider !== 'basic' && provider !== 'hosted'
+  return isAdminUser(userData) && provider !== 'hosted'
 }
 
 const canOpenStudyPackForCurrentState = (userData: UserData) => {
@@ -244,8 +244,7 @@ const TopNavBar: React.FC<TopNavBarProps> = ({ creationHost = 'navbar' }) => {
   const [avatarSrc, setAvatarSrc] = useState(() => readUserAvatar(adminUser.id))
   const isAdmin = isAdminUser(userData)
   const hostedAiUnavailable = studyPackAiProvider === 'hosted'
-  const canCreateStudyPath =
-    isAdmin && studyPackAiProvider !== 'basic' && !hostedAiUnavailable
+  const canCreateStudyPath = isAdmin && !hostedAiUnavailable
   const canCreateFromNotes = isAdmin && !hostedAiUnavailable
   const userModeLabel = isAdmin
     ? studyPackAiProviderLabels[studyPackAiProvider]
@@ -576,9 +575,7 @@ const TopNavBar: React.FC<TopNavBarProps> = ({ creationHost = 'navbar' }) => {
                     ? 'Viewer mode cannot create study paths'
                     : hostedAiUnavailable
                       ? 'Hosted AI tokens are not available yet'
-                      : studyPackAiProvider === 'basic'
-                        ? 'Create Study Path is disabled in Basic fallback mode'
-                        : 'Create Study Path'
+                      : 'Create Study Path'
                 }
                 sx={
                   !canCreateStudyPath
@@ -605,9 +602,7 @@ const TopNavBar: React.FC<TopNavBarProps> = ({ creationHost = 'navbar' }) => {
                     ? 'Viewer mode cannot create study paths'
                     : hostedAiUnavailable
                       ? 'Hosted AI tokens are not available yet'
-                      : studyPackAiProvider === 'basic'
-                        ? 'Create Study Path is disabled in Basic fallback mode'
-                        : 'Create Study Path'
+                      : 'Create Study Path'
                 }
               >
                 Create Study Path

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -158,8 +158,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     return {
       canCreateDashboard: isAdmin,
       canCreateFromNotes: isAdmin && provider !== 'hosted',
-      canCreateStudyPath:
-        isAdmin && provider !== 'basic' && provider !== 'hosted',
+      canCreateStudyPath: isAdmin && provider !== 'hosted',
       canCreateWidget: isAdmin,
     }
   }, [activeFlow])

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -165,7 +165,12 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
   }, [activeFlow])
 
   useEffect(() => {
-    const activateCreation = (flow: StudioFlow) => {
+    const activateCreation = (flow: StudioFlow, toggle = false) => {
+      if (toggle && isStudioOpen && activeFlow === flow) {
+        setIsStudioOpen(false)
+        return
+      }
+
       setActiveFlow(flow)
       setIsStudioOpen(true)
     }
@@ -193,14 +198,16 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       }
       dispatchWorkspaceOnboardingEvent({ type: 'widget-editor-opened' })
     }
-    const handleOpenStudyPack = () => {
+    const handleOpenStudyPack = (event: Event) => {
       if (permissions.canCreateFromNotes) {
-        activateCreation('from-notes')
+        const customEvent = event as CustomEvent<{ toggle?: boolean }>
+        activateCreation('from-notes', Boolean(customEvent.detail?.toggle))
       }
     }
-    const handleOpenStudyPath = () => {
+    const handleOpenStudyPath = (event: Event) => {
       if (permissions.canCreateStudyPath) {
-        activateCreation('study-path')
+        const customEvent = event as CustomEvent<{ toggle?: boolean }>
+        activateCreation('study-path', Boolean(customEvent.detail?.toggle))
       }
     }
     const handleOpenDashboard = () => {
@@ -226,9 +233,18 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       )
       window.removeEventListener(OPEN_STUDY_PACK_EVENT, handleOpenStudyPack)
       window.removeEventListener(OPEN_STUDY_PATH_EVENT, handleOpenStudyPath)
-      window.removeEventListener(OPEN_DASHBOARD_EDITOR_EVENT, handleOpenDashboard)
+      window.removeEventListener(
+        OPEN_DASHBOARD_EDITOR_EVENT,
+        handleOpenDashboard,
+      )
     }
-  }, [isPinned, permissions.canCreateFromNotes, permissions.canCreateStudyPath])
+  }, [
+    activeFlow,
+    isPinned,
+    isStudioOpen,
+    permissions.canCreateFromNotes,
+    permissions.canCreateStudyPath,
+  ])
 
   useEffect(() => {
     try {
@@ -383,7 +399,6 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
           onCreatePack={createPackAndHandleComplete}
         />
       )}
-
     </Box>
   )
 
@@ -458,9 +473,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
   if (isMobile) {
     return (
       <Box sx={{ height: '100%', minHeight: 0, overflow: 'hidden' }}>
-        <Box sx={{ height: '100%', ...workspaceCanvasSx }}>
-          {children}
-        </Box>
+        <Box sx={{ height: '100%', ...workspaceCanvasSx }}>{children}</Box>
         <Drawer
           anchor="left"
           open={isStudioOpen}
@@ -508,9 +521,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
           {studioContent}
         </Box>
       )}
-      <Box sx={{ flex: 1, minWidth: 0, ...workspaceCanvasSx }}>
-        {children}
-      </Box>
+      <Box sx={{ flex: 1, minWidth: 0, ...workspaceCanvasSx }}>{children}</Box>
       {widgetBuilderDialog}
     </Box>
   )

--- a/apps/studymesh/src/customHooks/useWorkspaceActions.ts
+++ b/apps/studymesh/src/customHooks/useWorkspaceActions.ts
@@ -250,12 +250,16 @@ export const useWorkspaceActions = () => {
     )
   }, [])
 
-  const openCreateStudyPack = useCallback(() => {
-    window.dispatchEvent(new CustomEvent(OPEN_STUDY_PACK_EVENT))
+  const openCreateStudyPack = useCallback((options?: { toggle?: boolean }) => {
+    window.dispatchEvent(
+      new CustomEvent(OPEN_STUDY_PACK_EVENT, { detail: options }),
+    )
   }, [])
 
-  const openCreateStudyPath = useCallback(() => {
-    window.dispatchEvent(new CustomEvent(OPEN_STUDY_PATH_EVENT))
+  const openCreateStudyPath = useCallback((options?: { toggle?: boolean }) => {
+    window.dispatchEvent(
+      new CustomEvent(OPEN_STUDY_PATH_EVENT, { detail: options }),
+    )
   }, [])
 
   const createStudyPackDashboard = useCallback(

--- a/apps/studymesh/src/userProfile.ts
+++ b/apps/studymesh/src/userProfile.ts
@@ -38,3 +38,34 @@ export const removeUserAvatar = (userId: string) => {
     console.error('Failed to remove user avatar', error)
   }
 }
+
+export const createSquareAvatarDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const objectUrl = URL.createObjectURL(file)
+    const image = new Image()
+
+    image.onload = () => {
+      const size = Math.min(image.naturalWidth, image.naturalHeight)
+      const sourceX = (image.naturalWidth - size) / 2
+      const sourceY = (image.naturalHeight - size) / 2
+      const canvas = document.createElement('canvas')
+      const context = canvas.getContext('2d')
+
+      URL.revokeObjectURL(objectUrl)
+
+      if (!context) {
+        reject(new Error('Could not prepare profile picture.'))
+        return
+      }
+
+      canvas.width = 256
+      canvas.height = 256
+      context.drawImage(image, sourceX, sourceY, size, size, 0, 0, 256, 256)
+      resolve(canvas.toDataURL('image/png'))
+    }
+    image.onerror = () => {
+      URL.revokeObjectURL(objectUrl)
+      reject(new Error('Could not read profile picture.'))
+    }
+    image.src = objectUrl
+  })


### PR DESCRIPTION
## Summary
- Align Create Study Path with the Create Study Material side-panel presentation
- Trim wordy helper text and nonessential alerts in the path flow
- Tighten embedded Create from notes copy and reduce text-area height for the lateral panel

## Verification
- npm run lint -- --filter=studymesh (turbo found no lint task)
- npm --workspace apps/studymesh run build (blocked: existing dependency resolution errors for jszip, pdfjs-dist, zod; plus existing Sass deprecation warnings)
- npm --workspace apps/studymesh exec tsc -- --noEmit --pretty false (blocked by existing project TS errors outside these changed sections)