### PR TITLE
Polish workspace studio integration

### DIFF
--- a/apps/studymesh/src/components/studyPack/CreateStudyPackModal.tsx
+++ b/apps/studymesh/src/components/studyPack/CreateStudyPackModal.tsx
@@ -100,10 +100,7 @@ interface CreateStudyPackModalProps {
     layoutMode?: StudyPackDashboardLayoutMode
   }) => void
   presentation?: 'dialog' | 'embedded'
-  onStatusChange?: (
-    state: WorkspaceCreationTaskState,
-    message?: string,
-  ) => void
+  onStatusChange?: (state: WorkspaceCreationTaskState, message?: string) => void
 }
 
 const sourceOptions: Array<{
@@ -1386,6 +1383,17 @@ const CreateStudyPackModal: React.FC<CreateStudyPackModalProps> = ({
           <IconButton
             aria-label="Close Create from notes"
             onClick={handleClose}
+            sx={{
+              color: 'text.primary',
+              bgcolor: 'background.default',
+              border: 1,
+              borderColor: 'divider',
+              boxShadow: '0 1px 3px rgba(0,0,0,0.14)',
+              '&:hover': {
+                bgcolor: 'action.hover',
+                borderColor: 'text.secondary',
+              },
+            }}
           >
             <CloseIcon />
           </IconButton>

--- a/apps/studymesh/src/components/studyPack/CreateStudyPathModal.tsx
+++ b/apps/studymesh/src/components/studyPack/CreateStudyPathModal.tsx
@@ -66,10 +66,7 @@ interface CreateStudyPathModalProps {
     }>
   }) => void
   presentation?: 'dialog' | 'embedded'
-  onStatusChange?: (
-    state: WorkspaceCreationTaskState,
-    message?: string,
-  ) => void
+  onStatusChange?: (state: WorkspaceCreationTaskState, message?: string) => void
 }
 
 const generationAmountOptions: Array<{
@@ -867,6 +864,17 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
           <IconButton
             aria-label="Close Create Study Path"
             onClick={handleClose}
+            sx={{
+              color: 'text.primary',
+              bgcolor: 'background.default',
+              border: 1,
+              borderColor: 'divider',
+              boxShadow: '0 1px 3px rgba(0,0,0,0.14)',
+              '&:hover': {
+                bgcolor: 'action.hover',
+                borderColor: 'text.secondary',
+              },
+            }}
           >
             <CloseIcon />
           </IconButton>

--- a/apps/studymesh/src/components/topnavbar/TopNavBar.tsx
+++ b/apps/studymesh/src/components/topnavbar/TopNavBar.tsx
@@ -6,6 +6,7 @@ import {
   Toolbar,
   Typography,
   Button,
+  CircularProgress,
   Menu,
   MenuItem,
   Divider,
@@ -214,27 +215,69 @@ const getCreationStatusColor = (state: WorkspaceCreationTaskState) => {
   return 'transparent'
 }
 
+const getCreationStatusBackground = (state: WorkspaceCreationTaskState) => {
+  if (state === 'running') {
+    return 'warning.light'
+  }
+
+  if (state === 'complete') {
+    return 'success.light'
+  }
+
+  if (state === 'error') {
+    return 'error.light'
+  }
+
+  return 'transparent'
+}
+
 const CreationStatusDot = ({
   state,
 }: {
   state: WorkspaceCreationTaskState
-}) => (
-  <Box
-    component="span"
-    sx={{
-      display: 'inline-flex',
-      width: 9,
-      height: 9,
-      borderRadius: '50%',
-      border: 1,
-      borderColor:
-        state === 'idle' ? 'foreground.contrastPrimary' : 'background.header',
-      bgcolor: getCreationStatusColor(state),
-      opacity: state === 'idle' ? 0.55 : 1,
-      flex: '0 0 auto',
-    }}
-  />
-)
+}) => {
+  if (state === 'idle') {
+    return null
+  }
+
+  const isRunning = state === 'running'
+  const symbol = state === 'complete' ? '✓' : state === 'error' ? '!' : ''
+
+  return (
+    <Box
+      component="span"
+      sx={{
+        position: 'relative',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: 18,
+        height: 18,
+        borderRadius: '50%',
+        border: 1,
+        borderColor: 'rgba(255,255,255,0.9)',
+        bgcolor: getCreationStatusBackground(state),
+        color: getCreationStatusColor(state),
+        boxShadow:
+          '0 0 0 2px rgba(255,255,255,0.18), 0 4px 10px rgba(0,0,0,0.22)',
+        flex: '0 0 auto',
+        fontSize: 11,
+        fontWeight: 900,
+        lineHeight: 1,
+      }}
+    >
+      {isRunning ? (
+        <CircularProgress
+          size={14}
+          thickness={5}
+          sx={{ color: getCreationStatusColor(state) }}
+        />
+      ) : (
+        symbol
+      )}
+    </Box>
+  )
+}
 
 const CreationStatusLabel = ({
   label,
@@ -248,11 +291,13 @@ const CreationStatusLabel = ({
     sx={{
       display: 'inline-flex',
       alignItems: 'center',
-      gap: 0.75,
+      gap: 0.85,
       minWidth: 0,
     }}
   >
-    <Box component="span">{label}</Box>
+    <Box component="span" sx={{ minWidth: 0 }}>
+      {label}
+    </Box>
     <CreationStatusDot state={state} />
   </Box>
 )
@@ -649,27 +694,27 @@ const TopNavBar: React.FC<TopNavBarProps> = ({ creationHost = 'navbar' }) => {
     setUserSettingsAvatarStatus('Profile picture removed.')
   }
 
-  const reportStudyPathStatus = useCallback((
-    state: WorkspaceCreationTaskState,
-    message?: string,
-  ) => {
-    dispatchWorkspaceCreationStatus({
-      task: 'study-path',
-      state,
-      message,
-    })
-  }, [])
+  const reportStudyPathStatus = useCallback(
+    (state: WorkspaceCreationTaskState, message?: string) => {
+      dispatchWorkspaceCreationStatus({
+        task: 'study-path',
+        state,
+        message,
+      })
+    },
+    [],
+  )
 
-  const reportFromNotesStatus = useCallback((
-    state: WorkspaceCreationTaskState,
-    message?: string,
-  ) => {
-    dispatchWorkspaceCreationStatus({
-      task: 'from-notes',
-      state,
-      message,
-    })
-  }, [])
+  const reportFromNotesStatus = useCallback(
+    (state: WorkspaceCreationTaskState, message?: string) => {
+      dispatchWorkspaceCreationStatus({
+        task: 'from-notes',
+        state,
+        message,
+      })
+    },
+    [],
+  )
 
   return (
     <>

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -43,12 +43,11 @@ import {
 type StudioFlow = 'quick' | 'study-path' | 'from-notes'
 
 const PINNED_STORAGE_KEY = 'studymesh-workspace-studio-pinned-v1'
-const studioPanelWidth = 400
+const studioPanelWidth = 424
 const workspaceCanvasSx = {
   minHeight: 0,
   overflow: 'hidden',
-  px: '6px',
-  pb: '2px',
+  p: '8px',
   boxSizing: 'border-box',
 }
 
@@ -347,18 +346,18 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
-        bgcolor: 'background.default',
+        bgcolor: 'background.paper',
         overflow: 'hidden',
       }}
     >
       <Box
         sx={{
-          minHeight: 48,
+          minHeight: 54,
           flexShrink: 0,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
-          px: 1.5,
+          px: 1.75,
           borderBottom: 1,
           borderColor: 'divider',
           bgcolor: 'background.paper',
@@ -367,6 +366,9 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         <Box sx={{ minWidth: 0 }}>
           <Typography variant="subtitle1" fontWeight={800} noWrap>
             Create Study Material
+          </Typography>
+          <Typography variant="caption" color="text.secondary" noWrap>
+            Build study dashboards without leaving the workspace
           </Typography>
         </Box>
         <Stack direction="row" spacing={0.5}>
@@ -398,39 +400,39 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
           display: activeFlow === 'quick' ? 'block' : 'none',
         }}
       >
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            Start from a prompt, notes, or advanced manual builders.
-          </Typography>
-          <Stack spacing={1.25}>
-            <QuickAction
-              icon={<RouteIcon />}
-              title="Create Study Path"
-              description="Generate ordered tutorial dashboards."
-              onClick={openCreateStudyPath}
-              disabled={!permissions.canCreateStudyPath}
-            />
-            <QuickAction
-              icon={<AutoStoriesIcon />}
-              title="Create From Notes"
-              description="Turn notes, images, PDFs, or slides into study material."
-              onClick={openCreateStudyPack}
-              disabled={!permissions.canCreateFromNotes}
-            />
-            <QuickAction
-              icon={<DashboardCustomizeIcon />}
-              title="Create Dashboard"
-              description="Compose a reusable workspace."
-              onClick={openCreateDashboard}
-              disabled={!permissions.canCreateDashboard}
-            />
-            <QuickAction
-              icon={<ConstructionIcon />}
-              title="Create Widget"
-              description="Build a reusable study widget from blocks."
-              onClick={openCreateWidget}
-              disabled={!permissions.canCreateWidget}
-            />
-          </Stack>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Start from a prompt, notes, or advanced manual builders.
+        </Typography>
+        <Stack spacing={1.25}>
+          <QuickAction
+            icon={<RouteIcon />}
+            title="Create Study Path"
+            description="Generate ordered tutorial dashboards."
+            onClick={openCreateStudyPath}
+            disabled={!permissions.canCreateStudyPath}
+          />
+          <QuickAction
+            icon={<AutoStoriesIcon />}
+            title="Create From Notes"
+            description="Turn notes, images, PDFs, or slides into study material."
+            onClick={openCreateStudyPack}
+            disabled={!permissions.canCreateFromNotes}
+          />
+          <QuickAction
+            icon={<DashboardCustomizeIcon />}
+            title="Create Dashboard"
+            description="Compose a reusable workspace."
+            onClick={openCreateDashboard}
+            disabled={!permissions.canCreateDashboard}
+          />
+          <QuickAction
+            icon={<ConstructionIcon />}
+            title="Create Widget"
+            description="Build a reusable study widget from blocks."
+            onClick={openCreateWidget}
+            disabled={!permissions.canCreateWidget}
+          />
+        </Stack>
       </Box>
 
       <Box
@@ -575,19 +577,65 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       <Box
         aria-hidden={!isStudioOpen}
         sx={{
-          width: isStudioOpen ? studioPanelWidth : 0,
-          maxWidth: isStudioOpen ? '32vw' : 0,
-          minWidth: isStudioOpen ? 360 : 0,
+          width: isStudioOpen ? `clamp(380px, 31vw, ${studioPanelWidth}px)` : 0,
+          maxWidth: isStudioOpen
+            ? `clamp(380px, 31vw, ${studioPanelWidth}px)`
+            : 0,
+          minWidth: isStudioOpen ? 380 : 0,
           flex: '0 0 auto',
           minHeight: 0,
           overflow: 'hidden',
-          borderRight: isStudioOpen ? 1 : 0,
-          borderColor: 'divider',
+          p: isStudioOpen ? '8px 0 8px 8px' : 0,
+          boxSizing: 'border-box',
+          transition: theme.transitions.create(
+            ['width', 'max-width', 'min-width', 'padding'],
+            {
+              duration: theme.transitions.duration.shorter,
+              easing: theme.transitions.easing.easeInOut,
+            },
+          ),
         }}
       >
-        {studioContent}
+        <Box
+          sx={{
+            height: '100%',
+            overflow: 'hidden',
+            border: 1,
+            borderColor: 'divider',
+            borderRadius: 2.5,
+            boxShadow:
+              theme.palette.mode === 'dark'
+                ? '0 18px 40px rgba(0,0,0,0.42)'
+                : '0 18px 42px rgba(16,24,40,0.10)',
+          }}
+        >
+          {studioContent}
+        </Box>
       </Box>
-      <Box sx={{ flex: 1, minWidth: 0, ...workspaceCanvasSx }}>{children}</Box>
+      <Box
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          ...workspaceCanvasSx,
+          transition: theme.transitions.create('padding', {
+            duration: theme.transitions.duration.shorter,
+          }),
+        }}
+      >
+        <Box
+          sx={{
+            height: '100%',
+            minHeight: 0,
+            overflow: 'hidden',
+            borderRadius: 2,
+            bgcolor: 'background.paper',
+            border: 1,
+            borderColor: 'divider',
+          }}
+        >
+          {children}
+        </Box>
+      </Box>
       {widgetBuilderDialog}
     </Box>
   )

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -377,6 +377,17 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
               aria-label={isPinned ? 'Unpin Studio' : 'Pin Studio'}
               onClick={() => setIsPinned((current) => !current)}
               size="small"
+              sx={{
+                color: isPinned ? 'primary.main' : 'text.primary',
+                bgcolor: isPinned ? 'primary.50' : 'background.default',
+                border: 1,
+                borderColor: isPinned ? 'primary.main' : 'divider',
+                boxShadow: '0 1px 3px rgba(0,0,0,0.14)',
+                '&:hover': {
+                  bgcolor: isPinned ? 'primary.100' : 'action.hover',
+                  borderColor: isPinned ? 'primary.dark' : 'text.secondary',
+                },
+              }}
             >
               {isPinned ? <PushPinIcon /> : <PushPinOutlinedIcon />}
             </IconButton>
@@ -386,6 +397,17 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
               aria-label="Close Studio"
               onClick={closeStudio}
               size="small"
+              sx={{
+                color: 'text.primary',
+                bgcolor: 'background.default',
+                border: 1,
+                borderColor: 'divider',
+                boxShadow: '0 1px 3px rgba(0,0,0,0.14)',
+                '&:hover': {
+                  bgcolor: 'action.hover',
+                  borderColor: 'text.secondary',
+                },
+              }}
             >
               <CloseIcon />
             </IconButton>


### PR DESCRIPTION
## Summary
- Refine the lateral Create Study Material shell integration with the main workspace without changing the embedded flow content
- Add a card-like studio container with smoother width/padding transitions, rounded edges, and better workspace framing
- Polish top-navbar creation status badges with circular progress, success, and error states

## Verification
- git diff --check
- npm --workspace apps/studymesh exec tsc -- --noEmit --pretty false (blocked by existing repo TypeScript errors unrelated to these changes, including WidgetEditor, onboarding, missing zod/jszip/pdfjs-dist types)