### PR TITLE
Add Ask Sources dashboard chat panel

### DIFF
--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -8,6 +8,7 @@ import {
   DialogContent,
   DialogActions,
   Divider,
+  Drawer,
   TextField,
   IconButton,
   FormControlLabel,
@@ -37,12 +38,16 @@ import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser'
 import AutoStoriesIcon from '@mui/icons-material/AutoStories'
 import RouteIcon from '@mui/icons-material/Route'
 import CloudUploadIcon from '@mui/icons-material/CloudUpload'
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline'
 import DashboardLayoutView from '../Layout/Layout'
 import { useLayout } from '../Layout/LayoutProvider'
-import { DashboardLayout } from '../../state/store'
+import { DashboardLayout, StateDashboard } from '../../state/store'
 import { useDashboards } from './DashboardProvider'
 import SavedDashboardsDialog from './DashboardLibrary'
 import StudyPathWorkspaceView from './StudyPathWorkspaceView'
+import DashboardChatPanel, {
+  DashboardChatMessage,
+} from '../dashboardChat/DashboardChatPanel'
 import {
   createStudyPathContainerState,
   getStudyPathMetaFromLayout,
@@ -680,6 +685,10 @@ const Dashboards = () => {
   const [dashboardLibraryMode, setDashboardLibraryMode] = useState<
     'workspace' | 'builder'
   >('workspace')
+  const [dashboardChatOpen, setDashboardChatOpen] = useState(false)
+  const [dashboardChatMessages, setDashboardChatMessages] = useState<
+    Record<string, DashboardChatMessage[]>
+  >({})
   const [
     dashboardLibraryInitialSearchKey,
     setDashboardLibraryInitialSearchKey,
@@ -687,8 +696,9 @@ const Dashboards = () => {
   const dashboardEditorTitleCancelRef = useRef(false)
   const { addComponent } = useLayout()
   const { topNavBarWidgets } = useTopNavBarWidgets()
+  const currentDashboard = openDashboards[selectedDashboard]
   const selectedDashboardIsEmpty = !hasDashboardContent(
-    openDashboards[selectedDashboard]?.layout,
+    currentDashboard?.layout,
   )
   const dashboardEditorIndex = dashboardEditorId
     ? openDashboards.findIndex(
@@ -789,6 +799,20 @@ const Dashboards = () => {
 
   const openCreateFromNotes = () => {
     window.dispatchEvent(new CustomEvent(OPEN_STUDY_PACK_EVENT))
+  }
+
+  const updateDashboardChatMessages = (
+    dashboard: StateDashboard | undefined,
+    messages: DashboardChatMessage[],
+  ) => {
+    if (!dashboard) {
+      return
+    }
+
+    setDashboardChatMessages((current) => ({
+      ...current,
+      [dashboard.id]: messages,
+    }))
   }
 
   const loadSavedDashboardInBuilder = (dashboard: SavedDashboard) => {
@@ -1911,6 +1935,59 @@ const Dashboards = () => {
           )
         })}
       </Tabs>
+
+      <TooltipStyled title="Ask this dashboard">
+        <Button
+          variant="contained"
+          size={isMobileDashboardView ? 'small' : 'medium'}
+          startIcon={<ChatBubbleOutlineIcon sx={{ fontSize: 18 }} />}
+          onClick={() => setDashboardChatOpen(true)}
+          sx={{
+            position: 'absolute',
+            right: isMobileDashboardView ? 16 : 24,
+            bottom: isMobileDashboardView ? 18 : 24,
+            zIndex: 12,
+            borderRadius: 999,
+            px: isMobileDashboardView ? 1.25 : 1.75,
+            py: isMobileDashboardView ? 0.75 : 0.9,
+            minWidth: 'fit-content',
+            boxShadow:
+              theme.palette.mode === 'dark'
+                ? '0 12px 30px rgba(0,0,0,0.45)'
+                : '0 12px 28px rgba(16,24,40,0.16)',
+          }}
+        >
+          {isMobileDashboardView ? 'Ask' : 'Ask Sources'}
+        </Button>
+      </TooltipStyled>
+
+      <Drawer
+        anchor="right"
+        open={dashboardChatOpen}
+        onClose={() => setDashboardChatOpen(false)}
+        ModalProps={{ keepMounted: true }}
+        PaperProps={{
+          sx: {
+            width: isMobileDashboardView ? '100%' : 'min(440px, 38vw)',
+            maxWidth: '100%',
+            height: '100dvh',
+            bgcolor: 'background.paper',
+          },
+        }}
+      >
+        <DashboardChatPanel
+          dashboard={currentDashboard}
+          messages={
+            currentDashboard
+              ? dashboardChatMessages[currentDashboard.id] || []
+              : []
+          }
+          onMessagesChange={(messages) =>
+            updateDashboardChatMessages(currentDashboard, messages)
+          }
+          onClose={() => setDashboardChatOpen(false)}
+        />
+      </Drawer>
 
       <Menu
         open={dashboardTabMenu !== null}

--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -1736,10 +1736,10 @@ const Dashboards = () => {
   return (
     <Box
       sx={{
-        height: '100%',
-        minHeight: 0,
-        overflow: 'hidden',
-        display: 'flex',
+        height: isMobileDashboardView ? 'auto' : '100%',
+        minHeight: isMobileDashboardView ? '100dvh' : 0,
+        overflow: isMobileDashboardView ? 'visible' : 'hidden',
+        display: isMobileDashboardView ? 'block' : 'flex',
         bgcolor: 'background.default',
       }}
     >
@@ -1749,7 +1749,7 @@ const Dashboards = () => {
           flex: 1,
           minWidth: 0,
           minHeight: 0,
-          overflow: 'hidden',
+          overflow: isMobileDashboardView ? 'visible' : 'hidden',
         }}
       >
         <Tabs

--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -1720,274 +1720,328 @@ const Dashboards = () => {
     setDraggedDashboardIndex(null)
   }
 
+  const dashboardChatPanel = (
+    <DashboardChatPanel
+      dashboard={currentDashboard}
+      messages={
+        currentDashboard ? dashboardChatMessages[currentDashboard.id] || [] : []
+      }
+      onMessagesChange={(messages) =>
+        updateDashboardChatMessages(currentDashboard, messages)
+      }
+      onClose={() => setDashboardChatOpen(false)}
+    />
+  )
+
   return (
-    <Box sx={{ height: '100%', minHeight: 0, overflow: 'hidden' }}>
-      <Tabs
-        className={`react-tabs ${
-          selectedDashboardIsEmpty ? 'react-tabs--empty-selected' : ''
-        } ${isMobileDashboardView ? 'react-tabs--mobile-dashboard' : ''}`.trim()}
-        selectedIndex={selectedDashboard}
-        onSelect={(index) => setSelectedDashboard(index)}
-        style={{ position: 'relative' }}
-      >
-        <TabList
-          onDragOver={
-            isMobileDashboardView ? undefined : allowDashboardTabListDrop
-          }
-          onDrop={isMobileDashboardView ? undefined : dropDashboardTabAtEnd}
-        >
-          {openDashboards.map((dashboard, index) => {
-            const isOnlyEmptyDashboard =
-              openDashboards.length === 1 &&
-              dashboard.kind !== 'studyPathContainer' &&
-              !hasDashboardContent(dashboard.layout)
-
-            return (
-              <Tab
-                key={dashboard.id}
-                draggable={!isMobileDashboardView}
-                onDragStart={(event) =>
-                  !isMobileDashboardView && startDashboardTabDrag(event, index)
-                }
-                onDragOver={(event) => {
-                  if (isMobileDashboardView) {
-                    return
-                  }
-                  event.preventDefault()
-                  event.dataTransfer.dropEffect = 'move'
-                }}
-                onDrop={(event) =>
-                  !isMobileDashboardView && dropDashboardTab(event, index)
-                }
-                onDragEnd={() => setDraggedDashboardIndex(null)}
-                onContextMenu={(event) => openDashboardTabMenu(event, index)}
-              >
-                <TooltipStyled
-                  title={dashboard.name}
-                  placement="bottom"
-                  enterTouchDelay={1000}
-                >
-                  <Typography
-                    component="span"
-                    variant="subtitle2"
-                    sx={{
-                      flex: '1 0 0',
-                      whiteSpace: 'nowrap',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      marginLeft: '0.5rem',
-                    }}
-                  >
-                    {dashboard.name}
-                  </Typography>
-                </TooltipStyled>
-                <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                  {!isMobileDashboardView &&
-                    isAdmin &&
-                    dashboard.layout?.children &&
-                    dashboard.layout.children.length > 0 && (
-                      <TooltipStyled title="Edit Dashboard">
-                        <IconButton
-                          aria-label={`Edit dashboard ${dashboard.name}`}
-                          size="small"
-                          onClick={(ev) => {
-                            ev.stopPropagation()
-                            openDashboardEditor(dashboard.id)
-                          }}
-                          sx={{
-                            p: 0.5,
-                            mr: 0.5,
-                            color: 'text.secondary',
-                            '&:hover': { color: 'primary.main' },
-                          }}
-                        >
-                          <EditIcon sx={{ fontSize: 16 }} />
-                        </IconButton>
-                      </TooltipStyled>
-                    )}
-                  {!isOnlyEmptyDashboard && (
-                    <Box
-                      className="close"
-                      sx={{
-                        display: 'flex',
-                        p: 0.5,
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        borderRadius: '999px',
-                        transition: 'all .25s ease',
-                        '&:hover': {
-                          backgroundColor: 'action.contrastHover',
-                        },
-                      }}
-                    >
-                      <CloseIcon
-                        width={16}
-                        height={16}
-                        onClick={(ev) => {
-                          // NOTE prevent the tab being closed from being selected too!
-                          ev.stopPropagation()
-                          removeDashboard(dashboard.id)
-                        }}
-                      />
-                    </Box>
-                  )}
-                </Box>
-              </Tab>
-            )
-          })}
-          {isAdmin && (
-            <Button
-              size="small"
-              variant="text"
-              disableRipple
-              data-testid="add-dashboard-button"
-              sx={{
-                position: 'relative',
-                top: '3px',
-                marginBottom: '8px',
-                minWidth: 'fit-content',
-                display: 'flex',
-                alignItems: 'middle',
-                gap: '8px',
-                fontSize: '13px',
-                p: '4px 12px',
-                color: 'primary.light',
-                transition: 'all .25s ease',
-                '.MuiButton-startIcon': {
-                  transition: 'all .25s ease',
-                  m: 0,
-                  color: 'primary.light',
-                },
-                ':hover': {
-                  backgroundColor: 'transparent',
-                  color: 'primary.main',
-                  '.MuiButton-startIcon': {
-                    color: 'primary.main',
-                  },
-                },
-              }}
-              startIcon={<AddIcon width={16} height={16} />}
-              onClick={createEmptyDashboardTab}
-            />
-          )}
-        </TabList>
-        {openDashboards.map((dashboard, index) => {
-          const isStudyPathContainer =
-            dashboard.kind === 'studyPathContainer' && dashboard.studyPath
-          const isEmptyDashboard =
-            !isStudyPathContainer && !hasDashboardContent(dashboard.layout)
-          return (
-            <TabPanel key={dashboard.id}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  height: isMobileDashboardView ? 'auto' : '100%',
-                  minHeight: isMobileDashboardView ? '100dvh' : undefined,
-                  backgroundColor: 'background.default',
-                }}
-              >
-                <Box
-                  sx={{
-                    position: 'relative',
-                    flex: 1,
-                    minHeight: 0,
-                    overflow: 'visible',
-                  }}
-                >
-                  {isStudyPathContainer && dashboard.studyPath ? (
-                    <StudyPathWorkspaceView
-                      studyPath={dashboard.studyPath}
-                      onStudyPathChange={(studyPath) =>
-                        updateStudyPathContainer(dashboard.id, () => studyPath)
-                      }
-                      mobileView={isMobileDashboardView}
-                    />
-                  ) : isEmptyDashboard ? (
-                    <DashboardEmptyState
-                      isAdmin={isAdmin}
-                      hasDashboard
-                      onCreateStudyPath={openCreateStudyPath}
-                      onCreateFromNotes={openCreateFromNotes}
-                      onOpenSavedLibrary={openSavedLibraryFromEmptyState}
-                      dashboardOptions={visibleDashboardOptions}
-                      onOpenDashboard={openSavedDashboardInWorkspace}
-                      onOpenStudyGuide={openStudyGuideFromEmptyState}
-                    />
-                  ) : (
-                    <DashboardLayoutView
-                      layout={dashboard.layout}
-                      mobileView={isMobileDashboardView}
-                      readOnly={isMobileDashboardView}
-                      updateLayout={(model) => {
-                        updateLayout(model)
-                        // Mark this dashboard as having changes after layout update
-                        setHasChanges((prev) => ({
-                          ...prev,
-                          [selectedDashboard]: true,
-                        }))
-                      }}
-                    />
-                  )}
-                </Box>
-              </Box>
-            </TabPanel>
-          )
-        })}
-      </Tabs>
-
-      <TooltipStyled title="Ask this dashboard">
-        <Button
-          variant="contained"
-          size={isMobileDashboardView ? 'small' : 'medium'}
-          startIcon={<ChatBubbleOutlineIcon sx={{ fontSize: 18 }} />}
-          onClick={() => setDashboardChatOpen(true)}
-          sx={{
-            position: 'absolute',
-            right: isMobileDashboardView ? 16 : 24,
-            bottom: isMobileDashboardView ? 18 : 24,
-            zIndex: 12,
-            borderRadius: 999,
-            px: isMobileDashboardView ? 1.25 : 1.75,
-            py: isMobileDashboardView ? 0.75 : 0.9,
-            minWidth: 'fit-content',
-            boxShadow:
-              theme.palette.mode === 'dark'
-                ? '0 12px 30px rgba(0,0,0,0.45)'
-                : '0 12px 28px rgba(16,24,40,0.16)',
-          }}
-        >
-          {isMobileDashboardView ? 'Ask' : 'Ask Sources'}
-        </Button>
-      </TooltipStyled>
-
-      <Drawer
-        anchor="right"
-        open={dashboardChatOpen}
-        onClose={() => setDashboardChatOpen(false)}
-        ModalProps={{ keepMounted: true }}
-        PaperProps={{
-          sx: {
-            width: isMobileDashboardView ? '100%' : 'min(440px, 38vw)',
-            maxWidth: '100%',
-            height: '100dvh',
-            bgcolor: 'background.paper',
-          },
+    <Box
+      sx={{
+        height: '100%',
+        minHeight: 0,
+        overflow: 'hidden',
+        display: 'flex',
+        bgcolor: 'background.default',
+      }}
+    >
+      <Box
+        sx={{
+          position: 'relative',
+          flex: 1,
+          minWidth: 0,
+          minHeight: 0,
+          overflow: 'hidden',
         }}
       >
-        <DashboardChatPanel
-          dashboard={currentDashboard}
-          messages={
-            currentDashboard
-              ? dashboardChatMessages[currentDashboard.id] || []
-              : []
-          }
-          onMessagesChange={(messages) =>
-            updateDashboardChatMessages(currentDashboard, messages)
-          }
+        <Tabs
+          className={`react-tabs ${
+            selectedDashboardIsEmpty ? 'react-tabs--empty-selected' : ''
+          } ${
+            isMobileDashboardView ? 'react-tabs--mobile-dashboard' : ''
+          }`.trim()}
+          selectedIndex={selectedDashboard}
+          onSelect={(index) => setSelectedDashboard(index)}
+          style={{ position: 'relative' }}
+        >
+          <TabList
+            onDragOver={
+              isMobileDashboardView ? undefined : allowDashboardTabListDrop
+            }
+            onDrop={isMobileDashboardView ? undefined : dropDashboardTabAtEnd}
+          >
+            {openDashboards.map((dashboard, index) => {
+              const isOnlyEmptyDashboard =
+                openDashboards.length === 1 &&
+                dashboard.kind !== 'studyPathContainer' &&
+                !hasDashboardContent(dashboard.layout)
+
+              return (
+                <Tab
+                  key={dashboard.id}
+                  draggable={!isMobileDashboardView}
+                  onDragStart={(event) =>
+                    !isMobileDashboardView &&
+                    startDashboardTabDrag(event, index)
+                  }
+                  onDragOver={(event) => {
+                    if (isMobileDashboardView) {
+                      return
+                    }
+                    event.preventDefault()
+                    event.dataTransfer.dropEffect = 'move'
+                  }}
+                  onDrop={(event) =>
+                    !isMobileDashboardView && dropDashboardTab(event, index)
+                  }
+                  onDragEnd={() => setDraggedDashboardIndex(null)}
+                  onContextMenu={(event) => openDashboardTabMenu(event, index)}
+                >
+                  <TooltipStyled
+                    title={dashboard.name}
+                    placement="bottom"
+                    enterTouchDelay={1000}
+                  >
+                    <Typography
+                      component="span"
+                      variant="subtitle2"
+                      sx={{
+                        flex: '1 0 0',
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        marginLeft: '0.5rem',
+                      }}
+                    >
+                      {dashboard.name}
+                    </Typography>
+                  </TooltipStyled>
+                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    {!isMobileDashboardView &&
+                      isAdmin &&
+                      dashboard.layout?.children &&
+                      dashboard.layout.children.length > 0 && (
+                        <TooltipStyled title="Edit Dashboard">
+                          <IconButton
+                            aria-label={`Edit dashboard ${dashboard.name}`}
+                            size="small"
+                            onClick={(ev) => {
+                              ev.stopPropagation()
+                              openDashboardEditor(dashboard.id)
+                            }}
+                            sx={{
+                              p: 0.5,
+                              mr: 0.5,
+                              color: 'text.secondary',
+                              '&:hover': { color: 'primary.main' },
+                            }}
+                          >
+                            <EditIcon sx={{ fontSize: 16 }} />
+                          </IconButton>
+                        </TooltipStyled>
+                      )}
+                    {!isOnlyEmptyDashboard && (
+                      <Box
+                        className="close"
+                        sx={{
+                          display: 'flex',
+                          p: 0.5,
+                          justifyContent: 'center',
+                          alignItems: 'center',
+                          borderRadius: '999px',
+                          transition: 'all .25s ease',
+                          '&:hover': {
+                            backgroundColor: 'action.contrastHover',
+                          },
+                        }}
+                      >
+                        <CloseIcon
+                          width={16}
+                          height={16}
+                          onClick={(ev) => {
+                            // NOTE prevent the tab being closed from being selected too!
+                            ev.stopPropagation()
+                            removeDashboard(dashboard.id)
+                          }}
+                        />
+                      </Box>
+                    )}
+                  </Box>
+                </Tab>
+              )
+            })}
+            {isAdmin && (
+              <Button
+                size="small"
+                variant="text"
+                disableRipple
+                data-testid="add-dashboard-button"
+                sx={{
+                  position: 'relative',
+                  top: '3px',
+                  marginBottom: '8px',
+                  minWidth: 'fit-content',
+                  display: 'flex',
+                  alignItems: 'middle',
+                  gap: '8px',
+                  fontSize: '13px',
+                  p: '4px 12px',
+                  color: 'primary.light',
+                  transition: 'all .25s ease',
+                  '.MuiButton-startIcon': {
+                    transition: 'all .25s ease',
+                    m: 0,
+                    color: 'primary.light',
+                  },
+                  ':hover': {
+                    backgroundColor: 'transparent',
+                    color: 'primary.main',
+                    '.MuiButton-startIcon': {
+                      color: 'primary.main',
+                    },
+                  },
+                }}
+                startIcon={<AddIcon width={16} height={16} />}
+                onClick={createEmptyDashboardTab}
+              />
+            )}
+          </TabList>
+          {openDashboards.map((dashboard, index) => {
+            const isStudyPathContainer =
+              dashboard.kind === 'studyPathContainer' && dashboard.studyPath
+            const isEmptyDashboard =
+              !isStudyPathContainer && !hasDashboardContent(dashboard.layout)
+            return (
+              <TabPanel key={dashboard.id}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    height: isMobileDashboardView ? 'auto' : '100%',
+                    minHeight: isMobileDashboardView ? '100dvh' : undefined,
+                    backgroundColor: 'background.default',
+                  }}
+                >
+                  <Box
+                    sx={{
+                      position: 'relative',
+                      flex: 1,
+                      minHeight: 0,
+                      overflow: 'visible',
+                    }}
+                  >
+                    {isStudyPathContainer && dashboard.studyPath ? (
+                      <StudyPathWorkspaceView
+                        studyPath={dashboard.studyPath}
+                        onStudyPathChange={(studyPath) =>
+                          updateStudyPathContainer(
+                            dashboard.id,
+                            () => studyPath,
+                          )
+                        }
+                        mobileView={isMobileDashboardView}
+                      />
+                    ) : isEmptyDashboard ? (
+                      <DashboardEmptyState
+                        isAdmin={isAdmin}
+                        hasDashboard
+                        onCreateStudyPath={openCreateStudyPath}
+                        onCreateFromNotes={openCreateFromNotes}
+                        onOpenSavedLibrary={openSavedLibraryFromEmptyState}
+                        dashboardOptions={visibleDashboardOptions}
+                        onOpenDashboard={openSavedDashboardInWorkspace}
+                        onOpenStudyGuide={openStudyGuideFromEmptyState}
+                      />
+                    ) : (
+                      <DashboardLayoutView
+                        layout={dashboard.layout}
+                        mobileView={isMobileDashboardView}
+                        readOnly={isMobileDashboardView}
+                        updateLayout={(model) => {
+                          updateLayout(model)
+                          // Mark this dashboard as having changes after layout update
+                          setHasChanges((prev) => ({
+                            ...prev,
+                            [selectedDashboard]: true,
+                          }))
+                        }}
+                      />
+                    )}
+                  </Box>
+                </Box>
+              </TabPanel>
+            )
+          })}
+        </Tabs>
+
+        {!dashboardChatOpen && (
+          <TooltipStyled title="Ask this dashboard">
+            <Button
+              variant="contained"
+              size={isMobileDashboardView ? 'small' : 'medium'}
+              startIcon={<ChatBubbleOutlineIcon sx={{ fontSize: 18 }} />}
+              onClick={() => setDashboardChatOpen(true)}
+              sx={{
+                position: 'absolute',
+                right: isMobileDashboardView ? 16 : 24,
+                bottom: isMobileDashboardView ? 18 : 24,
+                zIndex: 12,
+                borderRadius: 999,
+                px: isMobileDashboardView ? 1.25 : 1.75,
+                py: isMobileDashboardView ? 0.75 : 0.9,
+                minWidth: 'fit-content',
+                boxShadow:
+                  theme.palette.mode === 'dark'
+                    ? '0 12px 30px rgba(0,0,0,0.45)'
+                    : '0 12px 28px rgba(16,24,40,0.16)',
+              }}
+            >
+              {isMobileDashboardView ? 'Ask' : 'Ask Sources'}
+            </Button>
+          </TooltipStyled>
+        )}
+      </Box>
+
+      {isMobileDashboardView ? (
+        <Drawer
+          anchor="right"
+          open={dashboardChatOpen}
           onClose={() => setDashboardChatOpen(false)}
-        />
-      </Drawer>
+          ModalProps={{ keepMounted: true }}
+          PaperProps={{
+            sx: {
+              width: '100%',
+              maxWidth: '100%',
+              height: '100dvh',
+              bgcolor: 'background.paper',
+            },
+          }}
+        >
+          {dashboardChatPanel}
+        </Drawer>
+      ) : (
+        <Box
+          aria-hidden={!dashboardChatOpen}
+          sx={{
+            width: dashboardChatOpen ? 'min(440px, 38vw)' : 0,
+            maxWidth: dashboardChatOpen ? 'min(440px, 38vw)' : 0,
+            minWidth: dashboardChatOpen ? 360 : 0,
+            flex: '0 0 auto',
+            minHeight: 0,
+            overflow: 'hidden',
+            borderLeft: dashboardChatOpen ? 1 : 0,
+            borderColor: 'divider',
+            bgcolor: 'background.paper',
+            transition: theme.transitions.create(
+              ['width', 'max-width', 'min-width', 'border-left-width'],
+              {
+                duration: theme.transitions.duration.shorter,
+                easing: theme.transitions.easing.easeInOut,
+              },
+            ),
+          }}
+        >
+          {dashboardChatOpen ? dashboardChatPanel : null}
+        </Box>
+      )}
 
       <Menu
         open={dashboardTabMenu !== null}

--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -2021,17 +2021,17 @@ const Dashboards = () => {
         <Box
           aria-hidden={!dashboardChatOpen}
           sx={{
-            width: dashboardChatOpen ? 'min(440px, 38vw)' : 0,
-            maxWidth: dashboardChatOpen ? 'min(440px, 38vw)' : 0,
-            minWidth: dashboardChatOpen ? 360 : 0,
+            width: dashboardChatOpen ? 'min(460px, 40vw)' : 0,
+            maxWidth: dashboardChatOpen ? 'min(460px, 40vw)' : 0,
+            minWidth: dashboardChatOpen ? 380 : 0,
             flex: '0 0 auto',
             minHeight: 0,
             overflow: 'hidden',
-            borderLeft: dashboardChatOpen ? 1 : 0,
-            borderColor: 'divider',
-            bgcolor: 'background.paper',
+            p: dashboardChatOpen ? '8px 8px 8px 0' : 0,
+            boxSizing: 'border-box',
+            bgcolor: 'background.default',
             transition: theme.transitions.create(
-              ['width', 'max-width', 'min-width', 'border-left-width'],
+              ['width', 'max-width', 'min-width', 'padding'],
               {
                 duration: theme.transitions.duration.shorter,
                 easing: theme.transitions.easing.easeInOut,
@@ -2039,7 +2039,22 @@ const Dashboards = () => {
             ),
           }}
         >
-          {dashboardChatOpen ? dashboardChatPanel : null}
+          <Box
+            sx={{
+              height: '100%',
+              overflow: 'hidden',
+              border: 1,
+              borderColor: 'divider',
+              borderRadius: 2.5,
+              bgcolor: 'background.paper',
+              boxShadow:
+                theme.palette.mode === 'dark'
+                  ? '0 18px 40px rgba(0,0,0,0.42)'
+                  : '0 18px 42px rgba(16,24,40,0.10)',
+            }}
+          >
+            {dashboardChatOpen ? dashboardChatPanel : null}
+          </Box>
         </Box>
       )}
 

--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -1736,9 +1736,11 @@ const Dashboards = () => {
   return (
     <Box
       sx={{
-        height: isMobileDashboardView ? 'auto' : '100%',
-        minHeight: isMobileDashboardView ? '100dvh' : 0,
-        overflow: isMobileDashboardView ? 'visible' : 'hidden',
+        height: '100%',
+        minHeight: 0,
+        overflowX: 'hidden',
+        overflowY: isMobileDashboardView ? 'auto' : 'hidden',
+        WebkitOverflowScrolling: isMobileDashboardView ? 'touch' : undefined,
         display: isMobileDashboardView ? 'block' : 'flex',
         bgcolor: 'background.default',
       }}
@@ -1980,10 +1982,10 @@ const Dashboards = () => {
               startIcon={<ChatBubbleOutlineIcon sx={{ fontSize: 18 }} />}
               onClick={() => setDashboardChatOpen(true)}
               sx={{
-                position: 'absolute',
+                position: isMobileDashboardView ? 'fixed' : 'absolute',
                 right: isMobileDashboardView ? 16 : 24,
                 bottom: isMobileDashboardView ? 18 : 24,
-                zIndex: 12,
+                zIndex: isMobileDashboardView ? 1301 : 12,
                 borderRadius: 999,
                 px: isMobileDashboardView ? 1.25 : 1.75,
                 py: isMobileDashboardView ? 0.75 : 0.9,

--- a/apps/studymesh/src/components/Dasboard/tabs.scss
+++ b/apps/studymesh/src/components/Dasboard/tabs.scss
@@ -111,7 +111,7 @@
 
 .react-tabs--mobile-dashboard {
   height: auto;
-  min-height: 100dvh;
+  min-height: 100%;
   margin: 0;
   background-color: var(--background-default, #f4f7f8);
   overflow: visible;
@@ -146,7 +146,7 @@
   .react-tabs__tab-panel {
     flex: 0 0 auto;
     height: auto;
-    min-height: calc(100dvh - 56px);
+    min-height: calc(100dvh - 82px);
     overflow: visible;
     padding: 0 0 80px;
   }

--- a/apps/studymesh/src/components/Dasboard/tabs.scss
+++ b/apps/studymesh/src/components/Dasboard/tabs.scss
@@ -110,14 +110,21 @@
 }
 
 .react-tabs--mobile-dashboard {
-  margin: -48px 0 0 0;
+  height: auto;
+  min-height: 100dvh;
+  margin: 0;
   background-color: var(--background-default, #f4f7f8);
+  overflow: visible;
 
   .react-tabs__tab-list {
+    position: sticky;
+    top: 0;
+    z-index: 10;
     align-items: center;
     gap: 8px;
-    padding: 0 12px 8px;
+    padding: 8px 12px;
     scroll-snap-type: x proximity;
+    background-color: var(--background-default, #f4f7f8);
   }
 
   .react-tabs__tab {
@@ -137,8 +144,10 @@
   }
 
   .react-tabs__tab-panel {
+    flex: 0 0 auto;
     height: auto;
-    min-height: calc(100dvh - 96px);
+    min-height: calc(100dvh - 56px);
     overflow: visible;
+    padding: 0 0 80px;
   }
 }

--- a/apps/studymesh/src/components/WidgetEditor/components/preview/StudyBlockView.tsx
+++ b/apps/studymesh/src/components/WidgetEditor/components/preview/StudyBlockView.tsx
@@ -218,7 +218,7 @@ const renderMarkdownInline = (value: string): React.ReactNode[] => {
   return nodes
 }
 
-const renderMarkdown = (markdown: string): React.ReactNode[] => {
+export const renderMarkdown = (markdown: string): React.ReactNode[] => {
   const lines = markdown.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n')
   const blocks: React.ReactNode[] = []
   let index = 0
@@ -704,8 +704,8 @@ const StudyBlockView: React.FC<StudyBlockViewProps> = ({ type, props }) => {
                 const resultColor = isCorrect
                   ? 'success.main'
                   : isSelected
-                    ? 'error.main'
-                    : 'divider'
+                  ? 'error.main'
+                  : 'divider'
 
                 return (
                   <Button

--- a/apps/studymesh/src/components/dashboardChat/DashboardChatPanel.tsx
+++ b/apps/studymesh/src/components/dashboardChat/DashboardChatPanel.tsx
@@ -1,0 +1,366 @@
+import React, { useMemo, useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Divider,
+  IconButton,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import SendIcon from '@mui/icons-material/Send'
+import { StateDashboard } from '../../state/store'
+import {
+  buildDashboardChatContext,
+  formatDashboardChatContext,
+  selectDashboardChatChunks,
+} from '../../dashboardChat/contextBuilder'
+import { askDashboardSources } from '../../dashboardChat/askDashboard'
+
+export interface DashboardChatMessage {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  createdAt: number
+  sources?: string[]
+  pending?: boolean
+}
+
+interface DashboardChatPanelProps {
+  dashboard?: StateDashboard
+  messages: DashboardChatMessage[]
+  onMessagesChange: (messages: DashboardChatMessage[]) => void
+  onClose: () => void
+}
+
+const suggestions = [
+  'Summarize the key ideas',
+  'Explain this like I’m new',
+  'Generate exam-style questions',
+  'What should I review first?',
+]
+
+const makeMessageId = () =>
+  `dashboard-chat-${Date.now()}-${Math.random().toString(36).slice(2)}`
+
+const DashboardChatPanel = ({
+  dashboard,
+  messages,
+  onMessagesChange,
+  onClose,
+}: DashboardChatPanelProps) => {
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
+  const [draft, setDraft] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+  const context = useMemo(
+    () => buildDashboardChatContext(dashboard),
+    [dashboard],
+  )
+  const hasContext = context.chunks.length > 0
+
+  const sendQuestion = async (question: string) => {
+    const trimmed = question.trim()
+    if (!trimmed || isLoading) {
+      return
+    }
+
+    const userMessage: DashboardChatMessage = {
+      id: makeMessageId(),
+      role: 'user',
+      content: trimmed,
+      createdAt: Date.now(),
+    }
+    const pendingMessage: DashboardChatMessage = {
+      id: makeMessageId(),
+      role: 'assistant',
+      content: '',
+      createdAt: Date.now(),
+      pending: true,
+    }
+    const nextMessages = [...messages, userMessage, pendingMessage]
+    onMessagesChange(nextMessages)
+    setDraft('')
+    setError('')
+
+    if (!hasContext) {
+      onMessagesChange(
+        nextMessages.map((message) =>
+          message.id === pendingMessage.id
+            ? {
+                ...message,
+                content:
+                  'This dashboard does not have enough source content to answer from yet. Add source notes or generated study material, then ask again.',
+                pending: false,
+              }
+            : message,
+        ),
+      )
+      return
+    }
+
+    const sourceChunks = selectDashboardChatChunks(context, trimmed)
+    setIsLoading(true)
+
+    try {
+      const result = await askDashboardSources({
+        dashboardTitle: context.dashboardTitle,
+        contextText: formatDashboardChatContext(context, sourceChunks),
+        question: trimmed,
+        history: messages.map(({ role, content }) => ({ role, content })),
+        sourceChunks,
+      })
+      onMessagesChange(
+        nextMessages.map((message) =>
+          message.id === pendingMessage.id
+            ? {
+                ...message,
+                content: result.answer,
+                sources: result.sources,
+                pending: false,
+              }
+            : message,
+        ),
+      )
+    } catch (err) {
+      onMessagesChange(
+        nextMessages.map((message) =>
+          message.id === pendingMessage.id
+            ? {
+                ...message,
+                content: 'I could not answer from this dashboard yet.',
+                pending: false,
+              }
+            : message,
+        ),
+      )
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Could not answer from this dashboard.',
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <Box
+      sx={{
+        height: isMobile ? '100dvh' : '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        bgcolor: 'background.paper',
+      }}
+    >
+      <Box
+        sx={{
+          minHeight: 58,
+          px: 2,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          borderBottom: 1,
+          borderColor: 'divider',
+        }}
+      >
+        <Box sx={{ minWidth: 0 }}>
+          <Typography variant="subtitle1" fontWeight={900} noWrap>
+            Ask this dashboard
+          </Typography>
+          <Typography variant="caption" color="text.secondary" noWrap>
+            Based on sources and study material here
+          </Typography>
+        </Box>
+        <Stack direction="row" spacing={0.5}>
+          {messages.length > 0 && (
+            <Tooltip title="Clear chat">
+              <IconButton
+                size="small"
+                onClick={() => onMessagesChange([])}
+                aria-label="Clear dashboard chat"
+              >
+                <DeleteOutlineIcon />
+              </IconButton>
+            </Tooltip>
+          )}
+          <Tooltip title="Close">
+            <IconButton
+              size="small"
+              onClick={onClose}
+              aria-label="Close Ask Sources"
+            >
+              <CloseIcon />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+      </Box>
+
+      <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', p: 2 }}>
+        {!hasContext ? (
+          <Alert severity="info">
+            This dashboard does not have enough source content to chat with yet.
+          </Alert>
+        ) : messages.length === 0 ? (
+          <Stack spacing={2}>
+            <Box>
+              <Typography variant="h6" fontWeight={900}>
+                Ask this dashboard
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Ask questions based on the sources and study material in this
+                dashboard.
+              </Typography>
+            </Box>
+            <Stack spacing={1}>
+              {suggestions.map((suggestion) => (
+                <Button
+                  key={suggestion}
+                  variant="outlined"
+                  size="small"
+                  onClick={() => sendQuestion(suggestion)}
+                  sx={{ justifyContent: 'flex-start', borderRadius: 2 }}
+                >
+                  {suggestion}
+                </Button>
+              ))}
+            </Stack>
+          </Stack>
+        ) : (
+          <Stack spacing={1.5}>
+            {messages.map((message) => (
+              <Box
+                key={message.id}
+                sx={{
+                  alignSelf:
+                    message.role === 'user' ? 'flex-end' : 'flex-start',
+                  maxWidth: '88%',
+                }}
+              >
+                <Box
+                  sx={{
+                    px: 1.5,
+                    py: 1,
+                    borderRadius: 2,
+                    bgcolor:
+                      message.role === 'user'
+                        ? 'primary.main'
+                        : 'background.default',
+                    color:
+                      message.role === 'user'
+                        ? 'primary.contrastText'
+                        : 'text.primary',
+                    border: message.role === 'assistant' ? 1 : 0,
+                    borderColor: 'divider',
+                    whiteSpace: 'pre-wrap',
+                  }}
+                >
+                  {message.pending ? (
+                    <Stack direction="row" spacing={0.5} alignItems="center">
+                      {[0, 1, 2].map((dot) => (
+                        <Box
+                          key={dot}
+                          sx={{
+                            width: 6,
+                            height: 6,
+                            borderRadius: '50%',
+                            bgcolor: 'text.secondary',
+                            animation:
+                              'studymesh-chat-dot 1s infinite ease-in-out',
+                            animationDelay: `${dot * 140}ms`,
+                            '@keyframes studymesh-chat-dot': {
+                              '0%, 80%, 100%': {
+                                opacity: 0.35,
+                                transform: 'translateY(0)',
+                              },
+                              '40%': {
+                                opacity: 1,
+                                transform: 'translateY(-3px)',
+                              },
+                            },
+                          }}
+                        />
+                      ))}
+                    </Stack>
+                  ) : (
+                    <Typography variant="body2">{message.content}</Typography>
+                  )}
+                </Box>
+                {message.sources?.length ? (
+                  <Stack
+                    direction="row"
+                    spacing={0.5}
+                    flexWrap="wrap"
+                    sx={{ mt: 0.75 }}
+                  >
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ mr: 0.5 }}
+                    >
+                      Based on:
+                    </Typography>
+                    {message.sources.map((source) => (
+                      <Chip
+                        key={source}
+                        label={source}
+                        size="small"
+                        variant="outlined"
+                        sx={{ mb: 0.5 }}
+                      />
+                    ))}
+                  </Stack>
+                ) : null}
+              </Box>
+            ))}
+          </Stack>
+        )}
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+      </Box>
+
+      <Divider />
+      <Box sx={{ p: 1.5 }}>
+        <Stack direction="row" spacing={1} alignItems="flex-end">
+          <TextField
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            placeholder="Ask about this dashboard…"
+            disabled={isLoading}
+            fullWidth
+            multiline
+            maxRows={4}
+            size="small"
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault()
+                sendQuestion(draft)
+              }
+            }}
+          />
+          <IconButton
+            color="primary"
+            onClick={() => sendQuestion(draft)}
+            disabled={!draft.trim() || isLoading}
+            aria-label="Send dashboard question"
+          >
+            <SendIcon />
+          </IconButton>
+        </Stack>
+      </Box>
+    </Box>
+  )
+}
+
+export default DashboardChatPanel

--- a/apps/studymesh/src/components/dashboardChat/DashboardChatPanel.tsx
+++ b/apps/studymesh/src/components/dashboardChat/DashboardChatPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import {
   Alert,
   Box,
@@ -23,6 +23,8 @@ import {
   selectDashboardChatChunks,
 } from '../../dashboardChat/contextBuilder'
 import { askDashboardSources } from '../../dashboardChat/askDashboard'
+import { readStudyPackAiSettings } from '../../studyPack/ai'
+import { renderMarkdown } from '../WidgetEditor/components/preview/StudyBlockView'
 
 export interface DashboardChatMessage {
   id: string
@@ -59,17 +61,109 @@ const DashboardChatPanel = ({
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('md'))
   const [draft, setDraft] = useState('')
-  const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
+  const [activeStartedAt, setActiveStartedAt] = useState<number | null>(null)
+  const [elapsedSeconds, setElapsedSeconds] = useState(0)
+  const messagesRef = useRef(messages)
+  const queueRef = useRef(Promise.resolve())
+  const settings = readStudyPackAiSettings()
+  const isLocalAi = settings.provider === 'local'
   const context = useMemo(
-    () => buildDashboardChatContext(dashboard),
-    [dashboard],
+    () =>
+      buildDashboardChatContext(
+        dashboard,
+        isLocalAi
+          ? { sourceNotesOnly: true, studyPathScope: 'selected' }
+          : undefined,
+      ),
+    [dashboard, isLocalAi],
   )
   const hasContext = context.chunks.length > 0
 
-  const sendQuestion = async (question: string) => {
+  useEffect(() => {
+    messagesRef.current = messages
+  }, [messages])
+
+  useEffect(() => {
+    if (!activeStartedAt) {
+      setElapsedSeconds(0)
+      return undefined
+    }
+
+    const interval = window.setInterval(() => {
+      setElapsedSeconds(Math.floor((Date.now() - activeStartedAt) / 1000))
+    }, 1000)
+
+    return () => window.clearInterval(interval)
+  }, [activeStartedAt])
+
+  const updateMessage = (
+    messageId: string,
+    updater: (message: DashboardChatMessage) => DashboardChatMessage,
+  ) => {
+    const updated = messagesRef.current.map((message) =>
+      message.id === messageId ? updater(message) : message,
+    )
+    messagesRef.current = updated
+    onMessagesChange(updated)
+  }
+
+  const answerQuestion = async (
+    question: string,
+    pendingMessageId: string,
+    historyMessages: DashboardChatMessage[],
+  ) => {
+    setActiveStartedAt(Date.now())
+
+    if (!hasContext) {
+      updateMessage(pendingMessageId, (message) => ({
+        ...message,
+        content:
+          'This dashboard does not have enough source content to answer from yet. Add source notes or generated study material, then ask again.',
+        pending: false,
+      }))
+      setActiveStartedAt(null)
+      return
+    }
+
+    const sourceChunks = selectDashboardChatChunks(context, question)
+
+    try {
+      const result = await askDashboardSources({
+        dashboardTitle: context.dashboardTitle,
+        contextText: formatDashboardChatContext(context, sourceChunks),
+        question,
+        history: historyMessages.map(({ role, content }) => ({
+          role,
+          content,
+        })),
+        sourceChunks,
+      })
+      updateMessage(pendingMessageId, (message) => ({
+        ...message,
+        content: result.answer,
+        sources: result.sources,
+        pending: false,
+      }))
+    } catch (err) {
+      updateMessage(pendingMessageId, (message) => ({
+        ...message,
+        content: 'I could not answer from this dashboard yet.',
+        pending: false,
+      }))
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Could not answer from this dashboard.',
+      )
+    } finally {
+      setActiveStartedAt(null)
+    }
+  }
+
+  const sendQuestion = (question: string) => {
     const trimmed = question.trim()
-    if (!trimmed || isLoading) {
+    if (!trimmed) {
       return
     }
 
@@ -86,70 +180,24 @@ const DashboardChatPanel = ({
       createdAt: Date.now(),
       pending: true,
     }
-    const nextMessages = [...messages, userMessage, pendingMessage]
+    const previousMessages = messagesRef.current
+    const nextMessages = [...previousMessages, userMessage, pendingMessage]
+    messagesRef.current = nextMessages
     onMessagesChange(nextMessages)
     setDraft('')
     setError('')
 
-    if (!hasContext) {
-      onMessagesChange(
-        nextMessages.map((message) =>
-          message.id === pendingMessage.id
-            ? {
-                ...message,
-                content:
-                  'This dashboard does not have enough source content to answer from yet. Add source notes or generated study material, then ask again.',
-                pending: false,
-              }
-            : message,
-        ),
-      )
-      return
-    }
+    queueRef.current = queueRef.current.then(() =>
+      answerQuestion(trimmed, pendingMessage.id, previousMessages),
+    )
+  }
 
-    const sourceChunks = selectDashboardChatChunks(context, trimmed)
-    setIsLoading(true)
-
-    try {
-      const result = await askDashboardSources({
-        dashboardTitle: context.dashboardTitle,
-        contextText: formatDashboardChatContext(context, sourceChunks),
-        question: trimmed,
-        history: messages.map(({ role, content }) => ({ role, content })),
-        sourceChunks,
-      })
-      onMessagesChange(
-        nextMessages.map((message) =>
-          message.id === pendingMessage.id
-            ? {
-                ...message,
-                content: result.answer,
-                sources: result.sources,
-                pending: false,
-              }
-            : message,
-        ),
-      )
-    } catch (err) {
-      onMessagesChange(
-        nextMessages.map((message) =>
-          message.id === pendingMessage.id
-            ? {
-                ...message,
-                content: 'I could not answer from this dashboard yet.',
-                pending: false,
-              }
-            : message,
-        ),
-      )
-      setError(
-        err instanceof Error
-          ? err.message
-          : 'Could not answer from this dashboard.',
-      )
-    } finally {
-      setIsLoading(false)
-    }
+  const formatSeconds = (seconds: number) => {
+    const minutes = Math.floor(seconds / 60)
+    const remainingSeconds = seconds % 60
+    return minutes > 0
+      ? `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`
+      : `${remainingSeconds}s`
   }
 
   return (
@@ -264,32 +312,61 @@ const DashboardChatPanel = ({
                   }}
                 >
                   {message.pending ? (
-                    <Stack direction="row" spacing={0.5} alignItems="center">
-                      {[0, 1, 2].map((dot) => (
-                        <Box
-                          key={dot}
-                          sx={{
-                            width: 6,
-                            height: 6,
-                            borderRadius: '50%',
-                            bgcolor: 'text.secondary',
-                            animation:
-                              'studymesh-chat-dot 1s infinite ease-in-out',
-                            animationDelay: `${dot * 140}ms`,
-                            '@keyframes studymesh-chat-dot': {
-                              '0%, 80%, 100%': {
-                                opacity: 0.35,
-                                transform: 'translateY(0)',
+                    <Stack spacing={0.75}>
+                      <Stack direction="row" spacing={0.5} alignItems="center">
+                        {[0, 1, 2].map((dot) => (
+                          <Box
+                            key={dot}
+                            sx={{
+                              width: 6,
+                              height: 6,
+                              borderRadius: '50%',
+                              bgcolor: 'text.secondary',
+                              animation:
+                                'studymesh-chat-dot 1s infinite ease-in-out',
+                              animationDelay: `${dot * 140}ms`,
+                              '@keyframes studymesh-chat-dot': {
+                                '0%, 80%, 100%': {
+                                  opacity: 0.35,
+                                  transform: 'translateY(0)',
+                                },
+                                '40%': {
+                                  opacity: 1,
+                                  transform: 'translateY(-3px)',
+                                },
                               },
-                              '40%': {
-                                opacity: 1,
-                                transform: 'translateY(-3px)',
-                              },
-                            },
-                          }}
-                        />
-                      ))}
+                            }}
+                          />
+                        ))}
+                      </Stack>
+                      <Typography variant="caption" color="text.secondary">
+                        {activeStartedAt &&
+                        messages.findIndex(({ id }) => id === message.id) ===
+                          messages.findIndex(
+                            ({ role, pending }) =>
+                              role === 'assistant' && pending,
+                          )
+                          ? isLocalAi
+                            ? `Local AI is replying… ${formatSeconds(
+                                elapsedSeconds,
+                              )} elapsed. Estimate: about 1:30.`
+                            : `Replying… ${formatSeconds(
+                                elapsedSeconds,
+                              )} elapsed.`
+                          : 'Queued — I’ll answer this after the previous question.'}
+                      </Typography>
                     </Stack>
+                  ) : message.role === 'assistant' ? (
+                    <Box
+                      sx={{
+                        '& p': { m: 0, mb: 1 },
+                        '& p:last-child': { mb: 0 },
+                        '& ul, & ol': { pl: 2.5, my: 0.75 },
+                        '& pre': { maxWidth: '100%' },
+                      }}
+                    >
+                      {renderMarkdown(message.content)}
+                    </Box>
                   ) : (
                     <Typography variant="body2">{message.content}</Typography>
                   )}
@@ -337,7 +414,6 @@ const DashboardChatPanel = ({
             value={draft}
             onChange={(event) => setDraft(event.target.value)}
             placeholder="Ask about this dashboard…"
-            disabled={isLoading}
             fullWidth
             multiline
             maxRows={4}
@@ -352,7 +428,7 @@ const DashboardChatPanel = ({
           <IconButton
             color="primary"
             onClick={() => sendQuestion(draft)}
-            disabled={!draft.trim() || isLoading}
+            disabled={!draft.trim()}
             aria-label="Send dashboard question"
           >
             <SendIcon />

--- a/apps/studymesh/src/components/dashboardChat/DashboardChatPanel.tsx
+++ b/apps/studymesh/src/components/dashboardChat/DashboardChatPanel.tsx
@@ -207,26 +207,55 @@ const DashboardChatPanel = ({
         display: 'flex',
         flexDirection: 'column',
         bgcolor: 'background.paper',
+        overflow: 'hidden',
       }}
     >
       <Box
         sx={{
-          minHeight: 58,
+          minHeight: 76,
           px: 2,
+          py: 1.5,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
+          gap: 1.5,
           borderBottom: 1,
           borderColor: 'divider',
+          background:
+            theme.palette.mode === 'dark'
+              ? 'linear-gradient(135deg, rgba(34,197,94,0.14), rgba(14,165,233,0.08))'
+              : 'linear-gradient(135deg, rgba(34,197,94,0.10), rgba(14,165,233,0.06))',
         }}
       >
         <Box sx={{ minWidth: 0 }}>
           <Typography variant="subtitle1" fontWeight={900} noWrap>
-            Ask this dashboard
+            Ask Sources
           </Typography>
           <Typography variant="caption" color="text.secondary" noWrap>
-            Based on sources and study material here
+            Grounded in this workspace’s study material
           </Typography>
+          <Stack direction="row" spacing={0.75} sx={{ mt: 0.75 }}>
+            <Chip
+              size="small"
+              label={
+                isLocalAi
+                  ? 'Local AI'
+                  : settings.provider === 'gemini'
+                  ? 'Gemini'
+                  : 'Basic'
+              }
+              variant="outlined"
+              sx={{ height: 22, fontWeight: 700 }}
+            />
+            <Chip
+              size="small"
+              label={`${context.chunks.length} source${
+                context.chunks.length === 1 ? '' : 's'
+              }`}
+              variant="outlined"
+              sx={{ height: 22 }}
+            />
+          </Stack>
         </Box>
         <Stack direction="row" spacing={0.5}>
           {messages.length > 0 && (
@@ -252,20 +281,39 @@ const DashboardChatPanel = ({
         </Stack>
       </Box>
 
-      <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', p: 2 }}>
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          overflow: 'auto',
+          p: 2,
+          bgcolor:
+            theme.palette.mode === 'dark'
+              ? 'rgba(2,6,23,0.18)'
+              : 'rgba(248,250,252,0.72)',
+        }}
+      >
         {!hasContext ? (
           <Alert severity="info">
             This dashboard does not have enough source content to chat with yet.
           </Alert>
         ) : messages.length === 0 ? (
-          <Stack spacing={2}>
-            <Box>
+          <Stack spacing={2.25}>
+            <Box
+              sx={{
+                p: 2,
+                border: 1,
+                borderColor: 'divider',
+                borderRadius: 2.5,
+                bgcolor: 'background.paper',
+              }}
+            >
               <Typography variant="h6" fontWeight={900}>
-                Ask this dashboard
+                What do you want to understand?
               </Typography>
               <Typography variant="body2" color="text.secondary">
                 Ask questions based on the sources and study material in this
-                dashboard.
+                dashboard. I’ll keep answers grounded in what’s here.
               </Typography>
             </Box>
             <Stack spacing={1}>
@@ -275,7 +323,16 @@ const DashboardChatPanel = ({
                   variant="outlined"
                   size="small"
                   onClick={() => sendQuestion(suggestion)}
-                  sx={{ justifyContent: 'flex-start', borderRadius: 2 }}
+                  sx={{
+                    justifyContent: 'flex-start',
+                    borderRadius: 2,
+                    py: 1,
+                    px: 1.25,
+                    bgcolor: 'background.paper',
+                    borderColor: 'divider',
+                    color: 'text.primary',
+                    textTransform: 'none',
+                  }}
                 >
                   {suggestion}
                 </Button>
@@ -290,24 +347,33 @@ const DashboardChatPanel = ({
                 sx={{
                   alignSelf:
                     message.role === 'user' ? 'flex-end' : 'flex-start',
-                  maxWidth: '88%',
+                  maxWidth: '90%',
                 }}
               >
                 <Box
                   sx={{
                     px: 1.5,
-                    py: 1,
-                    borderRadius: 2,
+                    py: 1.1,
+                    borderRadius:
+                      message.role === 'user'
+                        ? '18px 18px 6px 18px'
+                        : '18px 18px 18px 6px',
                     bgcolor:
                       message.role === 'user'
                         ? 'primary.main'
-                        : 'background.default',
+                        : 'background.paper',
                     color:
                       message.role === 'user'
                         ? 'primary.contrastText'
                         : 'text.primary',
                     border: message.role === 'assistant' ? 1 : 0,
                     borderColor: 'divider',
+                    boxShadow:
+                      message.role === 'assistant'
+                        ? theme.palette.mode === 'dark'
+                          ? '0 10px 24px rgba(0,0,0,0.22)'
+                          : '0 10px 24px rgba(16,24,40,0.08)'
+                        : 'none',
                     whiteSpace: 'pre-wrap',
                   }}
                 >
@@ -408,7 +474,7 @@ const DashboardChatPanel = ({
       </Box>
 
       <Divider />
-      <Box sx={{ p: 1.5 }}>
+      <Box sx={{ p: 1.5, bgcolor: 'background.paper' }}>
         <Stack direction="row" spacing={1} alignItems="flex-end">
           <TextField
             value={draft}
@@ -418,6 +484,15 @@ const DashboardChatPanel = ({
             multiline
             maxRows={4}
             size="small"
+            sx={{
+              '& .MuiOutlinedInput-root': {
+                borderRadius: 2.5,
+                bgcolor:
+                  theme.palette.mode === 'dark'
+                    ? 'rgba(15,23,42,0.72)'
+                    : 'rgba(248,250,252,0.92)',
+              },
+            }}
             onKeyDown={(event) => {
               if (event.key === 'Enter' && !event.shiftKey) {
                 event.preventDefault()
@@ -430,6 +505,19 @@ const DashboardChatPanel = ({
             onClick={() => sendQuestion(draft)}
             disabled={!draft.trim()}
             aria-label="Send dashboard question"
+            sx={{
+              width: 42,
+              height: 42,
+              bgcolor: draft.trim()
+                ? 'primary.main'
+                : 'action.disabledBackground',
+              color: draft.trim() ? 'primary.contrastText' : 'text.disabled',
+              '&:hover': {
+                bgcolor: draft.trim()
+                  ? 'primary.dark'
+                  : 'action.disabledBackground',
+              },
+            }}
           >
             <SendIcon />
           </IconButton>

--- a/apps/studymesh/src/dashboardChat/askDashboard.ts
+++ b/apps/studymesh/src/dashboardChat/askDashboard.ts
@@ -1,0 +1,165 @@
+import {
+  callLocalLanguageModel,
+  readStudyPackAiSettings,
+  resolveStudyPackAiCredentials,
+} from '../studyPack/ai'
+import { DashboardSourceChunk } from './contextBuilder'
+
+interface AskDashboardOptions {
+  dashboardTitle: string
+  contextText: string
+  question: string
+  history: Array<{ role: 'user' | 'assistant'; content: string }>
+  sourceChunks: DashboardSourceChunk[]
+}
+
+export interface AskDashboardResult {
+  answer: string
+  sources: string[]
+}
+
+const GEMINI_REQUEST_TIMEOUT_MS = 45000
+
+const buildPrompt = ({
+  dashboardTitle,
+  contextText,
+  question,
+  history,
+}: AskDashboardOptions) => `You are StudyMesh's dashboard assistant. Help the student understand the current dashboard.
+
+Rules:
+- Answer using only the provided dashboard sources and study material when possible.
+- If the answer is not supported by the provided context, say that the dashboard sources do not contain enough information.
+- Do not invent facts, citations, links, or source names.
+- Be concise, clear, student-friendly, and practical.
+- Use bullets, examples, and study tips when helpful.
+
+Dashboard title: ${dashboardTitle}
+
+Dashboard/source context:
+${contextText}
+
+Recent chat:
+${history
+  .slice(-6)
+  .map(
+    (message) =>
+      `${message.role === 'user' ? 'Student' : 'Assistant'}: ${message.content}`,
+  )
+  .join('\n')}
+
+Student question: ${question}
+
+Answer:`
+
+const callGeminiText = async (
+  apiToken: string,
+  model: string,
+  prompt: string,
+): Promise<string> => {
+  const controller = new AbortController()
+  const timeoutId = window.setTimeout(
+    () => controller.abort(),
+    GEMINI_REQUEST_TIMEOUT_MS,
+  )
+
+  try {
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(
+        model,
+      )}:generateContent`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': apiToken,
+        },
+        signal: controller.signal,
+        body: JSON.stringify({
+          contents: [{ role: 'user', parts: [{ text: prompt }] }],
+          generationConfig: {
+            temperature: 0.2,
+            responseMimeType: 'text/plain',
+          },
+        }),
+      },
+    )
+
+    const payload = await response.json()
+    if (!response.ok) {
+      throw new Error(payload?.error?.message || 'Gemini request failed.')
+    }
+
+    const text = payload?.candidates?.[0]?.content?.parts
+      ?.map((part: { text?: string }) => part.text || '')
+      .join('')
+      .trim()
+
+    if (!text) {
+      throw new Error('Gemini returned an empty answer.')
+    }
+
+    return text
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new Error(
+        'The AI request timed out. Try a shorter question or fewer sources.',
+      )
+    }
+
+    throw error
+  } finally {
+    window.clearTimeout(timeoutId)
+  }
+}
+
+const basicAnswer = ({
+  question,
+  sourceChunks,
+}: AskDashboardOptions): string => {
+  const snippets = sourceChunks
+    .slice(0, 3)
+    .map((chunk) => `- ${chunk.title}: ${chunk.text.slice(0, 420).trim()}`)
+    .join('\n')
+
+  return `I can answer from the dashboard sources, but Basic mode does not call an external AI model.\n\nMost relevant source notes for “${question}”:\n${snippets}\n\nSwitch to Gemini or Local AI in StudyMesh settings for a synthesized chat answer.`
+}
+
+export const askDashboardSources = async (
+  options: AskDashboardOptions,
+): Promise<AskDashboardResult> => {
+  const settings = readStudyPackAiSettings()
+  const provider = settings.provider || 'basic'
+  const prompt = buildPrompt(options)
+  let answer: string
+
+  if (provider === 'hosted') {
+    throw new Error(
+      'Hosted AI is not configured yet. Choose Basic, Local AI, or Gemini in settings.',
+    )
+  }
+
+  if (provider === 'local') {
+    answer = await callLocalLanguageModel(prompt, {
+      promptType: 'notes',
+      stepLabel: 'Ask dashboard sources',
+    })
+  } else if (provider === 'gemini') {
+    const credentials = resolveStudyPackAiCredentials()
+    if (!credentials.apiToken) {
+      throw new Error('Own Gemini API token mode needs a configured API key.')
+    }
+    answer = await callGeminiText(
+      credentials.apiToken,
+      credentials.model,
+      prompt,
+    )
+  } else {
+    answer = basicAnswer(options)
+  }
+
+  return {
+    answer,
+    sources: options.sourceChunks.slice(0, 4).map((chunk) => chunk.title),
+  }
+}

--- a/apps/studymesh/src/dashboardChat/contextBuilder.ts
+++ b/apps/studymesh/src/dashboardChat/contextBuilder.ts
@@ -14,6 +14,11 @@ export interface DashboardChatContext {
   chunks: DashboardSourceChunk[]
 }
 
+interface BuildDashboardChatContextOptions {
+  sourceNotesOnly?: boolean
+  studyPathScope?: 'all' | 'selected'
+}
+
 const MAX_CHUNK_LENGTH = 2200
 const MAX_CONTEXT_LENGTH = 12000
 
@@ -138,11 +143,37 @@ const textFromProps = (props: Record<string, unknown>): string[] => {
   return values.map(normalizeText).filter(Boolean)
 }
 
+const isSourceNotesChunk = (chunk: DashboardSourceChunk): boolean => {
+  const value = `${chunk.title} ${chunk.type}`.toLowerCase()
+  return (
+    value.includes('source note') ||
+    value.includes('source-notes') ||
+    value.includes('sourcenotes') ||
+    value.includes('markdown')
+  )
+}
+
+const isSourceNotesComponent = (
+  record: Record<string, unknown>,
+  props: Record<string, unknown>,
+): boolean => {
+  const value = `${props.title || ''} ${props.__blockType || ''} ${
+    record.type || ''
+  } ${record.name || ''}`.toLowerCase()
+  return (
+    value.includes('source note') ||
+    value.includes('source-notes') ||
+    value.includes('sourcenotes') ||
+    value.includes('markdown')
+  )
+}
+
 const componentToChunks = (
   component: unknown,
   node: DashboardLayout,
   chunks: DashboardSourceChunk[],
   path: string[],
+  options: BuildDashboardChatContextOptions = {},
 ): void => {
   if (!component || typeof component !== 'object') {
     return
@@ -156,14 +187,17 @@ const componentToChunks = (
   const text = textFromProps(props).join('\n\n')
 
   if (text) {
-    chunks.push({
+    const chunk = {
       id: String(record.id || path.join('-') || chunks.length),
       title: titleFrom(props.title, record.name, node.name),
       type: String(
         props.__blockType || record.type || node.component || 'widget',
       ),
       text: truncate(text, MAX_CHUNK_LENGTH),
-    })
+    }
+    if (!options.sourceNotesOnly || isSourceNotesComponent(record, props)) {
+      chunks.push(chunk)
+    }
   }
 
   if (!text) {
@@ -171,20 +205,23 @@ const componentToChunks = (
     collectTextDeep(props, fallbackValues)
     const fallbackText = Array.from(new Set(fallbackValues)).join('\n')
     if (fallbackText) {
-      chunks.push({
+      const chunk = {
         id: String(record.id || path.join('-') || chunks.length),
         title: titleFrom(props.title, record.name, node.name),
         type: String(
           props.__blockType || record.type || node.component || 'widget',
         ),
         text: truncate(fallbackText, MAX_CHUNK_LENGTH),
-      })
+      }
+      if (!options.sourceNotesOnly || isSourceNotesComponent(record, props)) {
+        chunks.push(chunk)
+      }
     }
   }
 
   const children = Array.isArray(record.children) ? record.children : []
   children.forEach((child, index) =>
-    componentToChunks(child, node, chunks, [...path, String(index)]),
+    componentToChunks(child, node, chunks, [...path, String(index)], options),
   )
 }
 
@@ -192,6 +229,7 @@ const collectChunksFromLayout = (
   node: DashboardLayout | undefined,
   chunks: DashboardSourceChunk[],
   path: string[] = [],
+  options: BuildDashboardChatContextOptions = {},
 ): void => {
   if (!node) {
     return
@@ -212,7 +250,13 @@ const collectChunksFromLayout = (
   }
 
   components.forEach((component, index) =>
-    componentToChunks(component, node, chunks, [...path, String(index)]),
+    componentToChunks(
+      component,
+      node,
+      chunks,
+      [...path, String(index)],
+      options,
+    ),
   )
 
   const nodeText = [node.name, node.component]
@@ -220,12 +264,15 @@ const collectChunksFromLayout = (
     .filter(Boolean)
     .join('\n')
   if (node.component && nodeText && components.length === 0) {
-    chunks.push({
+    const chunk = {
       id: node.id || path.join('-') || `node-${chunks.length}`,
       title: titleFrom(node.name, node.component),
       type: node.component,
       text: truncate(nodeText, MAX_CHUNK_LENGTH),
-    })
+    }
+    if (!options.sourceNotesOnly || isSourceNotesChunk(chunk)) {
+      chunks.push(chunk)
+    }
   }
 
   if (components.length === 0 && customProps) {
@@ -233,16 +280,19 @@ const collectChunksFromLayout = (
     collectTextDeep(customProps, fallbackValues)
     const fallbackText = Array.from(new Set(fallbackValues)).join('\n')
     if (fallbackText) {
-      chunks.push({
+      const chunk = {
         id: `${node.id || path.join('-') || chunks.length}-custom-props`,
         title: titleFrom(node.name, node.component),
         type: node.component || 'dashboard widget',
         text: truncate(fallbackText, MAX_CHUNK_LENGTH),
-      })
+      }
+      if (!options.sourceNotesOnly || isSourceNotesChunk(chunk)) {
+        chunks.push(chunk)
+      }
     }
   }
   ;(node.children || []).forEach((child, index) =>
-    collectChunksFromLayout(child, chunks, [...path, String(index)]),
+    collectChunksFromLayout(child, chunks, [...path, String(index)], options),
   )
 }
 
@@ -261,24 +311,35 @@ const scoreChunk = (chunk: DashboardSourceChunk, question: string): number => {
 
 export const buildDashboardChatContext = (
   dashboard: StateDashboard | undefined,
+  options: BuildDashboardChatContextOptions = {},
 ): DashboardChatContext => {
   const chunks: DashboardSourceChunk[] = []
 
   if (dashboard?.kind === 'studyPathContainer' && dashboard.studyPath) {
     const dashboards = dashboard.studyPath.dashboards || []
     const selectedDashboard = dashboards[dashboard.studyPath.selectedIndex]
-    const orderedDashboards = selectedDashboard
-      ? [
-          selectedDashboard,
-          ...dashboards.filter(
-            (item) => item.dashboardKey !== selectedDashboard.dashboardKey,
-          ),
-        ]
-      : dashboards
+    const orderedDashboards =
+      options.studyPathScope === 'selected'
+        ? selectedDashboard
+          ? [selectedDashboard]
+          : []
+        : selectedDashboard
+        ? [
+            selectedDashboard,
+            ...dashboards.filter(
+              (item) => item.dashboardKey !== selectedDashboard.dashboardKey,
+            ),
+          ]
+        : dashboards
 
     orderedDashboards.forEach((studyDashboard, index) => {
       const beforeCount = chunks.length
-      collectChunksFromLayout(studyDashboard.layout, chunks, [String(index)])
+      collectChunksFromLayout(
+        studyDashboard.layout,
+        chunks,
+        [String(index)],
+        options,
+      )
 
       chunks.slice(beforeCount).forEach((chunk) => {
         chunk.title = `${studyDashboard.name}: ${chunk.title}`
@@ -286,11 +347,12 @@ export const buildDashboardChatContext = (
     })
   }
 
-  collectChunksFromLayout(dashboard?.layout, chunks)
+  collectChunksFromLayout(dashboard?.layout, chunks, [], options)
 
   return {
     dashboardId: dashboard?.id || 'unknown-dashboard',
-    dashboardTitle: dashboard?.studyPath?.title || dashboard?.name || 'Dashboard',
+    dashboardTitle:
+      dashboard?.studyPath?.title || dashboard?.name || 'Dashboard',
     chunks,
   }
 }

--- a/apps/studymesh/src/dashboardChat/contextBuilder.ts
+++ b/apps/studymesh/src/dashboardChat/contextBuilder.ts
@@ -1,0 +1,306 @@
+import { DashboardLayout, StateDashboard } from '../state/store'
+import WidgetStorage from '../components/WidgetEditor/WidgetStorage'
+
+export interface DashboardSourceChunk {
+  id: string
+  title: string
+  type: string
+  text: string
+}
+
+export interface DashboardChatContext {
+  dashboardId: string
+  dashboardTitle: string
+  chunks: DashboardSourceChunk[]
+}
+
+const MAX_CHUNK_LENGTH = 2200
+const MAX_CONTEXT_LENGTH = 12000
+
+const normalizeText = (value: unknown): string =>
+  typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : ''
+
+const truncate = (value: string, maxLength: number): string =>
+  value.length > maxLength ? `${value.slice(0, maxLength).trim()}…` : value
+
+const titleFrom = (...values: unknown[]) => {
+  for (const value of values) {
+    const text = normalizeText(value)
+    if (text) {
+      return text
+    }
+  }
+
+  return 'Dashboard source'
+}
+
+const ignoredTextKeys = new Set([
+  'id',
+  'parentId',
+  'widgetId',
+  '__blockType',
+  'type',
+  'component',
+  'createdAt',
+  'updatedAt',
+])
+
+const collectTextDeep = (
+  value: unknown,
+  values: string[],
+  key = '',
+  depth = 0,
+): void => {
+  if (depth > 6 || value === null || value === undefined) {
+    return
+  }
+
+  if (typeof value === 'string') {
+    const text = normalizeText(value)
+    if (text.length > 2 && !ignoredTextKeys.has(key)) {
+      values.push(text)
+    }
+    return
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectTextDeep(item, values, key, depth + 1))
+    return
+  }
+
+  if (typeof value === 'object') {
+    Object.entries(value as Record<string, unknown>).forEach(
+      ([childKey, childValue]) => {
+        if (!ignoredTextKeys.has(childKey)) {
+          collectTextDeep(childValue, values, childKey, depth + 1)
+        }
+      },
+    )
+  }
+}
+
+const textFromProps = (props: Record<string, unknown>): string[] => {
+  const values: string[] = []
+
+  ;[
+    'markdown',
+    'body',
+    'text',
+    'content',
+    'description',
+    'caption',
+    'question',
+    'answer',
+    'explanation',
+    'prompt',
+    'hiddenText',
+    'definition',
+    'term',
+    'code',
+  ].forEach((key) => {
+    const text = normalizeText(props[key])
+    if (text) {
+      values.push(text)
+    }
+  })
+
+  const items = props.items
+  if (Array.isArray(items)) {
+    values.push(
+      items
+        .map((item) => normalizeText(item))
+        .filter(Boolean)
+        .join('\n'),
+    )
+  } else if (typeof items === 'string') {
+    values.push(items)
+  }
+
+  const rows = props.rows
+  if (Array.isArray(rows)) {
+    values.push(
+      rows
+        .map((row) =>
+          Array.isArray(row)
+            ? row.map(normalizeText).join(' | ')
+            : normalizeText(row),
+        )
+        .filter(Boolean)
+        .join('\n'),
+    )
+  }
+
+  const options = props.options
+  if (Array.isArray(options)) {
+    values.push(options.map(normalizeText).filter(Boolean).join('\n'))
+  }
+
+  return values.map(normalizeText).filter(Boolean)
+}
+
+const componentToChunks = (
+  component: unknown,
+  node: DashboardLayout,
+  chunks: DashboardSourceChunk[],
+  path: string[],
+): void => {
+  if (!component || typeof component !== 'object') {
+    return
+  }
+
+  const record = component as Record<string, unknown>
+  const props =
+    record.props && typeof record.props === 'object'
+      ? (record.props as Record<string, unknown>)
+      : {}
+  const text = textFromProps(props).join('\n\n')
+
+  if (text) {
+    chunks.push({
+      id: String(record.id || path.join('-') || chunks.length),
+      title: titleFrom(props.title, record.name, node.name),
+      type: String(
+        props.__blockType || record.type || node.component || 'widget',
+      ),
+      text: truncate(text, MAX_CHUNK_LENGTH),
+    })
+  }
+
+  if (!text) {
+    const fallbackValues: string[] = []
+    collectTextDeep(props, fallbackValues)
+    const fallbackText = Array.from(new Set(fallbackValues)).join('\n')
+    if (fallbackText) {
+      chunks.push({
+        id: String(record.id || path.join('-') || chunks.length),
+        title: titleFrom(props.title, record.name, node.name),
+        type: String(
+          props.__blockType || record.type || node.component || 'widget',
+        ),
+        text: truncate(fallbackText, MAX_CHUNK_LENGTH),
+      })
+    }
+  }
+
+  const children = Array.isArray(record.children) ? record.children : []
+  children.forEach((child, index) =>
+    componentToChunks(child, node, chunks, [...path, String(index)]),
+  )
+}
+
+const collectChunksFromLayout = (
+  node: DashboardLayout | undefined,
+  chunks: DashboardSourceChunk[],
+  path: string[] = [],
+): void => {
+  if (!node) {
+    return
+  }
+
+  const customProps = node.config?.customProps
+  let components = Array.isArray(customProps?.components)
+    ? customProps.components
+    : []
+
+  if (
+    components.length === 0 &&
+    typeof customProps?.widgetId === 'string' &&
+    typeof window !== 'undefined'
+  ) {
+    components =
+      WidgetStorage.getWidgetById(customProps.widgetId)?.components || []
+  }
+
+  components.forEach((component, index) =>
+    componentToChunks(component, node, chunks, [...path, String(index)]),
+  )
+
+  const nodeText = [node.name, node.component]
+    .map(normalizeText)
+    .filter(Boolean)
+    .join('\n')
+  if (node.component && nodeText && components.length === 0) {
+    chunks.push({
+      id: node.id || path.join('-') || `node-${chunks.length}`,
+      title: titleFrom(node.name, node.component),
+      type: node.component,
+      text: truncate(nodeText, MAX_CHUNK_LENGTH),
+    })
+  }
+
+  if (components.length === 0 && customProps) {
+    const fallbackValues: string[] = []
+    collectTextDeep(customProps, fallbackValues)
+    const fallbackText = Array.from(new Set(fallbackValues)).join('\n')
+    if (fallbackText) {
+      chunks.push({
+        id: `${node.id || path.join('-') || chunks.length}-custom-props`,
+        title: titleFrom(node.name, node.component),
+        type: node.component || 'dashboard widget',
+        text: truncate(fallbackText, MAX_CHUNK_LENGTH),
+      })
+    }
+  }
+  ;(node.children || []).forEach((child, index) =>
+    collectChunksFromLayout(child, chunks, [...path, String(index)]),
+  )
+}
+
+const scoreChunk = (chunk: DashboardSourceChunk, question: string): number => {
+  const terms = question
+    .toLowerCase()
+    .split(/[^a-z0-9áéíóúüñ]+/i)
+    .filter((term) => term.length > 2)
+  const haystack = `${chunk.title} ${chunk.type} ${chunk.text}`.toLowerCase()
+
+  return terms.reduce(
+    (score, term) => score + (haystack.includes(term) ? 2 : 0),
+    chunk.type.toLowerCase().includes('source') ? 2 : 0,
+  )
+}
+
+export const buildDashboardChatContext = (
+  dashboard: StateDashboard | undefined,
+): DashboardChatContext => {
+  const chunks: DashboardSourceChunk[] = []
+  collectChunksFromLayout(dashboard?.layout, chunks)
+
+  return {
+    dashboardId: dashboard?.id || 'unknown-dashboard',
+    dashboardTitle: dashboard?.name || 'Dashboard',
+    chunks,
+  }
+}
+
+export const selectDashboardChatChunks = (
+  context: DashboardChatContext,
+  question: string,
+): DashboardSourceChunk[] => {
+  let totalLength = 0
+
+  return [...context.chunks]
+    .map((chunk) => ({ chunk, score: scoreChunk(chunk, question) }))
+    .sort((left, right) => right.score - left.score)
+    .map(({ chunk }) => chunk)
+    .filter((chunk) => {
+      if (totalLength >= MAX_CONTEXT_LENGTH) {
+        return false
+      }
+
+      totalLength += chunk.text.length
+      return true
+    })
+}
+
+export const formatDashboardChatContext = (
+  context: DashboardChatContext,
+  chunks: DashboardSourceChunk[],
+): string =>
+  [`Dashboard: ${context.dashboardTitle}`]
+    .concat(
+      chunks.map(
+        (chunk, index) =>
+          `Source ${index + 1}: ${chunk.title} (${chunk.type})\n${chunk.text}`,
+      ),
+    )
+    .join('\n\n---\n\n')

--- a/apps/studymesh/src/dashboardChat/contextBuilder.ts
+++ b/apps/studymesh/src/dashboardChat/contextBuilder.ts
@@ -263,11 +263,34 @@ export const buildDashboardChatContext = (
   dashboard: StateDashboard | undefined,
 ): DashboardChatContext => {
   const chunks: DashboardSourceChunk[] = []
+
+  if (dashboard?.kind === 'studyPathContainer' && dashboard.studyPath) {
+    const dashboards = dashboard.studyPath.dashboards || []
+    const selectedDashboard = dashboards[dashboard.studyPath.selectedIndex]
+    const orderedDashboards = selectedDashboard
+      ? [
+          selectedDashboard,
+          ...dashboards.filter(
+            (item) => item.dashboardKey !== selectedDashboard.dashboardKey,
+          ),
+        ]
+      : dashboards
+
+    orderedDashboards.forEach((studyDashboard, index) => {
+      const beforeCount = chunks.length
+      collectChunksFromLayout(studyDashboard.layout, chunks, [String(index)])
+
+      chunks.slice(beforeCount).forEach((chunk) => {
+        chunk.title = `${studyDashboard.name}: ${chunk.title}`
+      })
+    })
+  }
+
   collectChunksFromLayout(dashboard?.layout, chunks)
 
   return {
     dashboardId: dashboard?.id || 'unknown-dashboard',
-    dashboardTitle: dashboard?.name || 'Dashboard',
+    dashboardTitle: dashboard?.studyPath?.title || dashboard?.name || 'Dashboard',
     chunks,
   }
 }

--- a/apps/studymesh/tests/unit/dashboard/dashboardChatContext.test.ts
+++ b/apps/studymesh/tests/unit/dashboard/dashboardChatContext.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildDashboardChatContext,
+  selectDashboardChatChunks,
+} from '../../../src/dashboardChat/contextBuilder'
+
+const dashboard = {
+  id: 'dashboard-1',
+  name: 'French Subjunctive',
+  layout: {
+    type: 'row',
+    children: [
+      {
+        type: 'tabset',
+        children: [
+          {
+            type: 'tab',
+            name: 'Source notes',
+            component: 'CustomWidget',
+            config: {
+              customProps: {
+                components: [
+                  {
+                    id: 'source-markdown',
+                    type: 'MarkdownBlock',
+                    props: {
+                      __blockType: 'MarkdownBlock',
+                      title: 'Source notes',
+                      markdown:
+                        'Use the subjunctive after il faut que and other trigger phrases.',
+                    },
+                  },
+                  {
+                    id: 'quiz',
+                    type: 'QuizBlock',
+                    props: {
+                      __blockType: 'QuizBlock',
+                      question: 'Which mood follows il faut que?',
+                      answer: 'The subjunctive.',
+                      explanation: 'Il faut que is a subjunctive trigger.',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+
+describe('dashboard chat context builder', () => {
+  it('extracts useful source chunks from dashboard widget custom props', () => {
+    const context = buildDashboardChatContext(dashboard)
+
+    expect(context.dashboardTitle).toBe('French Subjunctive')
+    expect(context.chunks).toHaveLength(2)
+    expect(context.chunks[0].text).toContain('subjunctive')
+    expect(context.chunks[1].text).toContain('Which mood follows')
+  })
+
+  it('ranks chunks by the user question', () => {
+    const context = buildDashboardChatContext(dashboard)
+    const chunks = selectDashboardChatChunks(context, 'trigger phrases')
+
+    expect(chunks[0].title).toBe('Source notes')
+  })
+})

--- a/apps/studymesh/tests/unit/dashboard/dashboardChatContext.test.ts
+++ b/apps/studymesh/tests/unit/dashboard/dashboardChatContext.test.ts
@@ -67,37 +67,82 @@ describe('dashboard chat context builder', () => {
     expect(chunks[0].title).toBe('Source notes')
   })
 
-  it('extracts source chunks from dashboards inside a study path workspace', () => {
-    const context = buildDashboardChatContext({
-      id: 'path-1',
-      name: 'Spanish Study Path Workspace',
-      kind: 'studyPathContainer',
-      layout: {
-        type: 'row',
-        children: [],
-      },
-      studyPath: {
-        pathId: 'spanish-path',
-        title: 'Spanish Basics',
-        folderName: 'Spanish',
-        selectedIndex: 0,
-        dashboards: [
-          {
-            id: 'lesson-dashboard',
-            name: 'Lesson 1',
-            dashboardKey: 'lesson-1',
-            dashboardIndex: 0,
-            dashboardCount: 1,
-            folderName: 'Spanish',
-            layout: dashboard.layout,
+  const studyPathWorkspace = {
+    id: 'path-1',
+    name: 'Spanish Study Path Workspace',
+    kind: 'studyPathContainer' as const,
+    layout: {
+      type: 'row',
+      children: [],
+    },
+    studyPath: {
+      pathId: 'spanish-path',
+      title: 'Spanish Basics',
+      folderName: 'Spanish',
+      selectedIndex: 0,
+      dashboards: [
+        {
+          id: 'lesson-dashboard',
+          name: 'Lesson 1',
+          dashboardKey: 'lesson-1',
+          dashboardIndex: 0,
+          dashboardCount: 2,
+          folderName: 'Spanish',
+          layout: dashboard.layout,
+        },
+        {
+          id: 'lesson-dashboard-2',
+          name: 'Lesson 2',
+          dashboardKey: 'lesson-2',
+          dashboardIndex: 1,
+          dashboardCount: 2,
+          folderName: 'Spanish',
+          layout: {
+            type: 'row',
+            children: [
+              {
+                type: 'tab',
+                name: 'Generated quiz',
+                component: 'CustomWidget',
+                config: {
+                  customProps: {
+                    components: [
+                      {
+                        id: 'quiz-only',
+                        type: 'QuizBlock',
+                        props: {
+                          __blockType: 'QuizBlock',
+                          question: 'What is estar used for?',
+                          answer: 'Temporary states.',
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
           },
-        ],
-      },
-    })
+        },
+      ],
+    },
+  }
+
+  it('extracts source chunks from dashboards inside a study path workspace', () => {
+    const context = buildDashboardChatContext(studyPathWorkspace)
 
     expect(context.dashboardTitle).toBe('Spanish Basics')
-    expect(context.chunks).toHaveLength(2)
+    expect(context.chunks).toHaveLength(3)
     expect(context.chunks[0].title).toBe('Lesson 1: Source notes')
     expect(context.chunks[0].text).toContain('subjunctive')
+  })
+
+  it('can limit local chat context to source notes in the selected study path dashboard', () => {
+    const context = buildDashboardChatContext(studyPathWorkspace, {
+      sourceNotesOnly: true,
+      studyPathScope: 'selected',
+    })
+
+    expect(context.chunks).toHaveLength(1)
+    expect(context.chunks[0].title).toBe('Lesson 1: Source notes')
   })
 })

--- a/apps/studymesh/tests/unit/dashboard/dashboardChatContext.test.ts
+++ b/apps/studymesh/tests/unit/dashboard/dashboardChatContext.test.ts
@@ -66,4 +66,38 @@ describe('dashboard chat context builder', () => {
 
     expect(chunks[0].title).toBe('Source notes')
   })
+
+  it('extracts source chunks from dashboards inside a study path workspace', () => {
+    const context = buildDashboardChatContext({
+      id: 'path-1',
+      name: 'Spanish Study Path Workspace',
+      kind: 'studyPathContainer',
+      layout: {
+        type: 'row',
+        children: [],
+      },
+      studyPath: {
+        pathId: 'spanish-path',
+        title: 'Spanish Basics',
+        folderName: 'Spanish',
+        selectedIndex: 0,
+        dashboards: [
+          {
+            id: 'lesson-dashboard',
+            name: 'Lesson 1',
+            dashboardKey: 'lesson-1',
+            dashboardIndex: 0,
+            dashboardCount: 1,
+            folderName: 'Spanish',
+            layout: dashboard.layout,
+          },
+        ],
+      },
+    })
+
+    expect(context.dashboardTitle).toBe('Spanish Basics')
+    expect(context.chunks).toHaveLength(2)
+    expect(context.chunks[0].title).toBe('Lesson 1: Source notes')
+    expect(context.chunks[0].text).toContain('subjunctive')
+  })
 })


### PR DESCRIPTION
## Summary
- add a right-side Ask Sources panel scoped to the current dashboard
- build grounded dashboard context from widget custom props/source blocks and rank chunks by question
- reuse StudyMesh AI settings for Basic, Local AI, and Gemini responses
- keep chat history per dashboard with empty/loading/error states and source chips

## Verification
- npx prettier --write changed files
- git diff --check
- npm --workspace apps/studymesh run test:unit -- tests/unit/dashboard/dashboardChatContext.test.ts *(blocked: missing optional Rollup native package @rollup/rollup-linux-arm64-gnu in node_modules)*
- npm --workspace apps/studymesh exec tsc -- --noEmit --pretty false *(blocked by existing repo-wide TS issues in Dashboard/WidgetEditor/env/zod/jszip/pdfjs-dist; no new dashboard chat errors appeared before those existing failures)*