### PR TITLE
Equalize mobile workspace section transitions

### DIFF
--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -2103,11 +2103,11 @@ const Dashboards = () => {
             sx: {
               width: '100%',
               maxWidth: '100%',
-              top: 62,
-              bottom: 'calc(64px + env(safe-area-inset-bottom))',
+              top: 56,
+              bottom: 'calc(56px + env(safe-area-inset-bottom))',
               height: 'auto',
               bgcolor: 'background.default',
-              p: '8px',
+              p: '6px 8px 8px',
               boxSizing: 'border-box',
             },
           }}

--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -2106,11 +2106,29 @@ const Dashboards = () => {
               top: 62,
               bottom: 'calc(64px + env(safe-area-inset-bottom))',
               height: 'auto',
-              bgcolor: 'background.paper',
+              bgcolor: 'background.default',
+              p: '8px',
+              boxSizing: 'border-box',
             },
           }}
         >
-          {dashboardChatPanel}
+          <Box
+            sx={{
+              height: '100%',
+              minHeight: 0,
+              overflow: 'hidden',
+              border: 1,
+              borderColor: 'divider',
+              borderRadius: 2,
+              bgcolor: 'background.paper',
+              boxShadow:
+                theme.palette.mode === 'dark'
+                  ? '0 18px 40px rgba(0,0,0,0.42)'
+                  : '0 18px 42px rgba(16,24,40,0.10)',
+            }}
+          >
+            {dashboardChatPanel}
+          </Box>
         </Drawer>
       ) : (
         <Box

--- a/apps/studymesh/src/components/dashboardChat/DashboardChatPanel.tsx
+++ b/apps/studymesh/src/components/dashboardChat/DashboardChatPanel.tsx
@@ -203,7 +203,8 @@ const DashboardChatPanel = ({
   return (
     <Box
       sx={{
-        height: isMobile ? '100dvh' : '100%',
+        height: '100%',
+        minHeight: 0,
         display: 'flex',
         flexDirection: 'column',
         bgcolor: 'background.paper',
@@ -241,8 +242,8 @@ const DashboardChatPanel = ({
                 isLocalAi
                   ? 'Local AI'
                   : settings.provider === 'gemini'
-                  ? 'Gemini'
-                  : 'Basic'
+                    ? 'Gemini'
+                    : 'Basic'
               }
               variant="outlined"
               sx={{ height: 22, fontWeight: 700 }}

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -6,6 +6,7 @@ import {
   Drawer,
   IconButton,
   Paper,
+  Slide,
   Stack,
   Tooltip,
   Typography,
@@ -864,6 +865,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     setActiveFlow('hub')
     setIsStudioOpen(true)
     if (isMobile) {
+      window.dispatchEvent(new Event(CLOSE_DASHBOARD_CHAT_EVENT))
       setMobileSection('creation')
     }
   }
@@ -1154,34 +1156,55 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
           sx={{
             flex: 1,
             minHeight: 0,
-            display: mobileSection === 'creation' ? 'block' : 'none',
+            position: 'relative',
             overflow: 'hidden',
-            p: '8px',
-            boxSizing: 'border-box',
           }}
         >
           <Box
             sx={{
-              height: '100%',
-              overflow: 'hidden',
-              border: 1,
-              borderColor: 'divider',
-              borderRadius: 2,
-              bgcolor: 'background.paper',
+              position: 'absolute',
+              inset: 0,
+              ...workspaceCanvasSx,
             }}
           >
-            {studioContent}
+            {children}
           </Box>
-        </Box>
-        <Box
-          sx={{
-            flex: 1,
-            minHeight: 0,
-            display: mobileSection === 'creation' ? 'none' : 'block',
-            ...workspaceCanvasSx,
-          }}
-        >
-          {children}
+          <Slide
+            direction="right"
+            in={mobileSection === 'creation'}
+            mountOnEnter
+            unmountOnExit
+            timeout={{ enter: 260, exit: 220 }}
+          >
+            <Box
+              sx={{
+                position: 'absolute',
+                inset: 0,
+                overflow: 'hidden',
+                p: '8px',
+                boxSizing: 'border-box',
+                zIndex: 2,
+                bgcolor: 'background.default',
+              }}
+            >
+              <Box
+                sx={{
+                  height: '100%',
+                  overflow: 'hidden',
+                  border: 1,
+                  borderColor: 'divider',
+                  borderRadius: 2,
+                  bgcolor: 'background.paper',
+                  boxShadow:
+                    theme.palette.mode === 'dark'
+                      ? '0 18px 40px rgba(0,0,0,0.42)'
+                      : '0 18px 42px rgba(16,24,40,0.10)',
+                }}
+              >
+                {studioContent}
+              </Box>
+            </Box>
+          </Slide>
         </Box>
         {mobileSectionTabs}
         {widgetBuilderDialog}


### PR DESCRIPTION
## Summary
- Add the same sliding mobile transition feeling to the Creation section that AI Chat already had
- Keep the dashboard layer underneath so Creation can slide away while AI Chat slides in, and vice versa
- Give the mobile AI Chat panel the same bordered, rounded card treatment as the Creation section

## Verification
- git diff --check
- npm run build --workspace apps/studymesh
