### PR TITLE
Fix mobile creation option selection

### DIFF
--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -310,13 +310,20 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
   }, [])
 
   useEffect(() => {
-    const activateCreation = (flow: Exclude<StudioFlow, 'hub'>) =>
+    const activateCreation = (flow: Exclude<StudioFlow, 'hub'>) => {
       createNewDraft(flow)
+      if (isMobile) {
+        setMobileSection('creation')
+      }
+    }
     const handleOpenCreateHub = (event: Event) => {
       const customEvent = event as CustomEvent<{ intent?: CreateIntent }>
       setSelectedIntent(customEvent.detail?.intent || null)
       setActiveFlow('hub')
       setIsStudioOpen(true)
+      if (isMobile) {
+        setMobileSection('creation')
+      }
     }
 
     const handleOpenWidgetEditor = (event: Event) => {
@@ -458,6 +465,9 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     setActiveDraftByFlow((current) => ({ ...current, [flow]: draft.id }))
     setActiveFlow(flow)
     setIsStudioOpen(true)
+    if (isMobile) {
+      setMobileSection('creation')
+    }
   }
 
   const removeDraft = (draftId: string, flow: Exclude<StudioFlow, 'hub'>) => {
@@ -1225,6 +1235,13 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
           display: 'flex',
           flexDirection: 'column',
           bgcolor: 'background.default',
+          ...(isStudioOpen && mobileSection === 'creation'
+            ? {
+                '& [data-testid="study-path-navigator-overlay"]': {
+                  display: 'none',
+                },
+              }
+            : {}),
         }}
       >
         <Box


### PR DESCRIPTION
## Summary\n- Keep the mobile workspace on the Creation panel when a creation option is opened from phone navigation/events\n- Ensure Create hub events also switch the mobile tab to Creation\n\n## Verification\n- npm run build (apps/studymesh)\n- npx vitest --run --config ./vitest.config.ts ./tests/unit/components/topnavbar/TopNavBar.test.tsx (fails: existing TopNavBar test expectations can’t find mocked creation buttons / Settings in this branch)