### PR TITLE
Allow desktop tab moves and edit saved dashboards from navbar

### DIFF
--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -1958,8 +1958,7 @@ const Dashboards = () => {
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
               {!isMobileDashboardView &&
                 isAdmin &&
-                dashboard.layout?.children &&
-                dashboard.layout.children.length > 0 && (
+                dashboard.kind !== 'studyPathContainer' && (
                   <TooltipStyled title="Edit Dashboard">
                     <IconButton
                       aria-label={`Edit dashboard ${dashboard.name}`}
@@ -2099,9 +2098,7 @@ const Dashboards = () => {
               </Typography>
             </TooltipStyled>
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
-              {isAdmin &&
-                dashboard.layout?.children &&
-                dashboard.layout.children.length > 0 && (
+              {isAdmin && dashboard.kind !== 'studyPathContainer' && (
                   <TooltipStyled title="Edit Dashboard">
                     <IconButton
                       aria-label={`Edit dashboard ${dashboard.name}`}

--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -1911,10 +1911,11 @@ const Dashboards = () => {
       onDrop={isMobileDashboardView ? undefined : dropDashboardTabAtEnd}
     >
       {openDashboards.map((dashboard, index) => {
-        const isOnlyEmptyDashboard =
-          openDashboards.length === 1 &&
+        const isEmptyDashboard =
           dashboard.kind !== 'studyPathContainer' &&
           !hasDashboardContent(dashboard.layout)
+        const isOnlyEmptyDashboard =
+          openDashboards.length === 1 && isEmptyDashboard
 
         return (
           <Tab
@@ -1958,6 +1959,7 @@ const Dashboards = () => {
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
               {!isMobileDashboardView &&
                 isAdmin &&
+                !isEmptyDashboard &&
                 dashboard.kind !== 'studyPathContainer' && (
                   <TooltipStyled title="Edit Dashboard">
                     <IconButton
@@ -2053,10 +2055,11 @@ const Dashboards = () => {
       onDrop={dropDashboardTabAtEnd}
     >
       {openDashboards.map((dashboard, index) => {
-        const isOnlyEmptyDashboard =
-          openDashboards.length === 1 &&
+        const isEmptyDashboard =
           dashboard.kind !== 'studyPathContainer' &&
           !hasDashboardContent(dashboard.layout)
+        const isOnlyEmptyDashboard =
+          openDashboards.length === 1 && isEmptyDashboard
         const isSelected = selectedDashboard === index
 
         return (
@@ -2098,7 +2101,9 @@ const Dashboards = () => {
               </Typography>
             </TooltipStyled>
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
-              {isAdmin && dashboard.kind !== 'studyPathContainer' && (
+              {isAdmin &&
+                !isEmptyDashboard &&
+                dashboard.kind !== 'studyPathContainer' && (
                   <TooltipStyled title="Edit Dashboard">
                     <IconButton
                       aria-label={`Edit dashboard ${dashboard.name}`}

--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -1262,8 +1262,17 @@ const Dashboards = () => {
         return
       }
 
-      const customEvent = event as CustomEvent<{ host?: string }>
+      const customEvent = event as CustomEvent<{
+        host?: string
+        dashboard?: SavedDashboard
+      }>
       if (customEvent.detail?.host === 'studio') {
+        return
+      }
+
+      if (customEvent.detail?.dashboard) {
+        loadSavedDashboardInBuilder(customEvent.detail.dashboard)
+        dispatchWorkspaceOnboardingEvent({ type: 'dashboard-editor-opened' })
         return
       }
 

--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -921,6 +921,31 @@ const Dashboards = () => {
     dispatchWorkspaceOnboardingEvent({ type: 'dashboard-editor-opened' })
   }
 
+  const openStudyPathDashboardEditor = (dashboard: StateDashboard) => {
+    if (!isAdmin || !dashboard.studyPath) {
+      return
+    }
+
+    const selectedLessonIndex = Math.min(
+      Math.max(dashboard.studyPath.selectedIndex || 0, 0),
+      Math.max(dashboard.studyPath.dashboards.length - 1, 0),
+    )
+    const selectedLesson = dashboard.studyPath.dashboards[selectedLessonIndex]
+
+    if (!selectedLesson) {
+      return
+    }
+
+    setDashboardEditorId(null)
+    setDraftDashboard({
+      id: `draft-dashboard-${Date.now()}`,
+      name: selectedLesson.name,
+      layout: selectedLesson.layout,
+      savedDashboardId: selectedLesson.id,
+    })
+    dispatchWorkspaceOnboardingEvent({ type: 'dashboard-editor-opened' })
+  }
+
   const createDashboardInEditor = () => {
     if (!isAdmin) {
       return
@@ -1688,6 +1713,36 @@ const Dashboards = () => {
         }
 
         DashboardStorage.save(dashboardToSave)
+        openDashboards.forEach((openDashboard) => {
+          if (
+            openDashboard.kind !== 'studyPathContainer' ||
+            !openDashboard.studyPath ||
+            !draftDashboard.savedDashboardId
+          ) {
+            return
+          }
+
+          const lessonIndex = openDashboard.studyPath.dashboards.findIndex(
+            (lesson) => lesson.id === draftDashboard.savedDashboardId,
+          )
+
+          if (lessonIndex < 0) {
+            return
+          }
+
+          updateStudyPathContainer(openDashboard.id, (studyPath) => ({
+            ...studyPath,
+            dashboards: studyPath.dashboards.map((lesson, index) =>
+              index === lessonIndex
+                ? {
+                    ...lesson,
+                    name: dashboardToSave.name,
+                    layout: dashboardToSave.layout,
+                  }
+                : lesson,
+            ),
+          }))
+        })
         loadDashboardOptions()
         dispatchWorkspaceOnboardingEvent({
           type: 'dashboard-saved',
@@ -1959,14 +2014,17 @@ const Dashboards = () => {
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
               {!isMobileDashboardView &&
                 isAdmin &&
-                !isEmptyDashboard &&
-                dashboard.kind !== 'studyPathContainer' && (
+                !isEmptyDashboard && (
                   <TooltipStyled title="Edit Dashboard">
                     <IconButton
                       aria-label={`Edit dashboard ${dashboard.name}`}
                       size="small"
                       onClick={(ev) => {
                         ev.stopPropagation()
+                        if (dashboard.kind === 'studyPathContainer') {
+                          openStudyPathDashboardEditor(dashboard)
+                          return
+                        }
                         openDashboardEditor(dashboard.id)
                       }}
                       sx={{
@@ -2102,14 +2160,17 @@ const Dashboards = () => {
             </TooltipStyled>
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
               {isAdmin &&
-                !isEmptyDashboard &&
-                dashboard.kind !== 'studyPathContainer' && (
+                !isEmptyDashboard && (
                   <TooltipStyled title="Edit Dashboard">
                     <IconButton
                       aria-label={`Edit dashboard ${dashboard.name}`}
                       size="small"
                       onClick={(ev) => {
                         ev.stopPropagation()
+                        if (dashboard.kind === 'studyPathContainer') {
+                          openStudyPathDashboardEditor(dashboard)
+                          return
+                        }
                         openDashboardEditor(dashboard.id)
                       }}
                       sx={{

--- a/apps/studymesh/src/components/Dasboard/DashboardOptionsMenu.tsx
+++ b/apps/studymesh/src/components/Dasboard/DashboardOptionsMenu.tsx
@@ -22,6 +22,7 @@ import { DashboardLayout, StudyPathContainerState } from '../../state/store'
 import { useDashboards } from './DashboardProvider'
 import {
   ensureStarterDashboards,
+  OPEN_DASHBOARD_EDITOR_EVENT,
   OPEN_SAVED_DASHBOARDS_EVENT,
 } from '../../customHooks/useWorkspaceActions'
 import {
@@ -342,6 +343,19 @@ const DashboardOptionsMenu: React.FC<DashboardOptionsMenuProps> = ({
       dashboardId: dashboard.id,
       dashboardName: dashboard.name,
     })
+  }
+
+  const openDashboardInBuilder = (
+    event: React.MouseEvent<HTMLElement>,
+    dashboard: SavedDashboard,
+  ) => {
+    event.stopPropagation()
+    handleClose()
+    window.dispatchEvent(
+      new CustomEvent(OPEN_DASHBOARD_EDITOR_EVENT, {
+        detail: { host: 'workspace-builder', dashboard },
+      }),
+    )
   }
 
   const loadDashboardFolder = (dashboards: SavedDashboard[]) => {
@@ -827,7 +841,24 @@ const DashboardOptionsMenu: React.FC<DashboardOptionsMenuProps> = ({
                         },
                       }}
                     >
-                      {dashboard.name}
+                      <ListItemText
+                        primary={dashboard.name}
+                        primaryTypographyProps={{ noWrap: true }}
+                      />
+                      {isAdmin && (
+                        <Tooltip title={`Edit ${dashboard.name}`}>
+                          <IconButton
+                            size="small"
+                            aria-label={`Edit ${dashboard.name}`}
+                            onClick={(event) =>
+                              openDashboardInBuilder(event, dashboard)
+                            }
+                            sx={{ color: folderColor, p: 0.5, ml: 1 }}
+                          >
+                            <EditIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      )}
                     </MenuItem>
                   ))}
                   {!isFolderExpanded &&
@@ -972,7 +1003,24 @@ const DashboardOptionsMenu: React.FC<DashboardOptionsMenuProps> = ({
                         },
                       }}
                     >
-                      {dashboard.name}
+                      <ListItemText
+                        primary={dashboard.name}
+                        primaryTypographyProps={{ noWrap: true }}
+                      />
+                      {isAdmin && (
+                        <Tooltip title={`Edit ${dashboard.name}`}>
+                          <IconButton
+                            size="small"
+                            aria-label={`Edit ${dashboard.name}`}
+                            onClick={(event) =>
+                              openDashboardInBuilder(event, dashboard)
+                            }
+                            sx={{ color: folderColor, p: 0.5, ml: 1 }}
+                          >
+                            <EditIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      )}
                     </MenuItem>
                   ))}
                   {!isFolderExpanded &&

--- a/apps/studymesh/src/components/Layout/Layout.tsx
+++ b/apps/studymesh/src/components/Layout/Layout.tsx
@@ -69,6 +69,41 @@ const CONFIG = {
   borders: [],
 }
 
+const withDesktopTabMovementEnabled = (
+  node: DashboardLayout | undefined,
+): DashboardLayout | undefined => {
+  if (!node) {
+    return node
+  }
+
+  const children = node.children?.map((child) =>
+    withDesktopTabMovementEnabled(child),
+  ) as DashboardLayout[] | undefined
+
+  if (node.type === 'tab') {
+    return {
+      ...node,
+      children,
+      enableDrag: true,
+    } as DashboardLayout
+  }
+
+  if (node.type === 'tabset') {
+    return {
+      ...node,
+      children,
+      enableDrag: true,
+      enableDrop: true,
+      enableDivide: true,
+    } as DashboardLayout
+  }
+
+  return {
+    ...node,
+    children,
+  }
+}
+
 const EmptyWidget = () => (
   <div
     style={{
@@ -127,7 +162,9 @@ const DashboardLayoutView: React.FC<DashboardLayoutViewProps> = ({
         tabSetEnableClose: !readOnly,
         splitterEnableHandle: !readOnly,
       },
-      layout: layout || {},
+      layout: readOnly
+        ? layout || {}
+        : withDesktopTabMovementEnabled(layout) || {},
     })
     return Model.fromJson(config)
   }, [layout, readOnly])

--- a/apps/studymesh/src/components/Layout/Layout.tsx
+++ b/apps/studymesh/src/components/Layout/Layout.tsx
@@ -121,6 +121,8 @@ const DashboardLayoutView: React.FC<DashboardLayoutViewProps> = ({
         tabEnableDrag: !readOnly,
         tabEnableFloat: !readOnly,
         tabSetEnableDrag: !readOnly,
+        tabSetEnableDrop: !readOnly,
+        tabSetEnableDivide: !readOnly,
         tabEnableClose: !readOnly,
         tabSetEnableClose: !readOnly,
         splitterEnableHandle: !readOnly,

--- a/apps/studymesh/src/state/store.ts
+++ b/apps/studymesh/src/state/store.ts
@@ -41,6 +41,9 @@ export interface DashboardLayout {
   active?: boolean
   selected?: number
   weight?: number
+  enableDrag?: boolean
+  enableDrop?: boolean
+  enableDivide?: boolean
   children?: DashboardLayout[]
 }
 


### PR DESCRIPTION
## Summary\n- Explicitly enable desktop dashboard tab dropping/dividing so workspace tabs can be moved between tabsets\n- Add edit pen actions to saved dashboard entries in the top navbar Library menu\n- Open the Create Dashboard builder preloaded with the selected saved dashboard when using the pen action\n\n## Verification\n- npm run build (apps/studymesh)