### PR TITLE
StudyMesh:MAIN Polish Creation panel quick workflows

### DIFF
--- a/apps/studymesh/src/components/studyPack/CreateStudyPathModal.tsx
+++ b/apps/studymesh/src/components/studyPack/CreateStudyPathModal.tsx
@@ -590,6 +590,13 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
     }
 
     if (error) {
+      if (
+        autoCreateOnGenerate &&
+        autoRetrySignalRef.current !== autoRetrySignal
+      ) {
+        return
+      }
+
       onStatusChange?.('error', error)
       return
     }
@@ -599,7 +606,15 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
     }
 
     onStatusChange?.('idle')
-  }, [autoCreateOnGenerate, draft, error, isGenerating, onStatusChange, step])
+  }, [
+    autoCreateOnGenerate,
+    autoRetrySignal,
+    draft,
+    error,
+    isGenerating,
+    onStatusChange,
+    step,
+  ])
 
   const cancelActiveGeneration = () => {
     activeGenerationRef.current?.abort()

--- a/apps/studymesh/src/components/studyPack/CreateStudyPathModal.tsx
+++ b/apps/studymesh/src/components/studyPack/CreateStudyPathModal.tsx
@@ -71,6 +71,7 @@ interface CreateStudyPathModalProps {
   onContinueInBackground?: () => void
   autoCreateOnGenerate?: boolean
   openGeneratedInWorkspace?: boolean
+  autoRetrySignal?: number
   onStatusChange?: (state: WorkspaceCreationTaskState, message?: string) => void
   onDraftMetaChange?: (metadata: {
     title: string
@@ -131,6 +132,7 @@ const GEMINI_STUDY_PATH_ESTIMATES_MS: Record<
   deep: 90 * 1000,
 }
 const BASIC_FALLBACK_STUDY_PATH_DELAY_MS = 10 * 1000
+const DEFAULT_STUDY_PATH_PROMPT = 'Learn French level B2'
 
 interface GeminiTimedProgress {
   startedAt: number
@@ -519,6 +521,7 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
   onContinueInBackground,
   autoCreateOnGenerate = false,
   openGeneratedInWorkspace,
+  autoRetrySignal = 0,
   onStatusChange,
   onDraftMetaChange,
   initialPrompt,
@@ -528,7 +531,9 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
 }) => {
   const [step, setStep] = useState<'prompt' | 'review'>('prompt')
   const [sourceMode, setSourceMode] = useState<'prompt' | 'dashboard'>('prompt')
-  const [prompt, setPrompt] = useState(initialPrompt || '')
+  const [prompt, setPrompt] = useState(
+    initialPrompt || DEFAULT_STUDY_PATH_PROMPT,
+  )
   const [aiProvider, setAiProvider] = useState<StudyPackAiProvider>('basic')
   const [generationAmount, setGenerationAmount] =
     useState<GenerationAmount>('average')
@@ -550,6 +555,7 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
   const [error, setError] = useState('')
   const activeGenerationRef = useRef<AbortController | null>(null)
   const initializedProviderRef = useRef(false)
+  const autoRetrySignalRef = useRef(autoRetrySignal)
   const debugTrace = combinedDebugTrace(draft)
 
   React.useEffect(() => {
@@ -661,7 +667,7 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
   const reset = () => {
     setStep('prompt')
     setSourceMode('prompt')
-    setPrompt(initialPrompt || '')
+    setPrompt(initialPrompt || DEFAULT_STUDY_PATH_PROMPT)
     setGenerationAmount(aiProvider === 'local' ? 'superSmall' : 'average')
     setAdvancedOpen(false)
     setMustInclude('')
@@ -852,6 +858,17 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
     setError('')
     onStatusChange?.('idle')
   }
+
+  React.useEffect(() => {
+    if (autoRetrySignalRef.current === autoRetrySignal) {
+      return
+    }
+
+    autoRetrySignalRef.current = autoRetrySignal
+    if (autoCreateOnGenerate) {
+      void generatePath()
+    }
+  }, [autoCreateOnGenerate, autoRetrySignal])
 
   const buildPathPayload = (
     pathDraft: AiStudyPathDraft,

--- a/apps/studymesh/src/components/studyPack/CreateStudyPathModal.tsx
+++ b/apps/studymesh/src/components/studyPack/CreateStudyPathModal.tsx
@@ -69,6 +69,8 @@ interface CreateStudyPathModalProps {
   onCollapse?: () => void
   onContinueCreating?: () => void
   onContinueInBackground?: () => void
+  autoCreateOnGenerate?: boolean
+  openGeneratedInWorkspace?: boolean
   onStatusChange?: (state: WorkspaceCreationTaskState, message?: string) => void
   onDraftMetaChange?: (metadata: {
     title: string
@@ -515,6 +517,8 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
   onCollapse,
   onContinueCreating,
   onContinueInBackground,
+  autoCreateOnGenerate = false,
+  openGeneratedInWorkspace,
   onStatusChange,
   onDraftMetaChange,
   initialPrompt,
@@ -584,8 +588,12 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
       return
     }
 
+    if (autoCreateOnGenerate) {
+      return
+    }
+
     onStatusChange?.('idle')
-  }, [draft, error, isGenerating, onStatusChange, step])
+  }, [autoCreateOnGenerate, draft, error, isGenerating, onStatusChange, step])
 
   const cancelActiveGeneration = () => {
     activeGenerationRef.current?.abort()
@@ -733,6 +741,9 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
     )
     setLocalAiFailureDebug(null)
     setError('')
+    if (autoCreateOnGenerate) {
+      onCollapse?.()
+    }
 
     try {
       if (aiProvider === 'basic') {
@@ -796,7 +807,12 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
       const sanitizedDraft = { ...nextDraft, dashboards: sanitizedDashboards }
       setDraft(sanitizedDraft)
       setReviewFolderName(nextDraft.folderName || nextDraft.title || '')
-      setStep('review')
+      if (autoCreateOnGenerate) {
+        onCreatePath(buildPathPayload(sanitizedDraft))
+        reset()
+      } else {
+        setStep('review')
+      }
     } catch (err) {
       if (
         generationController.signal.aborted ||
@@ -837,15 +853,16 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
     onStatusChange?.('idle')
   }
 
-  const createPath = () => {
-    if (!draft) {
-      return
-    }
-
+  const buildPathPayload = (
+    pathDraft: AiStudyPathDraft,
+  ): Parameters<CreateStudyPathModalProps['onCreatePath']>[0] => {
     const effectiveFolder =
-      reviewFolderName.trim() || draft.folderName || draft.title || 'Study Path'
-    const studyPathId = makeStudyPathId(draft.title || effectiveFolder)
-    const dashboardCount = draft.dashboards.length
+      reviewFolderName.trim() ||
+      pathDraft.folderName ||
+      pathDraft.title ||
+      'Study Path'
+    const studyPathId = makeStudyPathId(pathDraft.title || effectiveFolder)
+    const dashboardCount = pathDraft.dashboards.length
     const firstMarkdown = (dashboard: AiStudyPathDraft['dashboards'][number]) =>
       dashboard.objects.find((object) => object.kind === 'markdown')
     const sourceTextForDashboard = (
@@ -856,17 +873,17 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
       return dashboard.rawNotes || markdown?.markdown || prompt
     }
 
-    onCreatePath({
+    return {
       folderName: effectiveFolder,
-      openInWorkspace,
-      dashboards: draft.dashboards.map((dashboard, index) => ({
-        name: dashboard.title || `${draft.title} ${index + 1}`,
+      openInWorkspace: openGeneratedInWorkspace ?? openInWorkspace,
+      dashboards: pathDraft.dashboards.map((dashboard, index) => ({
+        name: dashboard.title || `${pathDraft.title} ${index + 1}`,
         folderName: effectiveFolder,
         layoutMode: 'orchestrator',
         widgets: createStudyPackOrchestratorWidgets(
           {
-            id: makePackId(dashboard.title || draft.title, index),
-            title: dashboard.title || `${draft.title} ${index + 1}`,
+            id: makePackId(dashboard.title || pathDraft.title, index),
+            title: dashboard.title || `${pathDraft.title} ${index + 1}`,
             sourceFormat: dashboard.sourceFormat || 'text',
             objects: dashboard.objects,
             warnings: dashboard.warnings || [],
@@ -878,12 +895,16 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
             includeSourceWidget: true,
             includeSourceSummaryWidget: aiProvider !== 'local',
             includeSummaryChart: false,
-            widgetIdPrefix: makePackId(dashboard.title || draft.title, index),
+            widgetIdPrefix: makePackId(
+              dashboard.title || pathDraft.title,
+              index,
+            ),
             studyPath: {
               pathId: studyPathId,
-              title: draft.title || effectiveFolder,
+              title: pathDraft.title || effectiveFolder,
               dashboardKey: `${studyPathId}-${index + 1}`,
-              dashboardName: dashboard.title || `${draft.title} ${index + 1}`,
+              dashboardName:
+                dashboard.title || `${pathDraft.title} ${index + 1}`,
               dashboardIndex: index + 1,
               dashboardCount,
               folderName: effectiveFolder,
@@ -892,7 +913,15 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
           },
         ),
       })),
-    })
+    }
+  }
+
+  const createPath = () => {
+    if (!draft) {
+      return
+    }
+
+    onCreatePath(buildPathPayload(draft))
     handleClose()
   }
 
@@ -1161,7 +1190,7 @@ const CreateStudyPathModal: React.FC<CreateStudyPathModalProps> = ({
                   Hosted AI is not configured yet.
                 </Alert>
               )}
-              {isGenerating && (
+              {isGenerating && !autoCreateOnGenerate && (
                 <Paper
                   elevation={0}
                   sx={{ p: 2, border: 1, borderColor: 'primary.main' }}

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioLayouts.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioLayouts.tsx
@@ -114,6 +114,7 @@ interface WorkspaceDesktopLayoutProps {
   creationStatusMarkers: React.ReactNode
   widgetBuilderDialog: React.ReactNode
   isStudioOpen: boolean
+  creationQueueActive?: boolean
   studioWidth: number
   openCreateHub: () => void
   startStudioResize: (event: React.MouseEvent<HTMLDivElement>) => void
@@ -126,6 +127,7 @@ export const WorkspaceDesktopLayout = ({
   creationStatusMarkers,
   widgetBuilderDialog,
   isStudioOpen,
+  creationQueueActive = false,
   studioWidth,
   openCreateHub,
   startStudioResize,
@@ -171,7 +173,7 @@ export const WorkspaceDesktopLayout = ({
       >
         {studioContent}
       </Box>
-      {!isStudioOpen && (
+      {!isStudioOpen && !creationQueueActive && (
         <Tooltip title="Open Create" placement="right">
           <Box
             component="button"

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioLayouts.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioLayouts.tsx
@@ -114,7 +114,6 @@ interface WorkspaceDesktopLayoutProps {
   creationStatusMarkers: React.ReactNode
   widgetBuilderDialog: React.ReactNode
   isStudioOpen: boolean
-  creationQueueActive?: boolean
   studioWidth: number
   openCreateHub: () => void
   startStudioResize: (event: React.MouseEvent<HTMLDivElement>) => void
@@ -127,7 +126,6 @@ export const WorkspaceDesktopLayout = ({
   creationStatusMarkers,
   widgetBuilderDialog,
   isStudioOpen,
-  creationQueueActive = false,
   studioWidth,
   openCreateHub,
   startStudioResize,
@@ -173,7 +171,7 @@ export const WorkspaceDesktopLayout = ({
       >
         {studioContent}
       </Box>
-      {!isStudioOpen && !creationQueueActive && (
+      {!isStudioOpen && (
         <Tooltip title="Open Create" placement="right">
           <Box
             component="button"

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -114,7 +114,7 @@ const statusMarkerLabels: Record<
   editing: 'Creation draft open',
   idle: '',
   running: 'Generating study material…',
-  complete: 'Study material ready to review',
+  complete: 'Study material saved to dashboards',
   error: 'Generation failed. Click to review.',
 }
 
@@ -571,6 +571,22 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       : 'Sources required'
   const selectedQuickCreateIntent =
     selectedIntent && selectedIntent !== 'study-path' ? selectedIntent : null
+  const quickCreateJobs = generationDrafts.filter((draft) => draft.quickCreate)
+  const quickCreateStatusLabel = (draft: GenerationDraft) => {
+    if (draft.status === 'generating') {
+      return `Creating ${resourceTypeTitle(draft.selectedResourceType).toLowerCase()}…`
+    }
+
+    if (draft.status === 'ready') {
+      return 'Saved to your dashboards. Click to open it.'
+    }
+
+    if (draft.status === 'failed') {
+      return draft.error || 'Generation failed.'
+    }
+
+    return 'Preparing…'
+  }
 
   useEffect(() => {
     if (
@@ -761,6 +777,8 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     }
 
     setGenerationDrafts((current) => [...current, draft])
+    setActiveFlow('hub')
+    setQuickOptionsOpen(false)
     reportFromNotesStatus('running', `${titleBase} is generating`)
 
     try {
@@ -833,9 +851,9 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       updateDraft(draft.id, {
         status: 'ready',
         title: dashboard.name,
-        inputSummary: 'Ready in workspace',
+        inputSummary: 'Saved to dashboards',
       })
-      reportFromNotesStatus('complete', `${titleBase} ready.`)
+      reportFromNotesStatus('complete', `${titleBase} saved to dashboards.`)
     } catch (error) {
       const message =
         error instanceof Error
@@ -1051,101 +1069,253 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
               </Stack>
             </Paper>
 
-            <Stack spacing={1.25}>
-              <Box>
-                <Typography variant="subtitle1" fontWeight={900}>
-                  Quick Create
-                </Typography>
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ mt: 0.3 }}
+            <Paper
+              elevation={0}
+              sx={{
+                p: { xs: 1.35, sm: 1.5 },
+                borderRadius: 2.5,
+                border: 1,
+                borderColor: 'divider',
+                bgcolor: 'background.default',
+              }}
+            >
+              <Stack spacing={1.25}>
+                <Box>
+                  <Typography variant="subtitle1" fontWeight={900}>
+                    Quick Create
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mt: 0.3 }}
+                  >
+                    {hasCurrentDashboardContext
+                      ? 'Generate focused material from your current dashboard.'
+                      : 'Add material first, then generate focused study material.'}
+                  </Typography>
+                </Box>
+                {!hasCurrentDashboardContext ? (
+                  <Alert severity="info" sx={{ py: 0.5 }}>
+                    The current dashboard is empty. Pick a card and StudyMesh
+                    will open Create from Material with that output selected.
+                  </Alert>
+                ) : null}
+                <Box
+                  sx={{
+                    display: 'grid',
+                    gridTemplateColumns: {
+                      xs: '1fr',
+                      sm: 'repeat(3, minmax(0, 1fr))',
+                    },
+                    gap: 1,
+                  }}
                 >
-                  {hasCurrentDashboardContext
-                    ? 'Generate focused material from your current dashboard.'
-                    : 'Add material first, then generate focused study material.'}
-                </Typography>
-              </Box>
-              {!hasCurrentDashboardContext ? (
-                <Alert severity="info" sx={{ py: 0.5 }}>
-                  The current dashboard is empty. Pick a card to create from
-                  material instead.
-                </Alert>
-              ) : null}
-              <Box
+                  {(['quiz', 'flashcards', 'improvedNotes'] as const).map(
+                    (resourceType) => {
+                      const accent = quickCreateAccents[resourceType]
+                      const selected = false
+
+                      return (
+                        <Paper
+                          key={resourceType}
+                          component="button"
+                          type="button"
+                          elevation={0}
+                          onClick={() =>
+                            handleQuickCreateCardClick(resourceType)
+                          }
+                          sx={{
+                            minHeight: { xs: 82, sm: 110 },
+                            p: { xs: 1.15, sm: 1.35 },
+                            borderRadius: 2,
+                            border: selected ? 2 : 1,
+                            borderColor: selected
+                              ? accent
+                              : !hasCurrentDashboardContext
+                                ? alpha(theme.palette.warning.main, 0.55)
+                                : alpha(
+                                    accent,
+                                    theme.palette.mode === 'dark' ? 0.3 : 0.22,
+                                  ),
+                            bgcolor: alpha(
+                              accent,
+                              selected
+                                ? theme.palette.mode === 'dark'
+                                  ? 0.2
+                                  : 0.12
+                                : theme.palette.mode === 'dark'
+                                  ? 0.12
+                                  : 0.07,
+                            ),
+                            color: 'text.primary',
+                            cursor: 'pointer',
+                            textAlign: 'left',
+                            display: 'flex',
+                            flexDirection: 'row',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                            gap: 1.25,
+                            boxShadow: `0 10px 26px ${alpha(
+                              accent,
+                              theme.palette.mode === 'dark' ? 0.08 : 0.05,
+                            )}`,
+                            '&:hover': {
+                              borderColor: alpha(accent, 0.72),
+                              bgcolor: alpha(
+                                accent,
+                                theme.palette.mode === 'dark' ? 0.18 : 0.1,
+                              ),
+                              transform: 'translateY(-1px)',
+                            },
+                            '&:focus-visible': {
+                              outline: `3px solid ${alpha(accent, 0.26)}`,
+                              outlineOffset: 2,
+                            },
+                            transition:
+                              'background-color 160ms ease, border-color 160ms ease, transform 160ms ease',
+                          }}
+                        >
+                          <Stack spacing={1} sx={{ minWidth: 0 }}>
+                            <Box
+                              sx={{
+                                width: 34,
+                                height: 34,
+                                borderRadius: 1.5,
+                                display: 'grid',
+                                placeItems: 'center',
+                                bgcolor: alpha(
+                                  accent,
+                                  theme.palette.mode === 'dark' ? 0.2 : 0.14,
+                                ),
+                                color: accent,
+                                flex: '0 0 auto',
+                              }}
+                            >
+                              {quickCreateIcons[resourceType]}
+                            </Box>
+                            {selected ? (
+                              <Typography
+                                variant="caption"
+                                fontWeight={900}
+                                sx={{ color: accent, lineHeight: 1 }}
+                              >
+                                Selected
+                              </Typography>
+                            ) : null}
+                            <Typography
+                              variant="subtitle2"
+                              fontWeight={900}
+                              sx={{ lineHeight: 1.15 }}
+                            >
+                              {quickCreateLabels[resourceType]}
+                            </Typography>
+                          </Stack>
+                          <Box
+                            sx={{
+                              width: 26,
+                              height: 26,
+                              borderRadius: '50%',
+                              display: 'grid',
+                              placeItems: 'center',
+                              alignSelf: 'center',
+                              color: alpha(
+                                accent,
+                                theme.palette.mode === 'dark' ? 0.95 : 0.9,
+                              ),
+                              border: 1,
+                              borderColor: alpha(accent, 0.24),
+                              bgcolor: alpha(
+                                accent,
+                                theme.palette.mode === 'dark' ? 0.12 : 0.08,
+                              ),
+                              flex: '0 0 auto',
+                            }}
+                          >
+                            <ChevronRightIcon fontSize="small" />
+                          </Box>
+                        </Paper>
+                      )
+                    },
+                  )}
+                </Box>
+                <Button
+                  size="small"
+                  onClick={() => openCreateFromMaterial()}
+                  aria-expanded={quickOptionsOpen}
+                  sx={{
+                    alignSelf: 'flex-start',
+                    textTransform: 'none',
+                    borderRadius: 999,
+                    px: 0.5,
+                    fontWeight: 800,
+                  }}
+                >
+                  Create from material
+                </Button>
+              </Stack>
+            </Paper>
+
+            {quickCreateJobs.length ? (
+              <Paper
+                elevation={0}
                 sx={{
-                  display: 'grid',
-                  gridTemplateColumns: {
-                    xs: '1fr',
-                    sm: 'repeat(3, minmax(0, 1fr))',
-                  },
-                  gap: 1,
+                  p: { xs: 1.25, sm: 1.5 },
+                  borderRadius: 2.5,
+                  border: 1,
+                  borderColor: alpha(theme.palette.primary.main, 0.24),
+                  bgcolor: alpha(theme.palette.primary.main, 0.045),
                 }}
               >
-                {(['quiz', 'flashcards', 'improvedNotes'] as const).map(
-                  (resourceType) => {
-                    const accent = quickCreateAccents[resourceType]
-                    const selected = false
+                <Stack spacing={1}>
+                  <Box>
+                    <Typography variant="subtitle1" fontWeight={900}>
+                      Creating now
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      StudyMesh saves finished material directly to your
+                      dashboards, NotebookLM-style.
+                    </Typography>
+                  </Box>
+                  {quickCreateJobs.map((draft) => {
+                    const accent =
+                      draft.selectedResourceType === 'quiz' ||
+                      draft.selectedResourceType === 'flashcards' ||
+                      draft.selectedResourceType === 'improvedNotes'
+                        ? quickCreateAccents[draft.selectedResourceType]
+                        : theme.palette.primary.main
+                    const isReady = draft.status === 'ready'
+                    const isFailed = draft.status === 'failed'
 
                     return (
                       <Paper
-                        key={resourceType}
+                        key={draft.id}
                         component="button"
                         type="button"
                         elevation={0}
-                        onClick={() => handleQuickCreateCardClick(resourceType)}
+                        onClick={() => {
+                          if (isReady) {
+                            closeStudio()
+                          }
+                        }}
+                        disabled={!isReady}
                         sx={{
-                          minHeight: { xs: 82, sm: 110 },
-                          p: { xs: 1.15, sm: 1.35 },
+                          width: '100%',
+                          p: 1.1,
                           borderRadius: 2,
-                          border: selected ? 2 : 1,
-                          borderColor: selected
-                            ? accent
-                            : !hasCurrentDashboardContext
-                              ? alpha(theme.palette.warning.main, 0.55)
-                              : alpha(
-                                  accent,
-                                  theme.palette.mode === 'dark' ? 0.3 : 0.22,
-                                ),
+                          border: 1,
+                          borderColor: isFailed
+                            ? 'error.main'
+                            : alpha(accent, isReady ? 0.5 : 0.28),
                           bgcolor: alpha(
                             accent,
-                            selected
-                              ? theme.palette.mode === 'dark'
-                                ? 0.2
-                                : 0.12
-                              : theme.palette.mode === 'dark'
-                                ? 0.12
-                                : 0.07,
+                            theme.palette.mode === 'dark' ? 0.12 : 0.075,
                           ),
                           color: 'text.primary',
-                          cursor: 'pointer',
                           textAlign: 'left',
-                          display: 'flex',
-                          flexDirection: 'row',
-                          justifyContent: 'space-between',
-                          alignItems: 'center',
-                          gap: 1.25,
-                          boxShadow: `0 10px 26px ${alpha(
-                            accent,
-                            theme.palette.mode === 'dark' ? 0.08 : 0.05,
-                          )}`,
-                          '&:hover': {
-                            borderColor: alpha(accent, 0.72),
-                            bgcolor: alpha(
-                              accent,
-                              theme.palette.mode === 'dark' ? 0.18 : 0.1,
-                            ),
-                            transform: 'translateY(-1px)',
-                          },
-                          '&:focus-visible': {
-                            outline: `3px solid ${alpha(accent, 0.26)}`,
-                            outlineOffset: 2,
-                          },
-                          transition:
-                            'background-color 160ms ease, border-color 160ms ease, transform 160ms ease',
+                          cursor: isReady ? 'pointer' : 'default',
                         }}
                       >
-                        <Stack spacing={1} sx={{ minWidth: 0 }}>
+                        <Stack direction="row" spacing={1} alignItems="center">
                           <Box
                             sx={{
                               width: 34,
@@ -1153,76 +1323,59 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                               borderRadius: 1.5,
                               display: 'grid',
                               placeItems: 'center',
-                              bgcolor: alpha(
-                                accent,
-                                theme.palette.mode === 'dark' ? 0.2 : 0.14,
-                              ),
+                              bgcolor: alpha(accent, 0.14),
                               color: accent,
                               flex: '0 0 auto',
                             }}
                           >
-                            {quickCreateIcons[resourceType]}
+                            {draft.selectedResourceType === 'quiz' ? (
+                              <QuizIcon fontSize="small" />
+                            ) : draft.selectedResourceType === 'flashcards' ? (
+                              <StyleIcon fontSize="small" />
+                            ) : (
+                              <AutoStoriesIcon fontSize="small" />
+                            )}
                           </Box>
-                          {selected ? (
+                          <Box sx={{ minWidth: 0, flex: 1 }}>
+                            <Typography
+                              variant="subtitle2"
+                              fontWeight={900}
+                              noWrap
+                            >
+                              {formatDraftTitle(draft)}
+                            </Typography>
                             <Typography
                               variant="caption"
-                              fontWeight={900}
-                              sx={{ color: accent, lineHeight: 1 }}
+                              color="text.secondary"
                             >
-                              Selected
+                              {quickCreateStatusLabel(draft)}
                             </Typography>
-                          ) : null}
-                          <Typography
-                            variant="subtitle2"
-                            fontWeight={900}
-                            sx={{ lineHeight: 1.15 }}
-                          >
-                            {quickCreateLabels[resourceType]}
-                          </Typography>
+                          </Box>
+                          <Chip
+                            size="small"
+                            color={
+                              isFailed
+                                ? 'error'
+                                : isReady
+                                  ? 'success'
+                                  : 'primary'
+                            }
+                            label={
+                              isFailed
+                                ? 'Failed'
+                                : isReady
+                                  ? 'Saved'
+                                  : 'Working'
+                            }
+                            sx={{ fontWeight: 800 }}
+                          />
                         </Stack>
-                        <Box
-                          sx={{
-                            width: 26,
-                            height: 26,
-                            borderRadius: '50%',
-                            display: 'grid',
-                            placeItems: 'center',
-                            alignSelf: 'center',
-                            color: alpha(
-                              accent,
-                              theme.palette.mode === 'dark' ? 0.95 : 0.9,
-                            ),
-                            border: 1,
-                            borderColor: alpha(accent, 0.24),
-                            bgcolor: alpha(
-                              accent,
-                              theme.palette.mode === 'dark' ? 0.12 : 0.08,
-                            ),
-                            flex: '0 0 auto',
-                          }}
-                        >
-                          <ChevronRightIcon fontSize="small" />
-                        </Box>
                       </Paper>
                     )
-                  },
-                )}
-              </Box>
-              <Button
-                size="small"
-                onClick={() => openCreateFromMaterial()}
-                aria-expanded={quickOptionsOpen}
-                sx={{
-                  alignSelf: 'flex-start',
-                  textTransform: 'none',
-                  borderRadius: 999,
-                  px: 0.5,
-                  fontWeight: 800,
-                }}
-              >
-                Create from material
-              </Button>
-            </Stack>
+                  })}
+                </Stack>
+              </Paper>
+            ) : null}
           </>
         ) : (
           <Stack spacing={1.5}>
@@ -1250,8 +1403,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                 color="text.secondary"
                 sx={{ mt: 0.35 }}
               >
-                Add files, pasted notes, images, PDFs, or slides, then choose
-                what StudyMesh should create.
+                Pick the output, source, and options in one focused flow.
               </Typography>
             </Box>
           </Stack>
@@ -1892,6 +2044,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
   }
 
   const visibleCreationMarkers = generationDrafts
+    .filter((draft) => !draft.quickCreate)
     .map((draft) => {
       const state = getDraftMarkerState(draft)
       if (!isStudioOpen && state === 'editing') {

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -193,6 +193,26 @@ const resourceTypeTitle = (resourceType?: string | null) => {
   return 'Dashboard'
 }
 
+const generationMaterialLabel = (draft: GenerationDraft) => {
+  if (draft.flow === 'study-path') {
+    return 'study path'
+  }
+
+  if (draft.selectedResourceType === 'quiz') {
+    return 'quiz'
+  }
+
+  if (draft.selectedResourceType === 'flashcards') {
+    return 'flashcards'
+  }
+
+  if (draft.selectedResourceType === 'improvedNotes') {
+    return 'clear notes'
+  }
+
+  return 'material'
+}
+
 const formatDraftTitle = (draft: GenerationDraft) => {
   const base = draft.title.trim()
   const shortTitle = base.length > 46 ? `${base.slice(0, 45).trim()}...` : base
@@ -601,7 +621,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
   )
   const sortedQueueJobs = [...queueJobs].sort((first, second) => {
     const rank = (draft: GenerationDraft) => {
-      if (draft.status === 'ready' && !draft.openedAt) {
+      if (draft.status === 'ready' && !draft.acknowledgedAt) {
         return 0
       }
 
@@ -609,7 +629,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         return 1
       }
 
-      if (draft.status === 'failed') {
+      if (draft.status === 'failed' && !draft.acknowledgedAt) {
         return 2
       }
 
@@ -627,15 +647,16 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     )
   })
   const queueReadyCount = queueJobs.filter(
-    (draft) => draft.status === 'ready' && !draft.openedAt,
+    (draft) => draft.status === 'ready' && !draft.acknowledgedAt,
   ).length
   const queueGeneratingCount = queueJobs.filter(
     (draft) => draft.status === 'generating',
   ).length
   const queueFailedCount = queueJobs.filter(
-    (draft) => draft.status === 'failed',
+    (draft) => draft.status === 'failed' && !draft.acknowledgedAt,
   ).length
-  const hasQueueMarker = queueJobs.length > 0
+  const hasQueueMarker =
+    queueReadyCount > 0 || queueGeneratingCount > 0 || queueFailedCount > 0
   const queueMarkerLabel =
     queueReadyCount > 0
       ? `${queueReadyCount} generated item${queueReadyCount === 1 ? '' : 's'} ready`
@@ -646,6 +667,15 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
           : 'Creation queue'
 
   const openGenerationQueue = () => {
+    const acknowledgedAt = new Date().toISOString()
+    setGenerationDrafts((current) =>
+      current.map((draft) =>
+        (draft.status === 'ready' || draft.status === 'failed') &&
+        !draft.acknowledgedAt
+          ? { ...draft, acknowledgedAt }
+          : draft,
+      ),
+    )
     setSelectedIntent(null)
     setQuickOptionsOpen(false)
     setActiveFlow('hub')
@@ -681,7 +711,8 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       )
     }
 
-    updateDraft(draft.id, { openedAt: new Date().toISOString() })
+    const openedAt = new Date().toISOString()
+    updateDraft(draft.id, { acknowledgedAt: openedAt, openedAt })
     if (isMobile) {
       setIsStudioOpen(false)
       setMobileSection('dashboard')
@@ -1974,21 +2005,22 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                   const isGenerating = draft.status === 'generating'
                   const isFailed = draft.status === 'failed'
                   const opened = Boolean(draft.openedAt)
+                  const materialLabel = generationMaterialLabel(draft)
                   const label =
-                    draft.flow === 'study-path'
-                      ? isGenerating
-                        ? 'Creating study path...'
-                        : draft.title || 'Study Path'
+                    isGenerating && draft.flow === 'study-path'
+                      ? 'Creating study path...'
                       : isGenerating
-                        ? `Generating ${resourceTypeTitle(draft.selectedResourceType).toLowerCase()}...`
+                        ? `Generating ${materialLabel}...`
                         : draft.title ||
-                          resourceTypeTitle(draft.selectedResourceType)
+                          (draft.flow === 'study-path'
+                            ? 'Study Path'
+                            : resourceTypeTitle(draft.selectedResourceType))
                   const detail = isFailed
                     ? draft.error || 'Retry'
                     : isReady
                       ? opened
                         ? 'Opened'
-                        : 'Ready · Open'
+                        : 'Ready - Open'
                       : draft.inputSummary || 'based on source'
                   const statusIcon = isFailed ? (
                     <ErrorOutlineIcon fontSize="small" color="error" />
@@ -2060,8 +2092,8 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                           }}
                         >
                           {isFailed
-                            ? `${resourceTypeTitle(
-                                draft.selectedResourceType,
+                            ? `${materialLabel[0].toUpperCase()}${materialLabel.slice(
+                                1,
                               )} generation failed`
                             : label}
                         </Typography>
@@ -2631,7 +2663,6 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       creationStatusMarkers={creationStatusMarkers}
       widgetBuilderDialog={widgetBuilderDialog}
       isStudioOpen={isStudioOpen}
-      creationQueueActive={hasQueueMarker}
       studioWidth={studioWidth}
       openCreateHub={openCreateHub}
       startStudioResize={startStudioResize}

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -213,6 +213,50 @@ const generationMaterialLabel = (draft: GenerationDraft) => {
   return 'material'
 }
 
+const formatQueueDuration = (durationMs: number) => {
+  const totalSeconds = Math.max(0, Math.floor(durationMs / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+
+  if (minutes <= 0) {
+    return `${Math.max(1, seconds)}s`
+  }
+
+  return `${minutes}m ${String(seconds).padStart(2, '0')}s`
+}
+
+const estimateQueueDuration = (draft: GenerationDraft) => {
+  if (draft.aiProvider === 'local') {
+    if (draft.flow === 'study-path') {
+      if (draft.detailLevel === 'superSmall') {
+        return 'est. 12-15m'
+      }
+
+      if (draft.detailLevel === 'compact') {
+        return 'est. 14-17m'
+      }
+
+      return 'est. 15-20m'
+    }
+
+    return 'est. 1-3m'
+  }
+
+  if (draft.aiProvider === 'gemini') {
+    if (draft.detailLevel === 'long' || draft.detailLevel === 'deep') {
+      return 'est. 1-2m'
+    }
+
+    return 'est. 30-60s'
+  }
+
+  if (draft.aiProvider === 'basic') {
+    return 'est. seconds'
+  }
+
+  return ''
+}
+
 const formatDraftTitle = (draft: GenerationDraft) => {
   const base = draft.title.trim()
   const shortTitle = base.length > 46 ? `${base.slice(0, 45).trim()}...` : base
@@ -291,6 +335,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
   const [quickSourceMode, setQuickSourceMode] =
     useState<QuickSourceMode>('dashboard')
   const [quickSourceStatus, setQuickSourceStatus] = useState('')
+  const [queueClockMs, setQueueClockMs] = useState(() => Date.now())
   const [pendingQuickSourceFocus, setPendingQuickSourceFocus] =
     useState<QuickSourceFocus | null>(null)
   const [fullScreenWidgetPayload, setFullScreenWidgetPayload] = useState<{
@@ -386,7 +431,20 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
   }, [])
 
   useEffect(() => {
+    if (!generationDrafts.some((draft) => draft.status === 'generating')) {
+      return
+    }
+
+    const intervalId = window.setInterval(
+      () => setQueueClockMs(Date.now()),
+      1000,
+    )
+    return () => window.clearInterval(intervalId)
+  }, [generationDrafts])
+
+  useEffect(() => {
     const activateCreation = (flow: Exclude<StudioFlow, 'hub'>) => {
+      acknowledgeQueueAttention()
       createNewDraft(flow)
       if (isMobile) {
         setMobileSection('creation')
@@ -395,6 +453,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     const handleOpenCreateHub = (event: Event) => {
       const customEvent = event as CustomEvent<OpenCreateHubDetail>
       const detail = customEvent.detail || {}
+      acknowledgeQueueAttention()
       setSelectedIntent(detail.intent || null)
       if (detail.openQuickOptions) {
         setQuickOptionsOpen(true)
@@ -604,6 +663,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
           return {
             ...draft,
             status: nextStatus,
+            aiProvider: state === 'running' ? aiProvider : draft.aiProvider,
             error: state === 'error' ? message : undefined,
           }
         }),
@@ -666,7 +726,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
           ? `${queueFailedCount} generation${queueFailedCount === 1 ? '' : 's'} failed`
           : 'Creation queue'
 
-  const openGenerationQueue = () => {
+  const acknowledgeQueueAttention = () => {
     const acknowledgedAt = new Date().toISOString()
     setGenerationDrafts((current) =>
       current.map((draft) =>
@@ -676,6 +736,21 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
           : draft,
       ),
     )
+  }
+
+  const clearGenerationQueue = () => {
+    setGenerationDrafts((current) =>
+      current.filter(
+        (draft) =>
+          draft.isPlaceholder ||
+          draft.status === 'editing' ||
+          draft.status === 'generating',
+      ),
+    )
+  }
+
+  const openGenerationQueue = () => {
+    acknowledgeQueueAttention()
     setSelectedIntent(null)
     setQuickOptionsOpen(false)
     setActiveFlow('hub')
@@ -921,6 +996,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         sourceMode === 'dashboard' ? 'current dashboard' : 'sources',
       selectedResourceType: resourceType,
       detailLevel: quickDetailLevel,
+      aiProvider,
     })
 
     setActiveFlow('hub')
@@ -1993,11 +2069,29 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                 <Typography variant="subtitle2" fontWeight={900}>
                   Generation queue
                 </Typography>
-                <Chip
-                  size="small"
-                  label={`${queueJobs.length} job${queueJobs.length === 1 ? '' : 's'}`}
-                  sx={{ fontWeight: 800 }}
-                />
+                <Stack direction="row" spacing={0.75} alignItems="center">
+                  <Chip
+                    size="small"
+                    label={`${queueJobs.length} job${queueJobs.length === 1 ? '' : 's'}`}
+                    sx={{ fontWeight: 800 }}
+                  />
+                  <Button
+                    size="small"
+                    onClick={clearGenerationQueue}
+                    disabled={
+                      !queueJobs.some((draft) => draft.status !== 'generating')
+                    }
+                    sx={{
+                      minWidth: 0,
+                      px: 1,
+                      borderRadius: 999,
+                      textTransform: 'none',
+                      fontWeight: 800,
+                    }}
+                  >
+                    Clear
+                  </Button>
+                </Stack>
               </Stack>
               <Stack spacing={0.75}>
                 {sortedQueueJobs.map((draft) => {
@@ -2006,6 +2100,14 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                   const isFailed = draft.status === 'failed'
                   const opened = Boolean(draft.openedAt)
                   const materialLabel = generationMaterialLabel(draft)
+                  const elapsed =
+                    isGenerating &&
+                    formatQueueDuration(
+                      queueClockMs - new Date(draft.createdAt).getTime(),
+                    )
+                  const estimate = isGenerating
+                    ? estimateQueueDuration(draft)
+                    : ''
                   const label =
                     isGenerating && draft.flow === 'study-path'
                       ? 'Creating study path...'
@@ -2021,7 +2123,13 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                       ? opened
                         ? 'Opened'
                         : 'Ready - Open'
-                      : draft.inputSummary || 'based on source'
+                      : [
+                          draft.inputSummary || 'based on source',
+                          elapsed ? `${elapsed} elapsed` : '',
+                          estimate,
+                        ]
+                          .filter(Boolean)
+                          .join(' - ')
                   const statusIcon = isFailed ? (
                     <ErrorOutlineIcon fontSize="small" color="error" />
                   ) : isReady ? (
@@ -2210,6 +2318,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                     title: metadata.title,
                     inputSummary: metadata.inputSummary,
                     detailLevel: metadata.detailLevel,
+                    aiProvider,
                   })
                 }
               />
@@ -2293,6 +2402,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
 
   const openCreateHub = () => {
     if (isMobile && isStudioOpen && activeFlow === 'hub') {
+      acknowledgeQueueAttention()
       setMobileSection('creation')
       return
     }
@@ -2302,6 +2412,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       return
     }
 
+    acknowledgeQueueAttention()
     setSelectedIntent(null)
     setActiveFlow('hub')
     setIsStudioOpen(true)
@@ -2485,42 +2596,6 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         }),
       }}
     >
-      {isStudioOpen && (
-        <Tooltip title="Create" placement="right">
-          <Box
-            component="button"
-            type="button"
-            aria-label="Create"
-            onClick={openCreateHub}
-            sx={{
-              width: isMobile ? 34 : 34,
-              height: isMobile ? 82 : 82,
-              border: 0,
-              borderRadius: '0 20px 20px 0',
-              bgcolor:
-                activeFlow === 'hub' && isStudioOpen
-                  ? 'primary.main'
-                  : 'background.paper',
-              color:
-                activeFlow === 'hub' && isStudioOpen
-                  ? 'primary.contrastText'
-                  : 'primary.main',
-              cursor: 'pointer',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              boxShadow:
-                theme.palette.mode === 'dark'
-                  ? '0 12px 32px rgba(0,0,0,0.42)'
-                  : '0 12px 30px rgba(16,24,40,0.18)',
-              outline: 1,
-              outlineColor: 'divider',
-            }}
-          >
-            <AddIcon fontSize="small" />
-          </Box>
-        </Tooltip>
-      )}
       {hasQueueMarker ? (
         <Tooltip
           title={`${queueMarkerLabel}. Click to view queue.`}

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -278,8 +278,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
   const quickUploadButtonRef = useRef<HTMLLabelElement | null>(null)
   const quickPasteButtonRef = useRef<HTMLButtonElement | null>(null)
   const quickCopiedTextInputRef = useRef<HTMLTextAreaElement | null>(null)
-  const { createStudyPackDashboard, createStudyPackDashboards } =
-    useWorkspaceActions()
+  const { createStudyPackDashboards } = useWorkspaceActions()
   const { openDashboards, selectedDashboard } = useDashboards()
 
   const startStudioResize = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -877,18 +876,26 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         widgetGroups: groups,
       })
 
-      const dashboard = createStudyPackDashboard({
-        name: nextTitle,
-        widgets,
-        layoutMode:
-          resourceType === 'flashcards' || resourceType === 'quiz'
-            ? 'tabs'
-            : 'tabs',
+      createStudyPackDashboards({
+        dashboards: [
+          {
+            name: nextTitle,
+            widgets,
+            layoutMode: 'tabs',
+          },
+        ],
+        openInWorkspace: true,
       })
-      updateDraft(draft.id, {
-        status: 'ready',
-        title: dashboard.name,
-        inputSummary: 'saved to dashboards',
+      setGenerationDrafts((current) =>
+        current.filter((existingDraft) => existingDraft.id !== draft.id),
+      )
+      setActiveDraftByFlow((current) => {
+        if (current['from-notes'] !== draft.id) {
+          return current
+        }
+
+        const { 'from-notes': _removedDraftId, ...remaining } = current
+        return remaining
       })
       dispatchWorkspaceCreationStatus({
         task: 'from-notes',

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -27,6 +27,9 @@ import QuizIcon from '@mui/icons-material/Quiz'
 import RouteIcon from '@mui/icons-material/Route'
 import StyleIcon from '@mui/icons-material/Style'
 import UploadFileIcon from '@mui/icons-material/UploadFile'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
+import LoopIcon from '@mui/icons-material/Loop'
 
 import {
   OPEN_CREATE_HUB_EVENT,
@@ -53,6 +56,7 @@ import {
 import { extractRawNotesFromImage } from '../../studyPack/imageOcr'
 import { CustomWidget } from '../WidgetEditor/WidgetStorage'
 import { useDashboards } from '../Dasboard/DashboardProvider'
+import { createStudyPathContainerState } from '../Dasboard/studyPathContainer'
 import {
   buildDashboardChatContext,
   formatDashboardChatContext,
@@ -82,7 +86,6 @@ import {
   quickCreateLabels,
   quickCreateTargets,
   quickSourceAcceptValue,
-  statusMarkerColors,
   statusMarkerGlow,
   studioPanelMaxWidth,
   studioPanelMinWidth,
@@ -279,7 +282,13 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
   const quickPasteButtonRef = useRef<HTMLButtonElement | null>(null)
   const quickCopiedTextInputRef = useRef<HTMLTextAreaElement | null>(null)
   const { createStudyPackDashboards } = useWorkspaceActions()
-  const { openDashboards, selectedDashboard } = useDashboards()
+  const {
+    addDashboards,
+    addStudyPathContainer,
+    openDashboards,
+    selectedDashboard,
+  } = useDashboards()
+  const generationQueueRef = useRef<HTMLDivElement | null>(null)
 
   const startStudioResize = (event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault()
@@ -587,6 +596,98 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       }
     }
 
+  const queueJobs = generationDrafts.filter(
+    (draft) => !draft.isPlaceholder && draft.status !== 'editing',
+  )
+  const sortedQueueJobs = [...queueJobs].sort((first, second) => {
+    const rank = (draft: GenerationDraft) => {
+      if (draft.status === 'ready' && !draft.openedAt) {
+        return 0
+      }
+
+      if (draft.status === 'generating') {
+        return 1
+      }
+
+      if (draft.status === 'failed') {
+        return 2
+      }
+
+      return 3
+    }
+
+    const rankDelta = rank(first) - rank(second)
+    if (rankDelta !== 0) {
+      return rankDelta
+    }
+
+    return (
+      new Date(second.completedAt || second.createdAt).getTime() -
+      new Date(first.completedAt || first.createdAt).getTime()
+    )
+  })
+  const queueReadyCount = queueJobs.filter(
+    (draft) => draft.status === 'ready' && !draft.openedAt,
+  ).length
+  const queueGeneratingCount = queueJobs.filter(
+    (draft) => draft.status === 'generating',
+  ).length
+  const queueFailedCount = queueJobs.filter(
+    (draft) => draft.status === 'failed',
+  ).length
+  const hasQueueMarker = queueJobs.length > 0
+  const queueMarkerLabel =
+    queueReadyCount > 0
+      ? `${queueReadyCount} generated item${queueReadyCount === 1 ? '' : 's'} ready`
+      : queueGeneratingCount > 0
+        ? `${queueGeneratingCount} generation${queueGeneratingCount === 1 ? '' : 's'} running`
+        : queueFailedCount > 0
+          ? `${queueFailedCount} generation${queueFailedCount === 1 ? '' : 's'} failed`
+          : 'Creation queue'
+
+  const openGenerationQueue = () => {
+    setSelectedIntent(null)
+    setQuickOptionsOpen(false)
+    setActiveFlow('hub')
+    setIsStudioOpen(true)
+    if (isMobile) {
+      window.dispatchEvent(new Event(CLOSE_DASHBOARD_CHAT_EVENT))
+      setMobileSection('creation')
+    }
+    window.setTimeout(() => {
+      generationQueueRef.current?.scrollIntoView({
+        block: 'nearest',
+        behavior: 'smooth',
+      })
+      generationQueueRef.current?.focus()
+    }, 80)
+  }
+
+  const openGeneratedDraft = (draft: GenerationDraft) => {
+    if (draft.status !== 'ready' || !draft.generatedDashboards?.length) {
+      return
+    }
+
+    const studyPath = createStudyPathContainerState(draft.generatedDashboards)
+    if (studyPath) {
+      addStudyPathContainer(studyPath)
+    } else {
+      addDashboards(
+        draft.generatedDashboards.map((dashboard) => ({
+          name: dashboard.name,
+          layout: dashboard.layout,
+        })),
+        { replaceEmptySelected: true },
+      )
+    }
+
+    updateDraft(draft.id, { openedAt: new Date().toISOString() })
+    if (isMobile) {
+      setIsStudioOpen(false)
+      setMobileSection('dashboard')
+    }
+  }
+
   const closeFullScreenWidgetEditor = () => {
     setFullScreenWidgetPayload(null)
     resetOrCloseStudio()
@@ -780,12 +881,13 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     resourceType: StudyMaterialResourceType,
     sourceText: string,
     title: string,
+    sourceMode: QuickSourceMode,
   ) => {
     const draft = createGenerationDraft('from-notes', {
       quickCreate: true,
       title,
       inputSummary:
-        quickSourceMode === 'dashboard' ? 'current dashboard' : 'sources',
+        sourceMode === 'dashboard' ? 'current dashboard' : 'sources',
       selectedResourceType: resourceType,
       detailLevel: quickDetailLevel,
     })
@@ -876,7 +978,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         widgetGroups: groups,
       })
 
-      createStudyPackDashboards({
+      const savedDashboards = createStudyPackDashboards({
         dashboards: [
           {
             name: nextTitle,
@@ -884,28 +986,19 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
             layoutMode: 'tabs',
           },
         ],
-        openInWorkspace: true,
+        openInWorkspace: false,
       })
-      setGenerationDrafts((current) =>
-        current.filter((existingDraft) => existingDraft.id !== draft.id),
-      )
-      setActiveDraftByFlow((current) => {
-        if (current['from-notes'] !== draft.id) {
-          return current
-        }
-
-        const { 'from-notes': _removedDraftId, ...remaining } = current
-        return remaining
+      updateDraft(draft.id, {
+        title: nextTitle,
+        status: 'ready',
+        completedAt: new Date().toISOString(),
+        generatedDashboards: savedDashboards,
       })
       dispatchWorkspaceCreationStatus({
         task: 'from-notes',
         state: 'complete',
         message: 'Saved to dashboards',
       })
-      setIsStudioOpen(false)
-      if (isMobile) {
-        setMobileSection('dashboard')
-      }
     } catch (error) {
       const message =
         error instanceof Error
@@ -950,6 +1043,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         resourceType,
         sourceText,
         `${currentDashboardTitle} ${titleBase}`.trim(),
+        sourceMode,
       )
     } catch (error) {
       const message =
@@ -1839,6 +1933,166 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
             </Stack>
           </Paper>
         </Collapse>
+
+        {sortedQueueJobs.length > 0 ? (
+          <Paper
+            ref={generationQueueRef}
+            tabIndex={-1}
+            elevation={0}
+            aria-label="Generation queue"
+            sx={{
+              p: 1.25,
+              border: 1,
+              borderColor: 'divider',
+              borderRadius: 2.5,
+              bgcolor: alpha(theme.palette.background.default, 0.72),
+              outline: 'none',
+              '&:focus-visible': {
+                boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.24)}`,
+              },
+            }}
+          >
+            <Stack spacing={1}>
+              <Stack
+                direction="row"
+                alignItems="center"
+                justifyContent="space-between"
+                gap={1}
+              >
+                <Typography variant="subtitle2" fontWeight={900}>
+                  Generation queue
+                </Typography>
+                <Chip
+                  size="small"
+                  label={`${queueJobs.length} job${queueJobs.length === 1 ? '' : 's'}`}
+                  sx={{ fontWeight: 800 }}
+                />
+              </Stack>
+              <Stack spacing={0.75}>
+                {sortedQueueJobs.map((draft) => {
+                  const isReady = draft.status === 'ready'
+                  const isGenerating = draft.status === 'generating'
+                  const isFailed = draft.status === 'failed'
+                  const opened = Boolean(draft.openedAt)
+                  const label =
+                    draft.flow === 'study-path'
+                      ? isGenerating
+                        ? 'Creating study path...'
+                        : draft.title || 'Study Path'
+                      : isGenerating
+                        ? `Generating ${resourceTypeTitle(draft.selectedResourceType).toLowerCase()}...`
+                        : draft.title ||
+                          resourceTypeTitle(draft.selectedResourceType)
+                  const detail = isFailed
+                    ? draft.error || 'Retry'
+                    : isReady
+                      ? opened
+                        ? 'Opened'
+                        : 'Ready · Open'
+                      : draft.inputSummary || 'based on source'
+                  const statusIcon = isFailed ? (
+                    <ErrorOutlineIcon fontSize="small" color="error" />
+                  ) : isReady ? (
+                    <CheckCircleIcon fontSize="small" color="success" />
+                  ) : (
+                    <LoopIcon
+                      fontSize="small"
+                      color="warning"
+                      sx={{
+                        animation:
+                          'studymesh-generation-pill-spin 950ms linear infinite',
+                        '@keyframes studymesh-generation-pill-spin': {
+                          to: { transform: 'rotate(360deg)' },
+                        },
+                      }}
+                    />
+                  )
+
+                  return (
+                    <Paper
+                      key={draft.id}
+                      component={isReady ? 'button' : 'div'}
+                      type={isReady ? 'button' : undefined}
+                      elevation={0}
+                      onClick={
+                        isReady ? () => openGeneratedDraft(draft) : undefined
+                      }
+                      sx={{
+                        width: '100%',
+                        p: 1,
+                        border: 1,
+                        borderColor: isReady
+                          ? alpha(theme.palette.success.main, 0.45)
+                          : isFailed
+                            ? alpha(theme.palette.error.main, 0.35)
+                            : alpha(theme.palette.warning.main, 0.36),
+                        borderRadius: 2,
+                        bgcolor: isReady
+                          ? alpha(theme.palette.success.main, 0.075)
+                          : isFailed
+                            ? alpha(theme.palette.error.main, 0.055)
+                            : alpha(theme.palette.warning.main, 0.07),
+                        color: 'text.primary',
+                        cursor: isReady ? 'pointer' : 'default',
+                        textAlign: 'left',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1,
+                        '&:hover': isReady
+                          ? {
+                              borderColor: 'success.main',
+                              bgcolor: alpha(theme.palette.success.main, 0.11),
+                            }
+                          : undefined,
+                      }}
+                    >
+                      <Box sx={{ flex: '0 0 auto', display: 'grid' }}>
+                        {statusIcon}
+                      </Box>
+                      <Box sx={{ minWidth: 0, flex: 1 }}>
+                        <Typography
+                          variant="body2"
+                          fontWeight={900}
+                          sx={{
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {isFailed
+                            ? `${resourceTypeTitle(
+                                draft.selectedResourceType,
+                              )} generation failed`
+                            : label}
+                        </Typography>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{
+                            display: 'block',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {detail}
+                        </Typography>
+                      </Box>
+                      {isReady && !opened ? (
+                        <Chip
+                          size="small"
+                          color="success"
+                          label="Open"
+                          sx={{ fontWeight: 900 }}
+                        />
+                      ) : null}
+                    </Paper>
+                  )
+                })}
+              </Stack>
+            </Stack>
+          </Paper>
+        ) : null}
       </Stack>
     </Box>
   )
@@ -1891,17 +2145,26 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                 open
                 presentation="embedded"
                 onCollapse={returnToCreateHub}
-                onContinueCreating={returnToCreateHub}
-                onContinueInBackground={() => setIsStudioOpen(false)}
+                autoCreateOnGenerate
+                openGeneratedInWorkspace={false}
                 onClose={() =>
                   cancelDraftAndReturnToHub(draft.id, 'study-path')
                 }
                 onCreatePath={(payload) => {
-                  const dashboards = createStudyPackDashboards(payload)
-                  removeDraft(draft.id, 'study-path')
+                  const dashboards = createStudyPackDashboards({
+                    ...payload,
+                    openInWorkspace: false,
+                  })
+                  updateDraft(draft.id, {
+                    title: payload.folderName || 'Study Path',
+                    inputSummary: payload.folderName || draft.inputSummary,
+                    status: 'ready',
+                    completedAt: new Date().toISOString(),
+                    generatedDashboards: dashboards,
+                  })
                   reportCreationStatus(
                     'study-path',
-                    'idle',
+                    'complete',
                     'Study material created.',
                   )
                   return dashboards
@@ -2029,7 +2292,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     window.dispatchEvent(new Event(OPEN_DASHBOARD_CHAT_EVENT))
   }
 
-  const mobileCreationStatusTray = visibleCreationMarkers.length ? (
+  const mobileCreationStatusTray = hasQueueMarker ? (
     <Box
       aria-label="Creation generation status"
       sx={{
@@ -2047,75 +2310,67 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         scrollbarWidth: 'none',
       }}
     >
-      {visibleCreationMarkers.map(({ draft, state }) => {
-        const isActiveMarker = activeDraftByFlow[draft.flow] === draft.id
-        const isSelected =
-          isStudioOpen &&
-          mobileSection === 'creation' &&
-          activeFlow === draft.flow &&
-          isActiveMarker
-
-        return (
-          <Button
-            key={draft.id}
-            size="small"
-            variant={isSelected ? 'contained' : 'outlined'}
-            onClick={() => openCreationMarker(draft)}
-            aria-label={`${formatDraftTitle(draft)} - ${statusMarkerLabels[state]}`}
-            sx={{
-              flex: '0 0 auto',
-              maxWidth: 220,
-              minWidth: 0,
-              px: 1,
-              borderRadius: 999,
-              textTransform: 'none',
-              justifyContent: 'flex-start',
-              gap: 0.75,
-            }}
-          >
-            <Box
-              sx={{
-                position: 'relative',
-                width: 9,
-                height: 9,
-                borderRadius: '50%',
-                bgcolor: statusMarkerColors[state],
-                boxShadow: statusMarkerGlow[state],
-                flex: '0 0 auto',
-                '&::after':
-                  state === 'running'
-                    ? {
-                        content: '""',
-                        position: 'absolute',
-                        inset: -4,
-                        borderRadius: '50%',
-                        border: 1.5,
-                        borderColor: 'warning.main',
-                        borderTopColor: 'transparent',
-                        animation:
-                          'studymesh-mobile-marker-spin 900ms linear infinite',
-                      }
-                    : undefined,
-                '@keyframes studymesh-mobile-marker-spin': {
-                  to: { transform: 'rotate(360deg)' },
-                },
-              }}
-            />
-            <Typography
-              variant="caption"
-              sx={{
-                minWidth: 0,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                fontWeight: 800,
-              }}
-            >
-              {formatDraftTitle(draft)}
-            </Typography>
-          </Button>
-        )
-      })}
+      <Button
+        size="small"
+        variant={queueReadyCount > 0 ? 'contained' : 'outlined'}
+        onClick={openGenerationQueue}
+        aria-label={queueMarkerLabel}
+        sx={{
+          flex: '0 0 auto',
+          maxWidth: 240,
+          minWidth: 0,
+          px: 1,
+          borderRadius: 999,
+          textTransform: 'none',
+          justifyContent: 'flex-start',
+          gap: 0.75,
+        }}
+      >
+        <Box
+          sx={{
+            position: 'relative',
+            width: 10,
+            height: 10,
+            borderRadius: '50%',
+            bgcolor:
+              queueReadyCount > 0
+                ? 'success.main'
+                : queueFailedCount > 0 && queueGeneratingCount === 0
+                  ? 'error.main'
+                  : 'warning.main',
+            flex: '0 0 auto',
+            '&::after':
+              queueGeneratingCount > 0
+                ? {
+                    content: '""',
+                    position: 'absolute',
+                    inset: -4,
+                    borderRadius: '50%',
+                    border: 1.5,
+                    borderColor: 'warning.main',
+                    borderTopColor: 'transparent',
+                    animation:
+                      'studymesh-mobile-marker-spin 900ms linear infinite',
+                  }
+                : undefined,
+            '@keyframes studymesh-mobile-marker-spin': {
+              to: { transform: 'rotate(360deg)' },
+            },
+          }}
+        />
+        <Typography
+          variant="caption"
+          sx={{
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            fontWeight: 800,
+          }}
+        >
+          {queueMarkerLabel}
+        </Typography>
+      </Button>
     </Box>
   ) : null
 
@@ -2234,20 +2489,19 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
           </Box>
         </Tooltip>
       )}
-      {visibleCreationMarkers.map(({ draft, state }) => (
+      {hasQueueMarker ? (
         <Tooltip
-          key={draft.id}
-          title={`${formatDraftTitle(draft)} - ${statusMarkerLabels[state]}`}
+          title={`${queueMarkerLabel}. Click to view queue.`}
           placement="right"
         >
           <Box
             component="button"
             type="button"
-            aria-label={`${formatDraftTitle(draft)} - ${statusMarkerLabels[state]}`}
-            onClick={() => openCreationMarker(draft)}
+            aria-label={`${queueMarkerLabel}. View generation queue.`}
+            onClick={openGenerationQueue}
             sx={{
-              width: draft.flow === 'study-path' ? 38 : isMobile ? 30 : 30,
-              height: draft.flow === 'study-path' ? 92 : isMobile ? 76 : 76,
+              width: isMobile ? 34 : 34,
+              height: isMobile ? 82 : 82,
               border: 0,
               borderRadius: '0 18px 18px 0',
               bgcolor: 'background.paper',
@@ -2263,7 +2517,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
               outline: 1,
               outlineColor: 'divider',
               animation:
-                state === 'complete'
+                queueReadyCount > 0
                   ? 'studymesh-marker-ready 1.4s ease-out 1'
                   : 'none',
               '@keyframes studymesh-marker-ready': {
@@ -2283,10 +2537,28 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                 width: 14,
                 height: 14,
                 borderRadius: '50%',
-                bgcolor: statusMarkerColors[state],
-                boxShadow: statusMarkerGlow[state],
+                bgcolor:
+                  queueReadyCount > 0
+                    ? 'success.main'
+                    : queueFailedCount > 0 && queueGeneratingCount === 0
+                      ? 'error.main'
+                      : 'warning.main',
+                boxShadow:
+                  queueReadyCount > 0
+                    ? statusMarkerGlow.complete
+                    : queueFailedCount > 0 && queueGeneratingCount === 0
+                      ? statusMarkerGlow.error
+                      : statusMarkerGlow.running,
+                color:
+                  queueReadyCount > 0
+                    ? 'success.contrastText'
+                    : 'warning.contrastText',
+                display: 'grid',
+                placeItems: 'center',
+                fontSize: 9,
+                fontWeight: 900,
                 '&::after':
-                  state === 'running'
+                  queueGeneratingCount > 0
                     ? {
                         content: '""',
                         position: 'absolute',
@@ -2303,10 +2575,27 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                   to: { transform: 'rotate(360deg)' },
                 },
               }}
-            />
+            >
+              {queueReadyCount > 0 ? queueReadyCount : ''}
+              {queueFailedCount > 0 && queueReadyCount === 0 ? (
+                <Box
+                  sx={{
+                    position: 'absolute',
+                    right: -6,
+                    bottom: -6,
+                    width: 7,
+                    height: 7,
+                    borderRadius: '50%',
+                    bgcolor: 'error.main',
+                    border: 1,
+                    borderColor: 'background.paper',
+                  }}
+                />
+              ) : null}
+            </Box>
           </Box>
         </Tooltip>
-      ))}
+      ) : null}
     </Box>
   )
 
@@ -2328,7 +2617,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         widgetBuilderDialog={widgetBuilderDialog}
         isStudioOpen={isStudioOpen}
         mobileSection={mobileSection}
-        visibleCreationMarkerCount={visibleCreationMarkers.length}
+        visibleCreationMarkerCount={hasQueueMarker ? 1 : 0}
         theme={theme}
       >
         {children}
@@ -2342,6 +2631,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       creationStatusMarkers={creationStatusMarkers}
       widgetBuilderDialog={widgetBuilderDialog}
       isStudioOpen={isStudioOpen}
+      creationQueueActive={hasQueueMarker}
       studioWidth={studioWidth}
       openCreateHub={openCreateHub}
       startStudioResize={startStudioResize}

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -112,6 +112,21 @@ const quickCreateIcons: Record<StudyMaterialResourceType, React.ReactNode> = {
 
 type QuickSourceMode = 'dashboard' | 'sources'
 
+const GENERATION_RETRY_STORE_KEY = 'studymesh-generation-retry-snapshots'
+
+interface FromNotesRetrySnapshot {
+  flow: 'from-notes'
+  resourceType: StudyMaterialResourceType
+  sourceText: string
+  title: string
+  sourceMode: QuickSourceMode
+  detailLevel: StudyMaterialDetailLevel
+  difficulty: string
+  provider: StudyPackAiProvider
+}
+
+type GenerationRetrySnapshot = FromNotesRetrySnapshot
+
 const statusMarkerLabels: Record<
   WorkspaceCreationTaskState | 'editing',
   string
@@ -257,6 +272,54 @@ const estimateQueueDuration = (draft: GenerationDraft) => {
 
   return ''
 }
+
+const readGenerationRetrySnapshots = () => {
+  try {
+    const stored = window.localStorage.getItem(GENERATION_RETRY_STORE_KEY)
+    return stored
+      ? (JSON.parse(stored) as Record<string, GenerationRetrySnapshot>)
+      : {}
+  } catch (error) {
+    console.error('Failed to read generation retry snapshots', error)
+    return {}
+  }
+}
+
+const writeGenerationRetrySnapshots = (
+  snapshots: Record<string, GenerationRetrySnapshot>,
+) => {
+  try {
+    window.localStorage.setItem(
+      GENERATION_RETRY_STORE_KEY,
+      JSON.stringify(snapshots),
+    )
+  } catch (error) {
+    console.error('Failed to write generation retry snapshots', error)
+  }
+}
+
+const saveGenerationRetrySnapshot = (
+  draftId: string,
+  snapshot: GenerationRetrySnapshot,
+) => {
+  writeGenerationRetrySnapshots({
+    ...readGenerationRetrySnapshots(),
+    [draftId]: snapshot,
+  })
+}
+
+const removeGenerationRetrySnapshot = (draftId: string) => {
+  const snapshots = readGenerationRetrySnapshots()
+  if (!snapshots[draftId]) {
+    return
+  }
+
+  const { [draftId]: _removed, ...remaining } = snapshots
+  writeGenerationRetrySnapshots(remaining)
+}
+
+const getGenerationRetrySnapshot = (draftId: string) =>
+  readGenerationRetrySnapshots()[draftId]
 
 const formatDraftTitle = (draft: GenerationDraft) => {
   const base = draft.title.trim()
@@ -747,6 +810,9 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
   }
 
   const clearGenerationQueue = () => {
+    queueJobs
+      .filter((draft) => draft.status !== 'generating')
+      .forEach((draft) => removeGenerationRetrySnapshot(draft.id))
     setGenerationDrafts((current) =>
       current.filter(
         (draft) =>
@@ -807,25 +873,50 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       return
     }
 
-    if (
-      draft.flow === 'from-notes' &&
-      draft.retryResourceType &&
-      draft.retrySourceText &&
-      draft.retryTitle &&
-      draft.retrySourceMode
-    ) {
+    const storedSnapshot = getGenerationRetrySnapshot(draft.id)
+    const fromNotesRetry =
+      storedSnapshot?.flow === 'from-notes'
+        ? storedSnapshot
+        : draft.flow === 'from-notes' &&
+            draft.retryResourceType &&
+            draft.retrySourceText &&
+            draft.retryTitle &&
+            draft.retrySourceMode
+          ? {
+              flow: 'from-notes' as const,
+              resourceType: draft.retryResourceType,
+              sourceText: draft.retrySourceText,
+              title: draft.retryTitle,
+              sourceMode: draft.retrySourceMode,
+              detailLevel:
+                (draft.detailLevel as StudyMaterialDetailLevel) ||
+                quickDetailLevel,
+              difficulty: draft.retryDifficulty || quickDifficulty,
+              provider: (draft.aiProvider as StudyPackAiProvider) || aiProvider,
+            }
+          : null
+
+    if (draft.flow === 'from-notes' && fromNotesRetry) {
       void runDirectStudyPackCreate(
-        draft.retryResourceType,
-        draft.retrySourceText,
-        draft.retryTitle,
-        draft.retrySourceMode,
+        fromNotesRetry.resourceType,
+        fromNotesRetry.sourceText,
+        fromNotesRetry.title,
+        fromNotesRetry.sourceMode,
         {
           draftId: draft.id,
-          detailLevel: draft.detailLevel as StudyMaterialDetailLevel,
-          difficulty: draft.retryDifficulty,
-          provider: draft.aiProvider as StudyPackAiProvider,
+          detailLevel: fromNotesRetry.detailLevel,
+          difficulty: fromNotesRetry.difficulty,
+          provider: fromNotesRetry.provider,
         },
       )
+      return
+    }
+
+    if (draft.flow === 'from-notes') {
+      updateDraft(draft.id, {
+        error:
+          'Retry data is missing for this older failed job. Start it again from Creation once; future failed jobs keep a retry snapshot.',
+      })
       return
     }
 
@@ -1065,6 +1156,16 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     })
     const draftId = retryOptions.draftId || draft.id
     const generationDraft = { ...draft, id: draftId, status: 'generating' }
+    saveGenerationRetrySnapshot(draftId, {
+      flow: 'from-notes',
+      resourceType,
+      sourceText,
+      title,
+      sourceMode,
+      detailLevel: effectiveDetailLevel,
+      difficulty: effectiveDifficulty,
+      provider: effectiveProvider,
+    })
 
     setActiveFlow('hub')
     setQuickOptionsOpen(false)
@@ -1186,6 +1287,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         completedAt: new Date().toISOString(),
         generatedDashboards: savedDashboards,
       })
+      removeGenerationRetrySnapshot(draftId)
       dispatchWorkspaceCreationStatus({
         task: 'from-notes',
         state: 'complete',
@@ -2318,8 +2420,12 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                       {isFailed ? (
                         <Button
                           size="small"
+                          type="button"
                           variant="outlined"
-                          onClick={() => retryGenerationDraft(draft)}
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            retryGenerationDraft(draft)
+                          }}
                           sx={{
                             borderRadius: 999,
                             textTransform: 'none',

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -37,10 +37,11 @@ import {
   useWorkspaceActions,
 } from '../../customHooks/useWorkspaceActions'
 import { dispatchWorkspaceOnboardingEvent } from '../onboarding/onboardingEvents'
-import CreateStudyPackModal from '../studyPack/CreateStudyPackModal'
 import CreateStudyPathModal from '../studyPack/CreateStudyPathModal'
 import {
+  generateStudyPackWithAi,
   readStudyPackAiSettings,
+  resolveStudyPackAiCredentials,
   STUDY_PACK_AI_SETTINGS_CHANGED_EVENT,
   StudyMaterialDetailLevel,
   StudyMaterialResourceType,
@@ -77,7 +78,9 @@ import {
   QuickSourceFocus,
   readIsAdmin,
   quickCreateAccents,
+  quickCreateDetailToAmount,
   quickCreateLabels,
+  quickCreateTargets,
   quickSourceAcceptValue,
   statusMarkerColors,
   statusMarkerGlow,
@@ -91,6 +94,9 @@ import {
   WorkspaceDesktopLayout,
   WorkspaceMobileLayout,
 } from './WorkspaceStudioLayouts'
+import { createStudyPackOrchestratorWidgets } from '../../studyPack'
+import { augmentStudyPackPracticeObjects } from '../../studyPack/practice'
+import { StudyObject } from '../../studyPack/types'
 import WidgetEditorDialog from './WidgetEditorDialog'
 import { useResponsiveWorkspaceMode } from './useResponsiveWorkspaceMode'
 
@@ -111,6 +117,61 @@ const statusMarkerLabels: Record<
   running: 'Generating study material…',
   complete: 'Study material saved to dashboards',
   error: 'Generation failed. Click to review.',
+}
+
+const detailLevelCountLimits: Record<
+  StudyMaterialResourceType,
+  Record<StudyMaterialDetailLevel, { max: number }>
+> = {
+  improvedNotes: {
+    short: { max: 700 },
+    medium: { max: 1400 },
+    long: { max: 2600 },
+  },
+  flashcards: {
+    short: { max: 10 },
+    medium: { max: 18 },
+    long: { max: 35 },
+  },
+  quiz: {
+    short: { max: 7 },
+    medium: { max: 12 },
+    long: { max: 25 },
+  },
+}
+
+const getPackId = (title: string) =>
+  title.toLowerCase().replace(/[^a-z0-9]+/g, '-') || 'study-pack'
+
+const isReviewableStudyObject = (object: StudyObject) =>
+  object.kind === 'qa' ||
+  object.kind === 'quiz' ||
+  object.kind === 'term' ||
+  object.kind === 'code' ||
+  object.kind === 'comparison' ||
+  object.kind === 'list' ||
+  object.kind === 'table' ||
+  object.kind === 'reviewPrompt'
+
+const getReviewableObjects = (
+  objects: StudyObject[],
+  resourceType: StudyMaterialResourceType,
+  detailLevel: StudyMaterialDetailLevel,
+) => {
+  const filtered = objects.filter((object) =>
+    resourceType === 'improvedNotes'
+      ? object.kind === 'markdown'
+      : isReviewableStudyObject(object),
+  )
+
+  if (resourceType !== 'flashcards' && resourceType !== 'quiz') {
+    return filtered
+  }
+
+  return filtered.slice(
+    0,
+    detailLevelCountLimits[resourceType][detailLevel].max,
+  )
 }
 
 const resourceTypeTitle = (resourceType?: string | null) => {
@@ -184,12 +245,6 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
   const [selectedIntent, setSelectedIntent] = useState<CreateIntent | null>(
     null,
   )
-  const [initialStudyPackSourceText, setInitialStudyPackSourceText] = useState<
-    string | undefined
-  >(undefined)
-  const [initialStudyPackTitle, setInitialStudyPackTitle] = useState<
-    string | undefined
-  >(undefined)
   const [generationDrafts, setGenerationDrafts] =
     useState<GenerationDraft[]>(initialDrafts)
   const [activeDraftByFlow, setActiveDraftByFlow] = useState<
@@ -722,15 +777,141 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     return ''
   }
 
-  const openStudyPackCreator = (
+  const runDirectStudyPackCreate = async (
     resourceType: StudyMaterialResourceType,
-    sourceText?: string,
-    title?: string,
+    sourceText: string,
+    title: string,
   ) => {
-    setSelectedIntent(resourceType)
-    setInitialStudyPackSourceText(sourceText)
-    setInitialStudyPackTitle(title)
-    createNewDraft('from-notes')
+    const draft = createGenerationDraft('from-notes', {
+      quickCreate: true,
+      title,
+      inputSummary:
+        quickSourceMode === 'dashboard' ? 'current dashboard' : 'sources',
+      selectedResourceType: resourceType,
+      detailLevel: quickDetailLevel,
+    })
+
+    setActiveFlow('hub')
+    setQuickOptionsOpen(false)
+    setSelectedIntent(null)
+    setQuickSourceStatus('')
+    setGenerationDrafts((current) => [
+      ...current.filter(
+        (existingDraft) =>
+          existingDraft.flow !== 'from-notes' ||
+          existingDraft.status !== 'editing',
+      ),
+      { ...draft, status: 'generating' },
+    ])
+    setActiveDraftByFlow((current) => ({ ...current, 'from-notes': draft.id }))
+    dispatchWorkspaceCreationStatus({
+      task: 'from-notes',
+      state: 'running',
+      message: 'Creating study material…',
+    })
+
+    try {
+      const credentials = resolveStudyPackAiCredentials()
+      const generated = await generateStudyPackWithAi({
+        provider: aiProvider,
+        apiToken: credentials.apiToken,
+        model: credentials.model,
+        title,
+        rawNotes: sourceText,
+        packId: getPackId(title),
+        generationTargets: quickCreateTargets[resourceType],
+        generationAmount: quickCreateDetailToAmount[quickDetailLevel],
+        resourceType,
+        detailLevel: quickDetailLevel,
+        quizQuestionStyle:
+          resourceType === 'quiz' && quickDifficulty === 'challenge'
+            ? 'advanced'
+            : 'mixed',
+        promptMode: false,
+        studyPathMode: false,
+      })
+
+      const nextTitle = generated.title || title
+      const augmented = augmentStudyPackPracticeObjects(generated.objects, {
+        packId: getPackId(nextTitle),
+        title: nextTitle,
+        rawNotes: sourceText,
+        generationTargets: quickCreateTargets[resourceType],
+        generationAmount: quickCreateDetailToAmount[quickDetailLevel],
+      })
+      const objects = getReviewableObjects(
+        augmented.objects,
+        resourceType,
+        quickDetailLevel,
+      )
+
+      if (objects.length === 0) {
+        throw new Error(
+          'AI did not create any reviewable study material from these notes.',
+        )
+      }
+
+      const groups = [
+        {
+          name: `${nextTitle} ${quickCreateLabels[resourceType]}`,
+          objects,
+        },
+      ]
+      const pack = {
+        id: getPackId(nextTitle),
+        title: nextTitle,
+        sourceFormat: generated.sourceFormat || 'text',
+        objects,
+        warnings: [],
+        sourceSummary: generated.sourceSummary || undefined,
+      }
+      const widgets = createStudyPackOrchestratorWidgets(pack, {
+        forceQuizBlockComponent: resourceType === 'quiz',
+        focusedResourceType:
+          resourceType === 'flashcards' || resourceType === 'quiz'
+            ? resourceType
+            : undefined,
+        includeSourceWidget: false,
+        includeSummaryChart: false,
+        rawSource: sourceText,
+        widgetGroups: groups,
+      })
+
+      const dashboard = createStudyPackDashboard({
+        name: nextTitle,
+        widgets,
+        layoutMode:
+          resourceType === 'flashcards' || resourceType === 'quiz'
+            ? 'tabs'
+            : 'tabs',
+      })
+      updateDraft(draft.id, {
+        status: 'ready',
+        title: dashboard.name,
+        inputSummary: 'saved to dashboards',
+      })
+      dispatchWorkspaceCreationStatus({
+        task: 'from-notes',
+        state: 'complete',
+        message: 'Saved to dashboards',
+      })
+      setIsStudioOpen(false)
+      if (isMobile) {
+        setMobileSection('dashboard')
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : `Could not create ${quickCreateLabels[resourceType]}.`
+      updateDraft(draft.id, { status: 'failed', error: message })
+      dispatchWorkspaceCreationStatus({
+        task: 'from-notes',
+        state: 'error',
+        message,
+      })
+      setQuickSourceStatus(message)
+    }
   }
 
   const runQuickCreate = async (
@@ -758,7 +939,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         return
       }
 
-      openStudyPackCreator(
+      await runDirectStudyPackCreate(
         resourceType,
         sourceText,
         `${currentDashboardTitle} ${titleBase}`.trim(),
@@ -1025,6 +1206,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                           key={resourceType}
                           component="button"
                           type="button"
+                          aria-label={`Quick Create ${quickCreateLabels[resourceType]}`}
                           elevation={0}
                           onClick={() =>
                             handleQuickCreateCardClick(resourceType)
@@ -1755,49 +1937,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                     : 'none',
                 flexDirection: 'column',
               }}
-            >
-              <CreateStudyPackModal
-                open
-                presentation="embedded"
-                onCollapse={returnToCreateHub}
-                onClose={() => {
-                  setInitialStudyPackSourceText(undefined)
-                  setInitialStudyPackTitle(undefined)
-                  cancelDraftAndReturnToHub(draft.id, 'from-notes')
-                }}
-                onCreatePack={(payload) => {
-                  const dashboard = createStudyPackDashboard(payload)
-                  setInitialStudyPackSourceText(undefined)
-                  setInitialStudyPackTitle(undefined)
-                  removeDraft(draft.id, 'from-notes')
-                  reportCreationStatus(
-                    'from-notes',
-                    'idle',
-                    'Study material created.',
-                  )
-                  return dashboard
-                }}
-                initialResourceType={
-                  selectedIntent && selectedIntent !== 'study-path'
-                    ? selectedIntent
-                    : undefined
-                }
-                initialSourceText={initialStudyPackSourceText}
-                initialTitle={initialStudyPackTitle}
-                currentDashboardContext={currentDashboardContext}
-                currentDashboardTitle={currentDashboardTitle}
-                hasCurrentDashboardContext={hasCurrentDashboardContext}
-                onStatusChange={makeDraftStatusHandler(draft.id, 'from-notes')}
-                onDraftMetaChange={(metadata) =>
-                  updateDraft(draft.id, {
-                    title: metadata.title,
-                    inputSummary: metadata.inputSummary,
-                    selectedResourceType: metadata.resourceType,
-                    detailLevel: metadata.detailLevel,
-                  })
-                }
-              />
-            </Box>
+            ></Box>
           ))}
       </Box>
     </Box>

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -391,6 +391,9 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       canCreateWidget: isAdmin,
     }
   }, [aiProvider])
+  const hasGeneratingQueueJobs = generationDrafts.some(
+    (draft) => draft.status === 'generating',
+  )
 
   useEffect(() => {
     const showDashboardAfterChatClose = () => {
@@ -431,16 +434,17 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
   }, [])
 
   useEffect(() => {
-    if (!generationDrafts.some((draft) => draft.status === 'generating')) {
+    if (!hasGeneratingQueueJobs) {
       return
     }
 
+    setQueueClockMs(Date.now())
     const intervalId = window.setInterval(
       () => setQueueClockMs(Date.now()),
       1000,
     )
     return () => window.clearInterval(intervalId)
-  }, [generationDrafts])
+  }, [hasGeneratingQueueJobs])
 
   useEffect(() => {
     const activateCreation = (flow: Exclude<StudioFlow, 'hub'>) => {
@@ -2100,11 +2104,15 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                   const isFailed = draft.status === 'failed'
                   const opened = Boolean(draft.openedAt)
                   const materialLabel = generationMaterialLabel(draft)
-                  const elapsed =
-                    isGenerating &&
-                    formatQueueDuration(
-                      queueClockMs - new Date(draft.createdAt).getTime(),
-                    )
+                  const createdAtMs = new Date(draft.createdAt).getTime()
+                  const elapsed = isGenerating
+                    ? formatQueueDuration(
+                        queueClockMs -
+                          (Number.isFinite(createdAtMs)
+                            ? createdAtMs
+                            : queueClockMs),
+                      )
+                    : ''
                   const estimate = isGenerating
                     ? estimateQueueDuration(draft)
                     : ''

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -41,13 +41,10 @@ import CreateStudyPackModal from '../studyPack/CreateStudyPackModal'
 import CreateStudyPathModal from '../studyPack/CreateStudyPathModal'
 import {
   readStudyPackAiSettings,
-  resolveStudyPackAiCredentials,
-  generateStudyPackWithAi,
   STUDY_PACK_AI_SETTINGS_CHANGED_EVENT,
   StudyMaterialDetailLevel,
   StudyMaterialResourceType,
 } from '../../studyPack/ai'
-import { createStudyPackOrchestratorWidgets } from '../../studyPack'
 import {
   extractTextFromPdf,
   extractTextFromPptx,
@@ -80,9 +77,7 @@ import {
   QuickSourceFocus,
   readIsAdmin,
   quickCreateAccents,
-  quickCreateDetailToAmount,
   quickCreateLabels,
-  quickCreateTargets,
   quickSourceAcceptValue,
   statusMarkerColors,
   statusMarkerGlow,
@@ -189,6 +184,12 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
   const [selectedIntent, setSelectedIntent] = useState<CreateIntent | null>(
     null,
   )
+  const [initialStudyPackSourceText, setInitialStudyPackSourceText] = useState<
+    string | undefined
+  >(undefined)
+  const [initialStudyPackTitle, setInitialStudyPackTitle] = useState<
+    string | undefined
+  >(undefined)
   const [generationDrafts, setGenerationDrafts] =
     useState<GenerationDraft[]>(initialDrafts)
   const [activeDraftByFlow, setActiveDraftByFlow] = useState<
@@ -571,23 +572,6 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       : 'Sources required'
   const selectedQuickCreateIntent =
     selectedIntent && selectedIntent !== 'study-path' ? selectedIntent : null
-  const quickCreateJobs = generationDrafts.filter((draft) => draft.quickCreate)
-  const quickCreateStatusLabel = (draft: GenerationDraft) => {
-    if (draft.status === 'generating') {
-      return `Creating ${resourceTypeTitle(draft.selectedResourceType).toLowerCase()}…`
-    }
-
-    if (draft.status === 'ready') {
-      return 'Saved to your dashboards. Click to open it.'
-    }
-
-    if (draft.status === 'failed') {
-      return draft.error || 'Generation failed.'
-    }
-
-    return 'Preparing…'
-  }
-
   useEffect(() => {
     if (
       !pendingQuickSourceFocus ||
@@ -738,6 +722,17 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     return ''
   }
 
+  const openStudyPackCreator = (
+    resourceType: StudyMaterialResourceType,
+    sourceText?: string,
+    title?: string,
+  ) => {
+    setSelectedIntent(resourceType)
+    setInitialStudyPackSourceText(sourceText)
+    setInitialStudyPackTitle(title)
+    createNewDraft('from-notes')
+  }
+
   const runQuickCreate = async (
     resourceType: StudyMaterialResourceType,
     sourceMode: QuickSourceMode = quickSourceMode,
@@ -749,122 +744,32 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       : hasCurrentDashboardContext
 
     if (!hasUsableSource) {
-      setSelectedIntent(resourceType)
-      setQuickOptionsOpen(true)
-      if (!hasCurrentDashboardContext || usesSources) {
-        setQuickSourceMode('sources')
-        setPendingQuickSourceFocus('upload')
-      }
+      openCreateFromMaterial(resourceType, 'upload')
       setQuickSourceStatus(`Add material to create ${titleBase}.`)
       return
     }
-
-    const usingAttachedSources = usesSources && quickHasCustomSources
-    const draft: GenerationDraft = {
-      id: `quick-${resourceType}-${Date.now()}-${Math.random()
-        .toString(36)
-        .slice(2, 8)}`,
-      flow: 'from-notes',
-      status: 'generating',
-      title: titleBase,
-      createdAt: new Date().toISOString(),
-      inputSummary: usingAttachedSources
-        ? 'Attached sources'
-        : `Current dashboard: ${currentDashboardTitle}`,
-      selectedResourceType: resourceType,
-      detailLevel: quickDetailLevel,
-      quickCreate: true,
-    }
-
-    setGenerationDrafts((current) => [...current, draft])
-    setActiveFlow('hub')
-    setQuickOptionsOpen(false)
-    reportFromNotesStatus('running', `${titleBase} is generating`)
 
     try {
       const sourceText = await buildQuickSourceText(sourceMode)
 
       if (!sourceText.trim()) {
-        updateDraft(draft.id, {
-          status: 'failed',
-          error:
-            'Add pasted text or attachments in Options, or open a dashboard with study content.',
-        })
-        reportFromNotesStatus('error', 'Quick Create needs source material.')
+        openCreateFromMaterial(resourceType, 'upload')
+        setQuickSourceStatus(`Add material to create ${titleBase}.`)
         return
       }
 
-      const credentials = resolveStudyPackAiCredentials()
-      const generationAmount = quickCreateDetailToAmount[quickDetailLevel]
-      const rawNotes = [
-        sourceText,
-        quickDifficulty === 'standard' ? '' : `Difficulty: ${quickDifficulty}`,
-      ]
-        .filter(Boolean)
-        .join('\n\n')
-      const draftPack = await generateStudyPackWithAi({
-        provider: aiProvider,
-        apiToken: credentials.apiToken,
-        model: credentials.model,
-        title: `${currentDashboardTitle} ${titleBase}`,
-        rawNotes,
-        packId: `${resourceType}-${Date.now()}`,
-        generationTargets: quickCreateTargets[resourceType],
-        generationAmount,
+      openStudyPackCreator(
         resourceType,
-        detailLevel: quickDetailLevel,
-        quizQuestionStyle: 'mixed',
-        promptMode: false,
-        studyPathMode: false,
-      })
-      const widgets = createStudyPackOrchestratorWidgets(
-        {
-          id: `${resourceType}-${Date.now()}`,
-          title: draftPack.title || `${currentDashboardTitle} ${titleBase}`,
-          sourceFormat: draftPack.sourceFormat || 'text',
-          objects: draftPack.objects,
-          warnings: draftPack.warnings || [],
-          sourceSummary: draftPack.sourceSummary,
-        },
-        {
-          forceQuizBlockComponent: resourceType === 'quiz',
-          focusedResourceType:
-            resourceType === 'quiz' || resourceType === 'flashcards'
-              ? resourceType
-              : undefined,
-          includeSourceWidget: false,
-          includeSummaryChart: false,
-          rawSource: sourceText,
-          widgetGroups: [
-            {
-              name: `${draftPack.title || currentDashboardTitle} ${titleBase}`,
-              objects: draftPack.objects,
-            },
-          ],
-        },
+        sourceText,
+        `${currentDashboardTitle} ${titleBase}`.trim(),
       )
-      const dashboard = createStudyPackDashboard({
-        name: draftPack.title || `${currentDashboardTitle} ${titleBase}`,
-        widgets,
-        layoutMode: resourceType === 'improvedNotes' ? 'smart' : 'tabs',
-      })
-      updateDraft(draft.id, {
-        status: 'ready',
-        title: dashboard.name,
-        inputSummary: 'Saved to dashboards',
-      })
-      reportFromNotesStatus('complete', `${titleBase} saved to dashboards.`)
     } catch (error) {
       const message =
         error instanceof Error
           ? error.message
-          : `Could not create ${titleBase}.`
-      setQuickSourceStatus('')
-      updateDraft(draft.id, {
-        status: 'failed',
-        error: message,
-      })
-      reportFromNotesStatus('error', message)
+          : `Could not read source material for ${titleBase}.`
+      setQuickSourceStatus(message)
+      openCreateFromMaterial(resourceType, 'upload')
     }
   }
 
@@ -1254,128 +1159,6 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                 </Button>
               </Stack>
             </Paper>
-
-            {quickCreateJobs.length ? (
-              <Paper
-                elevation={0}
-                sx={{
-                  p: { xs: 1.25, sm: 1.5 },
-                  borderRadius: 2.5,
-                  border: 1,
-                  borderColor: alpha(theme.palette.primary.main, 0.24),
-                  bgcolor: alpha(theme.palette.primary.main, 0.045),
-                }}
-              >
-                <Stack spacing={1}>
-                  <Box>
-                    <Typography variant="subtitle1" fontWeight={900}>
-                      Creating now
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      StudyMesh saves finished material directly to your
-                      dashboards, NotebookLM-style.
-                    </Typography>
-                  </Box>
-                  {quickCreateJobs.map((draft) => {
-                    const accent =
-                      draft.selectedResourceType === 'quiz' ||
-                      draft.selectedResourceType === 'flashcards' ||
-                      draft.selectedResourceType === 'improvedNotes'
-                        ? quickCreateAccents[draft.selectedResourceType]
-                        : theme.palette.primary.main
-                    const isReady = draft.status === 'ready'
-                    const isFailed = draft.status === 'failed'
-
-                    return (
-                      <Paper
-                        key={draft.id}
-                        component="button"
-                        type="button"
-                        elevation={0}
-                        onClick={() => {
-                          if (isReady) {
-                            closeStudio()
-                          }
-                        }}
-                        disabled={!isReady}
-                        sx={{
-                          width: '100%',
-                          p: 1.1,
-                          borderRadius: 2,
-                          border: 1,
-                          borderColor: isFailed
-                            ? 'error.main'
-                            : alpha(accent, isReady ? 0.5 : 0.28),
-                          bgcolor: alpha(
-                            accent,
-                            theme.palette.mode === 'dark' ? 0.12 : 0.075,
-                          ),
-                          color: 'text.primary',
-                          textAlign: 'left',
-                          cursor: isReady ? 'pointer' : 'default',
-                        }}
-                      >
-                        <Stack direction="row" spacing={1} alignItems="center">
-                          <Box
-                            sx={{
-                              width: 34,
-                              height: 34,
-                              borderRadius: 1.5,
-                              display: 'grid',
-                              placeItems: 'center',
-                              bgcolor: alpha(accent, 0.14),
-                              color: accent,
-                              flex: '0 0 auto',
-                            }}
-                          >
-                            {draft.selectedResourceType === 'quiz' ? (
-                              <QuizIcon fontSize="small" />
-                            ) : draft.selectedResourceType === 'flashcards' ? (
-                              <StyleIcon fontSize="small" />
-                            ) : (
-                              <AutoStoriesIcon fontSize="small" />
-                            )}
-                          </Box>
-                          <Box sx={{ minWidth: 0, flex: 1 }}>
-                            <Typography
-                              variant="subtitle2"
-                              fontWeight={900}
-                              noWrap
-                            >
-                              {formatDraftTitle(draft)}
-                            </Typography>
-                            <Typography
-                              variant="caption"
-                              color="text.secondary"
-                            >
-                              {quickCreateStatusLabel(draft)}
-                            </Typography>
-                          </Box>
-                          <Chip
-                            size="small"
-                            color={
-                              isFailed
-                                ? 'error'
-                                : isReady
-                                  ? 'success'
-                                  : 'primary'
-                            }
-                            label={
-                              isFailed
-                                ? 'Failed'
-                                : isReady
-                                  ? 'Saved'
-                                  : 'Working'
-                            }
-                            sx={{ fontWeight: 800 }}
-                          />
-                        </Stack>
-                      </Paper>
-                    )
-                  })}
-                </Stack>
-              </Paper>
-            ) : null}
           </>
         ) : (
           <Stack spacing={1.5}>
@@ -1977,11 +1760,15 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                 open
                 presentation="embedded"
                 onCollapse={returnToCreateHub}
-                onClose={() =>
+                onClose={() => {
+                  setInitialStudyPackSourceText(undefined)
+                  setInitialStudyPackTitle(undefined)
                   cancelDraftAndReturnToHub(draft.id, 'from-notes')
-                }
+                }}
                 onCreatePack={(payload) => {
                   const dashboard = createStudyPackDashboard(payload)
+                  setInitialStudyPackSourceText(undefined)
+                  setInitialStudyPackTitle(undefined)
                   removeDraft(draft.id, 'from-notes')
                   reportCreationStatus(
                     'from-notes',
@@ -1995,8 +1782,8 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                     ? selectedIntent
                     : undefined
                 }
-                initialSourceText={undefined}
-                initialTitle={undefined}
+                initialSourceText={initialStudyPackSourceText}
+                initialTitle={initialStudyPackTitle}
                 currentDashboardContext={currentDashboardContext}
                 currentDashboardTitle={currentDashboardTitle}
                 hasCurrentDashboardContext={hasCurrentDashboardContext}

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -48,6 +48,7 @@ import {
   STUDY_PACK_AI_SETTINGS_CHANGED_EVENT,
   StudyMaterialDetailLevel,
   StudyMaterialResourceType,
+  StudyPackAiProvider,
 } from '../../studyPack/ai'
 import {
   extractTextFromPdf,
@@ -336,6 +337,9 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     useState<QuickSourceMode>('dashboard')
   const [quickSourceStatus, setQuickSourceStatus] = useState('')
   const [queueClockMs, setQueueClockMs] = useState(() => Date.now())
+  const [studyPathRetrySignals, setStudyPathRetrySignals] = useState<
+    Record<string, number>
+  >({})
   const [pendingQuickSourceFocus, setPendingQuickSourceFocus] =
     useState<QuickSourceFocus | null>(null)
   const [fullScreenWidgetPayload, setFullScreenWidgetPayload] = useState<{
@@ -798,6 +802,49 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     }
   }
 
+  const retryGenerationDraft = (draft: GenerationDraft) => {
+    if (draft.status !== 'failed') {
+      return
+    }
+
+    if (
+      draft.flow === 'from-notes' &&
+      draft.retryResourceType &&
+      draft.retrySourceText &&
+      draft.retryTitle &&
+      draft.retrySourceMode
+    ) {
+      void runDirectStudyPackCreate(
+        draft.retryResourceType,
+        draft.retrySourceText,
+        draft.retryTitle,
+        draft.retrySourceMode,
+        {
+          draftId: draft.id,
+          detailLevel: draft.detailLevel as StudyMaterialDetailLevel,
+          difficulty: draft.retryDifficulty,
+          provider: draft.aiProvider as StudyPackAiProvider,
+        },
+      )
+      return
+    }
+
+    if (draft.flow === 'study-path') {
+      updateDraft(draft.id, {
+        status: 'generating',
+        error: undefined,
+        acknowledgedAt: undefined,
+        openedAt: undefined,
+        completedAt: undefined,
+        generatedDashboards: undefined,
+      })
+      setStudyPathRetrySignals((current) => ({
+        ...current,
+        [draft.id]: (current[draft.id] || 0) + 1,
+      }))
+    }
+  }
+
   const closeFullScreenWidgetEditor = () => {
     setFullScreenWidgetPayload(null)
     resetOrCloseStudio()
@@ -992,30 +1039,64 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     sourceText: string,
     title: string,
     sourceMode: QuickSourceMode,
+    retryOptions: {
+      draftId?: string
+      detailLevel?: StudyMaterialDetailLevel
+      difficulty?: string
+      provider?: StudyPackAiProvider
+    } = {},
   ) => {
+    const effectiveDetailLevel = retryOptions.detailLevel || quickDetailLevel
+    const effectiveDifficulty = retryOptions.difficulty || quickDifficulty
+    const effectiveProvider = retryOptions.provider || aiProvider
     const draft = createGenerationDraft('from-notes', {
       quickCreate: true,
       title,
       inputSummary:
         sourceMode === 'dashboard' ? 'current dashboard' : 'sources',
       selectedResourceType: resourceType,
-      detailLevel: quickDetailLevel,
-      aiProvider,
+      detailLevel: effectiveDetailLevel,
+      aiProvider: effectiveProvider,
+      retrySourceText: sourceText,
+      retryTitle: title,
+      retrySourceMode: sourceMode,
+      retryResourceType: resourceType,
+      retryDifficulty: effectiveDifficulty,
     })
+    const draftId = retryOptions.draftId || draft.id
+    const generationDraft = { ...draft, id: draftId, status: 'generating' }
 
     setActiveFlow('hub')
     setQuickOptionsOpen(false)
     setSelectedIntent(null)
     setQuickSourceStatus('')
-    setGenerationDrafts((current) => [
-      ...current.filter(
-        (existingDraft) =>
-          existingDraft.flow !== 'from-notes' ||
-          existingDraft.status !== 'editing',
-      ),
-      { ...draft, status: 'generating' },
-    ])
-    setActiveDraftByFlow((current) => ({ ...current, 'from-notes': draft.id }))
+    setGenerationDrafts((current) => {
+      if (retryOptions.draftId) {
+        return current.map((existingDraft) =>
+          existingDraft.id === retryOptions.draftId
+            ? {
+                ...existingDraft,
+                ...generationDraft,
+                error: undefined,
+                acknowledgedAt: undefined,
+                openedAt: undefined,
+                completedAt: undefined,
+                generatedDashboards: undefined,
+              }
+            : existingDraft,
+        )
+      }
+
+      return [
+        ...current.filter(
+          (existingDraft) =>
+            existingDraft.flow !== 'from-notes' ||
+            existingDraft.status !== 'editing',
+        ),
+        generationDraft,
+      ]
+    })
+    setActiveDraftByFlow((current) => ({ ...current, 'from-notes': draftId }))
     dispatchWorkspaceCreationStatus({
       task: 'from-notes',
       state: 'running',
@@ -1025,18 +1106,18 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     try {
       const credentials = resolveStudyPackAiCredentials()
       const generated = await generateStudyPackWithAi({
-        provider: aiProvider,
+        provider: effectiveProvider,
         apiToken: credentials.apiToken,
         model: credentials.model,
         title,
         rawNotes: sourceText,
         packId: getPackId(title),
         generationTargets: quickCreateTargets[resourceType],
-        generationAmount: quickCreateDetailToAmount[quickDetailLevel],
+        generationAmount: quickCreateDetailToAmount[effectiveDetailLevel],
         resourceType,
-        detailLevel: quickDetailLevel,
+        detailLevel: effectiveDetailLevel,
         quizQuestionStyle:
-          resourceType === 'quiz' && quickDifficulty === 'challenge'
+          resourceType === 'quiz' && effectiveDifficulty === 'challenge'
             ? 'advanced'
             : 'mixed',
         promptMode: false,
@@ -1049,12 +1130,12 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         title: nextTitle,
         rawNotes: sourceText,
         generationTargets: quickCreateTargets[resourceType],
-        generationAmount: quickCreateDetailToAmount[quickDetailLevel],
+        generationAmount: quickCreateDetailToAmount[effectiveDetailLevel],
       })
       const objects = getReviewableObjects(
         augmented.objects,
         resourceType,
-        quickDetailLevel,
+        effectiveDetailLevel,
       )
 
       if (objects.length === 0) {
@@ -1099,7 +1180,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         ],
         openInWorkspace: false,
       })
-      updateDraft(draft.id, {
+      updateDraft(draftId, {
         title: nextTitle,
         status: 'ready',
         completedAt: new Date().toISOString(),
@@ -1115,7 +1196,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         error instanceof Error
           ? error.message
           : `Could not create ${quickCreateLabels[resourceType]}.`
-      updateDraft(draft.id, { status: 'failed', error: message })
+      updateDraft(draftId, { status: 'failed', error: message })
       dispatchWorkspaceCreationStatus({
         task: 'from-notes',
         state: 'error',
@@ -2234,6 +2315,21 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                           sx={{ fontWeight: 900 }}
                         />
                       ) : null}
+                      {isFailed ? (
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          onClick={() => retryGenerationDraft(draft)}
+                          sx={{
+                            borderRadius: 999,
+                            textTransform: 'none',
+                            fontWeight: 900,
+                            flex: '0 0 auto',
+                          }}
+                        >
+                          Retry
+                        </Button>
+                      ) : null}
                     </Paper>
                   )
                 })}
@@ -2294,6 +2390,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
                 presentation="embedded"
                 onCollapse={returnToCreateHub}
                 autoCreateOnGenerate
+                autoRetrySignal={studyPathRetrySignals[draft.id] || 0}
                 openGeneratedInWorkspace={false}
                 onClose={() =>
                   cancelDraftAndReturnToHub(draft.id, 'study-path')

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -162,6 +162,28 @@ const detailLevelCountLimits: Record<
 const getPackId = (title: string) =>
   title.toLowerCase().replace(/[^a-z0-9]+/g, '-') || 'study-pack'
 
+const truncateQuickCreationContext = (title: string) => {
+  const cleaned = title.trim() || 'Sources'
+  return cleaned.length > 28 ? `${cleaned.slice(0, 27).trim()}...` : cleaned
+}
+
+const getSavedDashboardNames = () => {
+  try {
+    const dashboards = window.localStorage.getItem('customDashboards')
+    if (!dashboards) {
+      return []
+    }
+
+    const parsed = JSON.parse(dashboards) as Array<{ name?: unknown }>
+    return parsed
+      .map((dashboard) => dashboard.name)
+      .filter((name): name is string => typeof name === 'string')
+  } catch (error) {
+    console.error('Failed to read saved dashboard names', error)
+    return []
+  }
+}
+
 const isReviewableStudyObject = (object: StudyObject) =>
   object.kind === 'qa' ||
   object.kind === 'quiz' ||
@@ -255,7 +277,7 @@ const estimateQueueDuration = (draft: GenerationDraft) => {
       return 'est. 15-20m'
     }
 
-    return 'est. 1-3m'
+    return 'est. 2m'
   }
 
   if (draft.aiProvider === 'gemini') {
@@ -975,6 +997,36 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       : 'Sources required'
   const selectedQuickCreateIntent =
     selectedIntent && selectedIntent !== 'study-path' ? selectedIntent : null
+  const getNextQuickCreationIndex = (
+    resourceType: StudyMaterialResourceType,
+  ) => {
+    const label = quickCreateLabels[resourceType]
+    const names = [
+      ...getSavedDashboardNames(),
+      ...generationDrafts.map((draft) => draft.title),
+    ]
+    const prefix = `${label} #`
+    const usedIndexes = names
+      .filter((name) => name.startsWith(prefix))
+      .map((name) => {
+        const match = name.slice(prefix.length).match(/^(\d+)/)
+        return match ? Number(match[1]) : 0
+      })
+      .filter((index) => Number.isFinite(index) && index > 0)
+
+    return usedIndexes.length > 0 ? Math.max(...usedIndexes) + 1 : 1
+  }
+  const buildQuickCreationTitle = (
+    resourceType: StudyMaterialResourceType,
+    sourceMode: QuickSourceMode,
+  ) => {
+    const label = quickCreateLabels[resourceType]
+    const contextTitle =
+      sourceMode === 'dashboard' ? currentDashboardTitle : quickSourceLabel
+    return `${label} #${getNextQuickCreationIndex(
+      resourceType,
+    )} - ${truncateQuickCreationContext(contextTitle)}`
+  }
   useEffect(() => {
     if (
       !pendingQuickSourceFocus ||
@@ -1225,7 +1277,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
         studyPathMode: false,
       })
 
-      const nextTitle = generated.title || title
+      const nextTitle = title
       const augmented = augmentStudyPackPracticeObjects(generated.objects, {
         packId: getPackId(nextTitle),
         title: nextTitle,
@@ -1247,7 +1299,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
 
       const groups = [
         {
-          name: `${nextTitle} ${quickCreateLabels[resourceType]}`,
+          name: nextTitle,
           objects,
         },
       ]
@@ -1336,7 +1388,7 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
       await runDirectStudyPackCreate(
         resourceType,
         sourceText,
-        `${currentDashboardTitle} ${titleBase}`.trim(),
+        buildQuickCreationTitle(resourceType, sourceMode),
         sourceMode,
       )
     } catch (error) {

--- a/apps/studymesh/src/components/workspace/workspaceStudioModel.ts
+++ b/apps/studymesh/src/components/workspace/workspaceStudioModel.ts
@@ -2,6 +2,7 @@ import type {
   StudyMaterialDetailLevel,
   StudyMaterialResourceType,
 } from '../../studyPack/ai'
+import type { DashboardLayout } from '../../state/store'
 import type { WorkspaceCreationTaskState } from '../../workspaceCreationStatus'
 
 export type StudioFlow = 'hub' | 'study-path' | 'from-notes'
@@ -34,6 +35,14 @@ export interface GenerationDraft {
   error?: string
   isPlaceholder?: boolean
   quickCreate?: boolean
+  completedAt?: string
+  openedAt?: string
+  generatedDashboards?: Array<{
+    id: string
+    name: string
+    layout: DashboardLayout
+    folder?: string
+  }>
 }
 
 export const quickCreateLabels: Record<StudyMaterialResourceType, string> = {

--- a/apps/studymesh/src/components/workspace/workspaceStudioModel.ts
+++ b/apps/studymesh/src/components/workspace/workspaceStudioModel.ts
@@ -39,6 +39,11 @@ export interface GenerationDraft {
   acknowledgedAt?: string
   openedAt?: string
   aiProvider?: string
+  retrySourceText?: string
+  retryTitle?: string
+  retrySourceMode?: 'dashboard' | 'sources'
+  retryResourceType?: StudyMaterialResourceType
+  retryDifficulty?: string
   generatedDashboards?: Array<{
     id: string
     name: string

--- a/apps/studymesh/src/components/workspace/workspaceStudioModel.ts
+++ b/apps/studymesh/src/components/workspace/workspaceStudioModel.ts
@@ -38,6 +38,7 @@ export interface GenerationDraft {
   completedAt?: string
   acknowledgedAt?: string
   openedAt?: string
+  aiProvider?: string
   generatedDashboards?: Array<{
     id: string
     name: string

--- a/apps/studymesh/src/components/workspace/workspaceStudioModel.ts
+++ b/apps/studymesh/src/components/workspace/workspaceStudioModel.ts
@@ -36,6 +36,7 @@ export interface GenerationDraft {
   isPlaceholder?: boolean
   quickCreate?: boolean
   completedAt?: string
+  acknowledgedAt?: string
   openedAt?: string
   generatedDashboards?: Array<{
     id: string

--- a/apps/studymesh/tests/unit/components/workspace/WorkspaceStudioShell.test.tsx
+++ b/apps/studymesh/tests/unit/components/workspace/WorkspaceStudioShell.test.tsx
@@ -67,7 +67,17 @@ vi.mock('../../../../src/studyPack/imageOcr', () => ({
 
 vi.mock('../../../../src/components/studyPack/CreateStudyPackModal', () => ({
   __esModule: true,
-  default: () => <div data-testid="create-study-pack-modal" />,
+  default: (props: {
+    initialResourceType?: string
+    initialSourceText?: string
+    initialTitle?: string
+  }) => (
+    <div data-testid="create-study-pack-modal">
+      <span>resource:{props.initialResourceType || ''}</span>
+      <span>source:{props.initialSourceText || ''}</span>
+      <span>title:{props.initialTitle || ''}</span>
+    </div>
+  ),
 }))
 
 vi.mock('../../../../src/components/studyPack/CreateStudyPathModal', () => ({
@@ -128,7 +138,7 @@ describe('WorkspaceStudioShell Quick Create', () => {
     })
   })
 
-  it('runs quick creation immediately from the dashboard', async () => {
+  it('opens the Create from notes command with dashboard context for quick creation', async () => {
     render(
       <WorkspaceStudioShell>
         <div>Dashboard canvas</div>
@@ -138,15 +148,15 @@ describe('WorkspaceStudioShell Quick Create', () => {
     openCreation()
     clickQuickCard('Quiz')
 
-    await waitFor(() => expect(generateStudyPackWithAi).toHaveBeenCalled())
-    expect(generateStudyPackWithAi).toHaveBeenCalledWith(
-      expect.objectContaining({
-        resourceType: 'quiz',
-        rawNotes: expect.stringContaining(
-          'Dashboard notes about photosynthesis',
-        ),
-      }),
+    await waitFor(() =>
+      expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
+        'resource:quiz',
+      ),
     )
+    expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
+      'Dashboard notes about photosynthesis',
+    )
+    expect(generateStudyPackWithAi).not.toHaveBeenCalled()
   })
 
   it('opens a separate Create from Material flow from the hub link', () => {
@@ -198,16 +208,18 @@ describe('WorkspaceStudioShell Quick Create', () => {
     addCopiedMaterial('Custom source notes about enzymes')
     fireEvent.click(screen.getByRole('button', { name: /^Create Quiz$/i }))
 
-    await waitFor(() => expect(generateStudyPackWithAi).toHaveBeenCalled())
-    expect(generateStudyPackWithAi).toHaveBeenCalledWith(
-      expect.objectContaining({
-        resourceType: 'quiz',
-        rawNotes: expect.stringContaining('Custom source notes about enzymes'),
-      }),
+    await waitFor(() =>
+      expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
+        'Custom source notes about enzymes',
+      ),
     )
+    expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
+      'resource:quiz',
+    )
+    expect(generateStudyPackWithAi).not.toHaveBeenCalled()
   })
 
-  it('keeps Quick Create one-click after returning from Create from Material', async () => {
+  it('keeps Quick Create wired to dashboard source after returning from Create from Material', async () => {
     render(
       <WorkspaceStudioShell>
         <div>Dashboard canvas</div>
@@ -219,15 +231,15 @@ describe('WorkspaceStudioShell Quick Create', () => {
     fireEvent.click(screen.getByRole('button', { name: /Back to Creation/i }))
     clickQuickCard('Quiz')
 
-    await waitFor(() => expect(generateStudyPackWithAi).toHaveBeenCalled())
-    expect(generateStudyPackWithAi).toHaveBeenCalledWith(
-      expect.objectContaining({
-        resourceType: 'quiz',
-        rawNotes: expect.stringContaining(
-          'Dashboard notes about photosynthesis',
-        ),
-      }),
+    await waitFor(() =>
+      expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
+        'Dashboard notes about photosynthesis',
+      ),
     )
+    expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
+      'resource:quiz',
+    )
+    expect(generateStudyPackWithAi).not.toHaveBeenCalled()
   })
 
   it('routes empty-dashboard quick card clicks into Create from Material with the output preselected', () => {
@@ -307,15 +319,15 @@ describe('WorkspaceStudioShell Quick Create', () => {
     openCreateFromMaterial()
     fireEvent.click(screen.getByRole('button', { name: /^Create Quiz$/i }))
 
-    await waitFor(() => expect(generateStudyPackWithAi).toHaveBeenCalled())
-    expect(generateStudyPackWithAi).toHaveBeenCalledWith(
-      expect.objectContaining({
-        resourceType: 'quiz',
-        rawNotes: expect.stringContaining(
-          'Dashboard notes about photosynthesis',
-        ),
-      }),
+    await waitFor(() =>
+      expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
+        'Dashboard notes about photosynthesis',
+      ),
     )
+    expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
+      'resource:quiz',
+    )
+    expect(generateStudyPackWithAi).not.toHaveBeenCalled()
   })
 
   it('shows source controls after Sources is selected inside Create from Material', () => {

--- a/apps/studymesh/tests/unit/components/workspace/WorkspaceStudioShell.test.tsx
+++ b/apps/studymesh/tests/unit/components/workspace/WorkspaceStudioShell.test.tsx
@@ -28,7 +28,29 @@ vi.mock('../../../../src/components/Dasboard/DashboardProvider', () => ({
       {
         id: 'dashboard-1',
         name: 'Biology Dashboard',
-        layout: { type: 'row', children: [] },
+        layout: {
+          type: 'tabset',
+          children: [
+            {
+              type: 'tab',
+              name: 'Notes',
+              component: 'custom-widget',
+              config: {
+                customWidget: {
+                  id: 'widget-1',
+                  name: 'Notes',
+                  components: [
+                    {
+                      id: 'label-1',
+                      type: 'Label',
+                      props: { text: 'Dashboard notes about photosynthesis' },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
       },
     ],
     selectedDashboard: 0,
@@ -54,6 +76,14 @@ vi.mock('../../../../src/studyPack', () => ({
   createStudyPackOrchestratorWidgets: vi.fn(() => []),
 }))
 
+vi.mock('../../../../src/studyPack/practice', () => ({
+  __esModule: true,
+  augmentStudyPackPracticeObjects: (objects: unknown[]) => ({
+    objects,
+    warnings: [],
+  }),
+}))
+
 vi.mock('../../../../src/studyPack/documentExtraction', () => ({
   __esModule: true,
   extractTextFromPdf: vi.fn(),
@@ -63,21 +93,6 @@ vi.mock('../../../../src/studyPack/documentExtraction', () => ({
 vi.mock('../../../../src/studyPack/imageOcr', () => ({
   __esModule: true,
   extractRawNotesFromImage: vi.fn(),
-}))
-
-vi.mock('../../../../src/components/studyPack/CreateStudyPackModal', () => ({
-  __esModule: true,
-  default: (props: {
-    initialResourceType?: string
-    initialSourceText?: string
-    initialTitle?: string
-  }) => (
-    <div data-testid="create-study-pack-modal">
-      <span>resource:{props.initialResourceType || ''}</span>
-      <span>source:{props.initialSourceText || ''}</span>
-      <span>title:{props.initialTitle || ''}</span>
-    </div>
-  ),
 }))
 
 vi.mock('../../../../src/components/studyPack/CreateStudyPathModal', () => ({
@@ -101,7 +116,7 @@ const openCreation = (detail: Record<string, unknown> = {}) => {
 }
 
 const clickQuickCard = (label: string) => {
-  const button = screen.getAllByRole('button', { name: label })[0]
+  const button = screen.getByRole('button', { name: `Quick Create ${label}` })
   if (!button) {
     throw new Error(`Could not find ${label} quick card button`)
   }
@@ -132,13 +147,22 @@ describe('WorkspaceStudioShell Quick Create', () => {
       id: 'draft-pack',
       title: 'Generated Dashboard',
       sourceFormat: 'text',
-      objects: [],
+      objects: [
+        {
+          id: 'quiz-1',
+          kind: 'quiz',
+          question: 'What is photosynthesis?',
+          options: ['A plant process', 'A mineral', 'A planet'],
+          answer: 'A plant process',
+          correctIndex: 0,
+        },
+      ],
       warnings: [],
       sourceSummary: { title: 'Summary', bullets: [] },
     })
   })
 
-  it('opens the Create from notes command with dashboard context for quick creation', async () => {
+  it('runs direct AI generation with dashboard context for quick creation', async () => {
     render(
       <WorkspaceStudioShell>
         <div>Dashboard canvas</div>
@@ -148,15 +172,16 @@ describe('WorkspaceStudioShell Quick Create', () => {
     openCreation()
     clickQuickCard('Quiz')
 
-    await waitFor(() =>
-      expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
-        'resource:quiz',
-      ),
+    await waitFor(() => expect(generateStudyPackWithAi).toHaveBeenCalled())
+    expect(generateStudyPackWithAi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceType: 'quiz',
+        rawNotes: expect.stringContaining(
+          'Dashboard notes about photosynthesis',
+        ),
+      }),
     )
-    expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
-      'Dashboard notes about photosynthesis',
-    )
-    expect(generateStudyPackWithAi).not.toHaveBeenCalled()
+    await waitFor(() => expect(createStudyPackDashboardMock).toHaveBeenCalled())
   })
 
   it('opens a separate Create from Material flow from the hub link', () => {
@@ -191,7 +216,7 @@ describe('WorkspaceStudioShell Quick Create', () => {
 
     openCreation()
     openCreateFromMaterial()
-    clickQuickCard('Flashcards')
+    fireEvent.click(screen.getByRole('button', { name: /^Flashcards$/i }))
 
     expect(screen.getByText(/Flashcards selected/i)).toBeInTheDocument()
     expect(generateStudyPackWithAi).not.toHaveBeenCalled()
@@ -208,15 +233,14 @@ describe('WorkspaceStudioShell Quick Create', () => {
     addCopiedMaterial('Custom source notes about enzymes')
     fireEvent.click(screen.getByRole('button', { name: /^Create Quiz$/i }))
 
-    await waitFor(() =>
-      expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
-        'Custom source notes about enzymes',
-      ),
+    await waitFor(() => expect(generateStudyPackWithAi).toHaveBeenCalled())
+    expect(generateStudyPackWithAi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceType: 'quiz',
+        rawNotes: expect.stringContaining('Custom source notes about enzymes'),
+      }),
     )
-    expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
-      'resource:quiz',
-    )
-    expect(generateStudyPackWithAi).not.toHaveBeenCalled()
+    await waitFor(() => expect(createStudyPackDashboardMock).toHaveBeenCalled())
   })
 
   it('keeps Quick Create wired to dashboard source after returning from Create from Material', async () => {
@@ -231,15 +255,15 @@ describe('WorkspaceStudioShell Quick Create', () => {
     fireEvent.click(screen.getByRole('button', { name: /Back to Creation/i }))
     clickQuickCard('Quiz')
 
-    await waitFor(() =>
-      expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
-        'Dashboard notes about photosynthesis',
-      ),
+    await waitFor(() => expect(generateStudyPackWithAi).toHaveBeenCalled())
+    expect(generateStudyPackWithAi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceType: 'quiz',
+        rawNotes: expect.stringContaining(
+          'Dashboard notes about photosynthesis',
+        ),
+      }),
     )
-    expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
-      'resource:quiz',
-    )
-    expect(generateStudyPackWithAi).not.toHaveBeenCalled()
   })
 
   it('routes empty-dashboard quick card clicks into Create from Material with the output preselected', () => {
@@ -319,15 +343,15 @@ describe('WorkspaceStudioShell Quick Create', () => {
     openCreateFromMaterial()
     fireEvent.click(screen.getByRole('button', { name: /^Create Quiz$/i }))
 
-    await waitFor(() =>
-      expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
-        'Dashboard notes about photosynthesis',
-      ),
+    await waitFor(() => expect(generateStudyPackWithAi).toHaveBeenCalled())
+    expect(generateStudyPackWithAi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceType: 'quiz',
+        rawNotes: expect.stringContaining(
+          'Dashboard notes about photosynthesis',
+        ),
+      }),
     )
-    expect(screen.getByTestId('create-study-pack-modal')).toHaveTextContent(
-      'resource:quiz',
-    )
-    expect(generateStudyPackWithAi).not.toHaveBeenCalled()
   })
 
   it('shows source controls after Sources is selected inside Create from Material', () => {

--- a/apps/studymesh/tests/unit/components/workspace/WorkspaceStudioShell.test.tsx
+++ b/apps/studymesh/tests/unit/components/workspace/WorkspaceStudioShell.test.tsx
@@ -5,7 +5,7 @@ import WorkspaceStudioShell from '../../../../src/components/workspace/Workspace
 import { OPEN_CREATE_HUB_EVENT } from '../../../../src/customHooks/useWorkspaceActions'
 import { generateStudyPackWithAi } from '../../../../src/studyPack/ai'
 
-const createStudyPackDashboardMock = vi.fn()
+const createStudyPackDashboardsMock = vi.fn()
 let dashboardContextText = 'Dashboard notes about photosynthesis'
 
 vi.mock('../../../../src/customHooks/useWorkspaceActions', () => ({
@@ -16,8 +16,7 @@ vi.mock('../../../../src/customHooks/useWorkspaceActions', () => ({
   OPEN_STUDY_PATH_EVENT: 'studymesh-open-study-path',
   OPEN_WIDGET_EDITOR_EVENT: 'studymesh-open-widget-editor',
   useWorkspaceActions: () => ({
-    createStudyPackDashboard: createStudyPackDashboardMock,
-    createStudyPackDashboards: vi.fn(),
+    createStudyPackDashboards: createStudyPackDashboardsMock,
   }),
 }))
 
@@ -139,9 +138,12 @@ describe('WorkspaceStudioShell Quick Create', () => {
   beforeEach(() => {
     dashboardContextText = 'Dashboard notes about photosynthesis'
     Element.prototype.scrollIntoView = vi.fn()
-    createStudyPackDashboardMock.mockReturnValue({
-      name: 'Generated Dashboard',
-    })
+    createStudyPackDashboardsMock.mockClear()
+    createStudyPackDashboardsMock.mockReturnValue([
+      {
+        name: 'Generated Dashboard',
+      },
+    ])
     vi.mocked(generateStudyPackWithAi).mockClear()
     vi.mocked(generateStudyPackWithAi).mockResolvedValue({
       id: 'draft-pack',
@@ -181,7 +183,9 @@ describe('WorkspaceStudioShell Quick Create', () => {
         ),
       }),
     )
-    await waitFor(() => expect(createStudyPackDashboardMock).toHaveBeenCalled())
+    await waitFor(() =>
+      expect(createStudyPackDashboardsMock).toHaveBeenCalled(),
+    )
   })
 
   it('opens a separate Create from Material flow from the hub link', () => {
@@ -240,7 +244,9 @@ describe('WorkspaceStudioShell Quick Create', () => {
         rawNotes: expect.stringContaining('Custom source notes about enzymes'),
       }),
     )
-    await waitFor(() => expect(createStudyPackDashboardMock).toHaveBeenCalled())
+    await waitFor(() =>
+      expect(createStudyPackDashboardsMock).toHaveBeenCalled(),
+    )
   })
 
   it('keeps Quick Create wired to dashboard source after returning from Create from Material', async () => {


### PR DESCRIPTION
Polishes the new Creation panel flow and fixes Quick Create wiring.

What changed:
- Empty-dashboard Quick Create cards now route into Create from Material with the chosen output selected and an explicit “add material” message.
- Quick Create now lives in its own card instead of blending into the main Creation page.
- Create from Material header/copy is cleaner.
- Fixed the broken inline “Preparing… Working” job: Quick Create now opens the real existing Create from notes / Create Study Pack command with the selected resource and source prefilled.
- Create from Material’s final CTA also hands off to that existing creation command, so generation uses the old tested path instead of a fake inline job.
- Quick generations no longer create floating mini-markers.

Verification:
- `npx vitest --run --config ./vitest.config.ts tests/unit/components/workspace/WorkspaceStudioShell.test.tsx tests/unit/components/dashboard/Dashboard.test.tsx` — 18 passed.
- `npm --workspace studymesh run build` — passed with existing Sass/asset warnings.