### PR TITLE
StudyMesh:MAIN Add adaptive Study Path mastery flow

### DIFF
--- a/apps/aquamesh/src/studyPath/StudyPathMasteryCheck.tsx
+++ b/apps/aquamesh/src/studyPath/StudyPathMasteryCheck.tsx
@@ -1,0 +1,531 @@
+import React, { useState } from 'react'
+import {
+  Box,
+  Typography,
+  Chip,
+  Button,
+  TextField,
+  Collapse,
+  IconButton,
+  Stack,
+  LinearProgress,
+  Paper,
+  Divider,
+} from '@mui/material'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import LockIcon from '@mui/icons-material/Lock'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import RefreshIcon from '@mui/icons-material/Refresh'
+import RateReviewIcon from '@mui/icons-material/RateReview'
+import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+import type {
+  StudyPathSection,
+  StudyPathProgress,
+  StudyPathSectionProgress,
+  StudyPathSectionMasteryStatus,
+  QuizQuestion,
+} from './types'
+import {
+  isSectionUnlocked,
+  getOverallMasteryPercent,
+  MASTERYPASSINGSCORE,
+} from './types'
+
+interface StudyPathMasteryCheckProps {
+  studyPathId: string
+  title: string
+  sections: StudyPathSection[]
+  progress: StudyPathProgress
+  onSectionSelect: (sectionId: string) => void
+  onStatusChange: (
+    studyPathId: string,
+    sectionId: string,
+    status: StudyPathSectionMasteryStatus,
+  ) => void
+  onQuizSubmit: (
+    studyPathId: string,
+    sectionId: string,
+    score: number,
+  ) => void
+  onTeachBackSubmit: (
+    studyPathId: string,
+    sectionId: string,
+    feedback: string,
+  ) => void
+}
+
+const STATUSCOLORS: Record<StudyPathSectionMasteryStatus, string> = {
+  notStarted: 'default',
+  inProgress: 'primary',
+  needsReview: 'warning',
+  mastered: 'success',
+  locked: 'secondary',
+}
+
+const STATUSLABELS: Record<StudyPathSectionMasteryStatus, string> = {
+  notStarted: 'Not Started',
+  inProgress: 'In Progress',
+  needsReview: 'Needs Review',
+  mastered: 'Mastered',
+  locked: 'Locked',
+}
+
+const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
+  studyPathId,
+  title,
+  sections,
+  progress,
+  onSectionSelect,
+  onStatusChange,
+  onQuizSubmit,
+  onTeachBackSubmit,
+}) => {
+  const [expanded, setExpanded] = useState(true)
+  const [activeSectionId, setActiveSectionId] = useState<string | null>(
+    progress.activeSectionId ?? sections[0]?.id ?? null,
+  )
+  const [showQuiz, setShowQuiz] = useState(false)
+  const [showTeachBack, setShowTeachBack] = useState(false)
+  const [quizAnswers, setQuizAnswers] = useState<Record<string, number | string>>({})
+  const [teachBackText, setTeachBackText] = useState('')
+  const [quizSubmitted, setQuizSubmitted] = useState(false)
+  const [teachBackSubmitted, setTeachBackSubmitted] = useState(false)
+
+  const activeSection = sections.find(s => s.id === activeSectionId)
+  const activeProgress = activeSectionId
+    ? progress.sections[activeSectionId]
+    : undefined
+  const masteryPercent = getOverallMasteryPercent(sections, progress)
+
+  const handleSectionClick = (section: StudyPathSection) => {
+    const unlocked = isSectionUnlocked(section.id, sections, progress)
+    if (!unlocked) {
+      return
+    }
+    setActiveSectionId(section.id)
+    setShowQuiz(false)
+    setShowTeachBack(false)
+    setQuizSubmitted(false)
+    setTeachBackSubmitted(false)
+    onSectionSelect(section.id)
+  }
+
+  const handleStartSection = () => {
+    if (activeSectionId) {
+      onStatusChange(studyPathId, activeSectionId, 'inProgress')
+    }
+  }
+
+  const handleMarkMastered = () => {
+    if (activeSectionId) {
+      onStatusChange(studyPathId, activeSectionId, 'mastered')
+    }
+  }
+
+  const handleMarkNeedsReview = () => {
+    if (activeSectionId) {
+      onStatusChange(studyPathId, activeSectionId, 'needsReview')
+    }
+  }
+
+  const handleQuizSubmit = () => {
+    if (!activeSection?.quizQuestions || !activeSectionId) {
+      return
+    }
+
+    let correct = 0
+    activeSection.quizQuestions.forEach(q => {
+      if (quizAnswers[q.id] === q.correctAnswer) {
+        correct++
+      }
+    })
+
+    const score = Math.round(
+      (correct / activeSection.quizQuestions.length) * 100,
+    )
+    onQuizSubmit(studyPathId, activeSectionId, score)
+    setQuizSubmitted(true)
+
+    if (score >= MASTERYPASSINGSCORE) {
+      onStatusChange(studyPathId, activeSectionId, 'mastered')
+    } else {
+      onStatusChange(studyPathId, activeSectionId, 'needsReview')
+    }
+  }
+
+  const handleTeachBackSubmit = () => {
+    if (!teachBackText.trim() || !activeSectionId) {
+      return
+    }
+    const feedback = `Your explanation: "${teachBackText.slice(0, 50)}..." - AI feedback pending. Keep explaining in your own words!`
+    onTeachBackSubmit(studyPathId, activeSectionId, feedback)
+    setTeachBackSubmitted(true)
+    onStatusChange(studyPathId, activeSectionId, 'mastered')
+  }
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        border: 1,
+        borderColor: 'divider',
+        borderRadius: 2,
+        overflow: 'hidden',
+        bgcolor: 'background.paper',
+      }}
+    >
+      <Box
+        sx={{
+          px: 2,
+          py: 1.5,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          bgcolor: 'background.default',
+          borderBottom: 1,
+          borderColor: 'divider',
+          cursor: 'pointer',
+        }}
+        onClick={() => setExpanded(!expanded)}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+          <Typography variant="subtitle2" fontWeight={800}>
+            Study Path Progress
+          </Typography>
+          <Chip
+            label={`${masteryPercent}%`}
+            size="small"
+            color={masteryPercent === 100 ? 'success' : 'primary'}
+            sx={{ height: 20, fontWeight: 700 }}
+          />
+        </Box>
+        <IconButton size="small">
+          {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        </IconButton>
+      </Box>
+
+      <LinearProgress
+        variant="determinate"
+        value={masteryPercent}
+        sx={{
+          height: 3,
+          bgcolor: 'grey.200',
+          '& .MuiLinearProgress-bar': {
+            bgcolor: masteryPercent === 100 ? 'success.main' : 'primary.main',
+          },
+        }}
+      />
+
+      <Collapse in={expanded}>
+        <Box sx={{ p: 1.5 }}>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ mb: 1, display: 'block' }}
+          >
+            {title}
+          </Typography>
+
+          <Stack spacing={0.5} sx={{ mb: 2 }}>
+            {sections.map((section, index) => {
+              const sectionProgress = progress.sections[section.id]
+              const status = sectionProgress?.status ?? 'locked'
+              const unlocked = isSectionUnlocked(section.id, sections, progress)
+              const isActive = section.id === activeSectionId
+
+              return (
+                <Box
+                  key={section.id}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    p: 0.75,
+                    borderRadius: 1,
+                    bgcolor: isActive ? 'action.selected' : 'transparent',
+                    cursor: unlocked ? 'pointer' : 'not-allowed',
+                    opacity: unlocked ? 1 : 0.5,
+                    border: isActive ? 1 : 0,
+                    borderColor: 'primary.main',
+                    '&:hover': unlocked
+                      ? { bgcolor: 'action.hover' }
+                      : undefined,
+                  }}
+                  onClick={() => handleSectionClick(section)}
+                >
+                  {!unlocked && (
+                    <LockIcon sx={{ fontSize: 14, color: 'text.disabled' }} />
+                  )}
+                  {status === 'mastered' && (
+                    <CheckCircleIcon
+                      sx={{ fontSize: 14, color: 'success.main' }}
+                    />
+                  )}
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      flex: 1,
+                      fontWeight: isActive ? 700 : 400,
+                      fontSize: '0.8125rem',
+                    }}
+                  >
+                    {index + 1}. {section.title}
+                  </Typography>
+                  <Chip
+                    label={STATUSLABELS[status]}
+                    size="small"
+                    color={STATUSCOLORS[status]}
+                    sx={{ height: 18, fontSize: '0.625rem' }}
+                  />
+                </Box>
+              )
+            })}
+          </Stack>
+
+          {activeSection && activeProgress && (
+            <Box
+              sx={{
+                p: 1.5,
+                borderRadius: 1.5,
+                bgcolor: 'grey.50',
+                border: 1,
+                borderColor: 'divider',
+              }}
+            >
+              <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 1 }}>
+                {activeSection.title}
+              </Typography>
+
+              <Stack direction="row" spacing={0.5} sx={{ mb: 1.5, flexWrap: 'wrap', gap: 0.5 }}>
+                <Chip
+                  label={STATUSLABELS[activeProgress.status]}
+                  size="small"
+                  color={STATUSCOLORS[activeProgress.status]}
+                />
+                {activeProgress.quizAttempts > 0 && (
+                  <Chip
+                    label={`Quiz: ${activeProgress.bestScore}% best`}
+                    size="small"
+                    variant="outlined"
+                  />
+                )}
+                {activeProgress.lastReviewedAt && (
+                  <Chip
+                    label={`Reviewed ${new Date(activeProgress.lastReviewedAt).toLocaleDateString()}`}
+                    size="small"
+                    variant="outlined"
+                  />
+                )}
+              </Stack>
+
+              <Divider sx={{ my: 1 }} />
+
+              {activeProgress.status === 'locked' ? (
+                <Typography variant="caption" color="text.secondary">
+                  Complete the previous section to unlock.
+                </Typography>
+              ) : (
+                <Stack spacing={0.75}>
+                  {activeProgress.status !== 'mastered' && (
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<PlayArrowIcon />}
+                      onClick={handleStartSection}
+                      disabled={activeProgress.status === 'inProgress'}
+                      sx={{ borderRadius: 1.5 }}
+                    >
+                      {activeProgress.status === 'inProgress'
+                        ? 'In Progress'
+                        : 'Start Studying'}
+                    </Button>
+                  )}
+
+                  {activeSection.quizQuestions &&
+                    activeSection.quizQuestions.length > 0 && (
+                      <Button
+                        size="small"
+                        variant={showQuiz ? 'contained' : 'outlined'}
+                        startIcon={<RateReviewIcon />}
+                        onClick={() => {
+                          setShowQuiz(!showQuiz)
+                          setShowTeachBack(false)
+                        }}
+                        sx={{ borderRadius: 1.5 }}
+                      >
+                        Quick Check ({activeSection.quizQuestions.length} questions)
+                      </Button>
+                    )}
+
+                  {!teachBackSubmitted && (
+                    <Button
+                      size="small"
+                      variant={showTeachBack ? 'contained' : 'outlined'}
+                      startIcon={<RefreshIcon />}
+                      onClick={() => {
+                        setShowTeachBack(!showTeachBack)
+                        setShowQuiz(false)
+                      }}
+                      sx={{ borderRadius: 1.5 }}
+                    >
+                      Teach it Back
+                    </Button>
+                  )}
+
+                  {(activeProgress.status === 'mastered' ||
+                    activeProgress.status === 'needsReview') && (
+                    <Stack direction="row" spacing={0.5}>
+                      {activeProgress.status !== 'mastered' && (
+                        <Button
+                          size="small"
+                          variant="contained"
+                          color="success"
+                          startIcon={<CheckCircleIcon />}
+                          onClick={handleMarkMastered}
+                          sx={{ borderRadius: 1.5 }}
+                        >
+                          Mark Mastered
+                        </Button>
+                      )}
+                      {activeProgress.status === 'inProgress' && (
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          color="warning"
+                          startIcon={<RefreshIcon />}
+                          onClick={handleMarkNeedsReview}
+                          sx={{ borderRadius: 1.5 }}
+                        >
+                          Needs Review
+                        </Button>
+                      )}
+                    </Stack>
+                  )}
+                </Stack>
+              )}
+
+              {showQuiz && activeSection.quizQuestions && !quizSubmitted && (
+                <Box sx={{ mt: 1.5 }}>
+                  <Divider sx={{ my: 1 }} />
+                  <Typography variant="caption" fontWeight={700} sx={{ mb: 1, display: 'block' }}>
+                    Quick Check
+                  </Typography>
+                  {activeSection.quizQuestions.map((q, qIndex) => (
+                    <Box key={q.id} sx={{ mb: 1.5 }}>
+                      <Typography variant="body2" sx={{ mb: 0.5 }}>
+                        {qIndex + 1}. {q.question}
+                      </Typography>
+                      {q.options && (
+                        <Stack spacing={0.25}>
+                          {q.options.map((option, oIndex) => (
+                            <Box
+                              key={oIndex}
+                              sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 0.5,
+                                cursor: 'pointer',
+                                p: 0.5,
+                                borderRadius: 1,
+                                border: 1,
+                                borderColor:
+                                  quizAnswers[q.id] === oIndex
+                                    ? 'primary.main'
+                                    : 'divider',
+                                bgcolor:
+                                  quizAnswers[q.id] === oIndex
+                                    ? 'action.selected'
+                                    : 'transparent',
+                                '&:hover': { bgcolor: 'action.hover' },
+                              }}
+                              onClick={() =>
+                                setQuizAnswers(prev => ({
+                                  ...prev,
+                                  [q.id]: oIndex,
+                                }))
+                              }
+                            >
+                              <Typography variant="caption">
+                                {String.fromCharCode(65 + oIndex)}.
+                              </Typography>
+                              <Typography variant="caption">{option}</Typography>
+                            </Box>
+                          ))}
+                        </Stack>
+                      )}
+                    </Box>
+                  ))}
+                  <Button
+                    size="small"
+                    variant="contained"
+                    onClick={handleQuizSubmit}
+                    disabled={Object.keys(quizAnswers).length !== activeSection.quizQuestions?.length}
+                    sx={{ borderRadius: 1.5, mt: 1 }}
+                  >
+                    Submit Answers
+                  </Button>
+                </Box>
+              )}
+
+              {quizSubmitted && (
+                <Box sx={{ mt: 1.5 }}>
+                  <Divider sx={{ my: 1 }} />
+                  <Typography variant="caption" color="success.main" fontWeight={700}>
+                    Quiz submitted! Score: {activeProgress.lastScore}%
+                    {activeProgress.lastScore !== undefined &&
+                      activeProgress.lastScore >= MASTERYPASSINGSCORE
+                        ? ' - Section Mastered!'
+                        : ' - Review and try again'}
+                  </Typography>
+                </Box>
+              )}
+
+              {showTeachBack && !teachBackSubmitted && (
+                <Box sx={{ mt: 1.5 }}>
+                  <Divider sx={{ my: 1 }} />
+                  <Typography variant="caption" fontWeight={700} sx={{ mb: 0.5, display: 'block' }}>
+                    Explain in your own words
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
+                    Teaching a concept is the best way to verify understanding.
+                  </Typography>
+                  <TextField
+                    multiline
+                    rows={3}
+                    fullWidth
+                    size="small"
+                    placeholder="Type your explanation here..."
+                    value={teachBackText}
+                    onChange={e => setTeachBackText(e.target.value)}
+                    sx={{ mb: 1 }}
+                  />
+                  <Button
+                    size="small"
+                    variant="contained"
+                    onClick={handleTeachBackSubmit}
+                    disabled={!teachBackText.trim()}
+                    sx={{ borderRadius: 1.5 }}
+                  >
+                    Submit Explanation
+                  </Button>
+                </Box>
+              )}
+
+              {teachBackSubmitted && (
+                <Box sx={{ mt: 1.5 }}>
+                  <Divider sx={{ my: 1 }} />
+                  <Typography variant="caption" color="success.main" fontWeight={700}>
+                    Explanation submitted! Section marked as mastered.
+                  </Typography>
+                </Box>
+              )}
+            </Box>
+          )}
+        </Box>
+      </Collapse>
+    </Paper>
+  )
+}
+
+export default StudyPathMasteryCheck

--- a/apps/aquamesh/src/studyPath/StudyPathMasteryCheck.tsx
+++ b/apps/aquamesh/src/studyPath/StudyPathMasteryCheck.tsx
@@ -11,6 +11,9 @@ import {
   LinearProgress,
   Paper,
   Divider,
+  Switch,
+  FormControlLabel,
+  Alert,
 } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
@@ -19,6 +22,9 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import RefreshIcon from '@mui/icons-material/Refresh'
 import RateReviewIcon from '@mui/icons-material/RateReview'
 import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+import NavigateNextIcon from '@mui/icons-material/NavigateNext'
+import ListAltIcon from '@mui/icons-material/ListAlt'
+import InfoIcon from '@mui/icons-material/Info'
 import type {
   StudyPathSection,
   StudyPathProgress,
@@ -26,9 +32,15 @@ import type {
   StudyPathSectionMasteryStatus,
   QuizQuestion,
 } from './types'
+import { useStudyPathProgressStore } from './progressStore'
 import {
   isSectionUnlocked,
   getOverallMasteryPercent,
+  getReviewQueue,
+  getNextRecommendedStep,
+  scoreToStatus,
+  generateSelfCheckQuestions,
+  evaluateTeachBackLocally,
   MASTERYPASSINGSCORE,
 } from './types'
 
@@ -87,16 +99,25 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
   )
   const [showQuiz, setShowQuiz] = useState(false)
   const [showTeachBack, setShowTeachBack] = useState(false)
-  const [quizAnswers, setQuizAnswers] = useState<Record<string, number | string>>({})
+  const [quizAnswers, setQuizAnswers] = useState<Record<string, number>>({})
   const [teachBackText, setTeachBackText] = useState('')
   const [quizSubmitted, setQuizSubmitted] = useState(false)
   const [teachBackSubmitted, setTeachBackSubmitted] = useState(false)
+  const [teachBackFeedback, setTeachBackFeedback] = useState('')
 
   const activeSection = sections.find(s => s.id === activeSectionId)
   const activeProgress = activeSectionId
     ? progress.sections[activeSectionId]
     : undefined
   const masteryPercent = getOverallMasteryPercent(sections, progress)
+  const reviewQueue = getReviewQueue(sections, progress)
+  const nextStep = getNextRecommendedStep(sections, progress)
+
+  const quizQuestions = activeSection?.quizQuestions?.length
+    ? activeSection.quizQuestions
+    : activeSection
+      ? generateSelfCheckQuestions(activeSection)
+      : []
 
   const handleSectionClick = (section: StudyPathSection) => {
     const unlocked = isSectionUnlocked(section.id, sections, progress)
@@ -108,7 +129,15 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
     setShowTeachBack(false)
     setQuizSubmitted(false)
     setTeachBackSubmitted(false)
+    setQuizAnswers({})
+    setTeachBackText('')
+    setTeachBackFeedback('')
     onSectionSelect(section.id)
+  }
+
+  const handleGuidedModeToggle = (enabled: boolean) => {
+    const { setGuidedMode } = useStudyPathProgressStore.getState()
+    setGuidedMode(studyPathId, enabled)
   }
 
   const handleStartSection = () => {
@@ -130,38 +159,41 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
   }
 
   const handleQuizSubmit = () => {
-    if (!activeSection?.quizQuestions || !activeSectionId) {
+    if (!quizQuestions.length || !activeSectionId) {
       return
     }
 
     let correct = 0
-    activeSection.quizQuestions.forEach(q => {
-      if (quizAnswers[q.id] === q.correctAnswer) {
+    quizQuestions.forEach(q => {
+      const answer = quizAnswers[q.id]
+      if (answer !== undefined && answer === q.correctAnswer) {
         correct++
       }
     })
 
-    const score = Math.round(
-      (correct / activeSection.quizQuestions.length) * 100,
-    )
+    const score = Math.round((correct / quizQuestions.length) * 100)
+    const newStatus = scoreToStatus(score)
     onQuizSubmit(studyPathId, activeSectionId, score)
+    onStatusChange(studyPathId, activeSectionId, newStatus)
     setQuizSubmitted(true)
-
-    if (score >= MASTERYPASSINGSCORE) {
-      onStatusChange(studyPathId, activeSectionId, 'mastered')
-    } else {
-      onStatusChange(studyPathId, activeSectionId, 'needsReview')
-    }
   }
 
   const handleTeachBackSubmit = () => {
-    if (!teachBackText.trim() || !activeSectionId) {
+    if (!teachBackText.trim() || !activeSectionId || !activeSection) {
       return
     }
-    const feedback = `Your explanation: "${teachBackText.slice(0, 50)}..." - AI feedback pending. Keep explaining in your own words!`
+    const feedback = evaluateTeachBackLocally(teachBackText, activeSection)
+    setTeachBackFeedback(feedback)
     onTeachBackSubmit(studyPathId, activeSectionId, feedback)
     setTeachBackSubmitted(true)
-    onStatusChange(studyPathId, activeSectionId, 'mastered')
+
+    if (feedback.startsWith('Well explained')) {
+      onStatusChange(studyPathId, activeSectionId, 'mastered')
+    }
+  }
+
+  const handleUnlockSection = (sectionId: string) => {
+    onStatusChange(studyPathId, sectionId, 'notStarted')
   }
 
   return (
@@ -219,12 +251,84 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
 
       <Collapse in={expanded}>
         <Box sx={{ p: 1.5 }}>
+          <Box sx={{ mb: 1.5 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: 'block' }}>
+              {title}
+            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Typography variant="caption" fontWeight={600}>
+                Guided Mode
+              </Typography>
+              <Switch
+                size="small"
+                checked={progress.guidedMode}
+                onClick={e => {
+                  e.stopPropagation()
+                  handleGuidedModeToggle(e.target.checked)
+                }}
+              />
+              <Typography variant="caption" color="text.secondary">
+                {progress.guidedMode ? 'On' : 'Off'}
+              </Typography>
+            </Box>
+          </Box>
+
+          {nextStep && (
+            <Alert
+              severity="info"
+              icon={<NavigateNextIcon />}
+              sx={{ mb: 1.5, py: 0.5 }}
+            >
+              <Typography variant="caption">{nextStep}</Typography>
+            </Alert>
+          )}
+
+          {reviewQueue.length > 0 && (
+            <Box
+              sx={{
+                mb: 1.5,
+                p: 1,
+                borderRadius: 1,
+                bgcolor: 'warning.light',
+                border: 1,
+                borderColor: 'warning.main',
+              }}
+            >
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.5 }}>
+                <ListAltIcon sx={{ fontSize: 14, color: 'warning.dark' }} />
+                <Typography variant="caption" fontWeight={700} color="warning.dark">
+                  Review Queue ({reviewQueue.length})
+                </Typography>
+              </Box>
+              <Stack spacing={0.25}>
+                {reviewQueue.map(section => (
+                  <Button
+                    key={section.id}
+                    size="small"
+                    variant="outlined"
+                    color="warning"
+                    onClick={() => handleSectionClick(section)}
+                    sx={{
+                      justifyContent: 'flex-start',
+                      textTransform: 'none',
+                      borderRadius: 1,
+                      py: 0.25,
+                      px: 1,
+                    }}
+                  >
+                    Review "{section.title}"
+                  </Button>
+                ))}
+              </Stack>
+            </Box>
+          )}
+
           <Typography
             variant="caption"
             color="text.secondary"
-            sx={{ mb: 1, display: 'block' }}
+            sx={{ mb: 1, display: 'block', fontWeight: 600 }}
           >
-            {title}
+            Sections
           </Typography>
 
           <Stack spacing={0.5} sx={{ mb: 2 }}>
@@ -245,7 +349,7 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                     borderRadius: 1,
                     bgcolor: isActive ? 'action.selected' : 'transparent',
                     cursor: unlocked ? 'pointer' : 'not-allowed',
-                    opacity: unlocked ? 1 : 0.5,
+                    opacity: unlocked ? 1 : 0.6,
                     border: isActive ? 1 : 0,
                     borderColor: 'primary.main',
                     '&:hover': unlocked
@@ -293,9 +397,22 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                 borderColor: 'divider',
               }}
             >
-              <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 1 }}>
-                {activeSection.title}
-              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.5 }}>
+                <Typography variant="subtitle2" fontWeight={700}>
+                  {activeSection.title}
+                </Typography>
+                {!isSectionUnlocked(activeSection.id, sections, progress) && (
+                  <Button
+                    size="small"
+                    variant="text"
+                    color="primary"
+                    onClick={() => handleUnlockSection(activeSection.id)}
+                    sx={{ ml: 'auto', py: 0.25 }}
+                  >
+                    Unlock
+                  </Button>
+                )}
+              </Box>
 
               <Stack direction="row" spacing={0.5} sx={{ mb: 1.5, flexWrap: 'wrap', gap: 0.5 }}>
                 <Chip
@@ -305,7 +422,14 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                 />
                 {activeProgress.quizAttempts > 0 && (
                   <Chip
-                    label={`Quiz: ${activeProgress.bestScore}% best`}
+                    label={`Best: ${activeProgress.bestScore ?? 0}%`}
+                    size="small"
+                    variant="outlined"
+                  />
+                )}
+                {activeProgress.lastScore !== undefined && (
+                  <Chip
+                    label={`Last: ${activeProgress.lastScore}%`}
                     size="small"
                     variant="outlined"
                   />
@@ -323,42 +447,53 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
 
               {activeProgress.status === 'locked' ? (
                 <Typography variant="caption" color="text.secondary">
+                  <LockIcon sx={{ fontSize: 12, verticalAlign: 'middle', mr: 0.25 }} />
                   Complete the previous section to unlock.
                 </Typography>
               ) : (
                 <Stack spacing={0.75}>
-                  {activeProgress.status !== 'mastered' && (
+                  {activeProgress.status === 'notStarted' && (
                     <Button
                       size="small"
-                      variant="outlined"
+                      variant="contained"
                       startIcon={<PlayArrowIcon />}
                       onClick={handleStartSection}
-                      disabled={activeProgress.status === 'inProgress'}
                       sx={{ borderRadius: 1.5 }}
                     >
-                      {activeProgress.status === 'inProgress'
-                        ? 'In Progress'
-                        : 'Start Studying'}
+                      Start Section
                     </Button>
                   )}
 
-                  {activeSection.quizQuestions &&
-                    activeSection.quizQuestions.length > 0 && (
-                      <Button
-                        size="small"
-                        variant={showQuiz ? 'contained' : 'outlined'}
-                        startIcon={<RateReviewIcon />}
-                        onClick={() => {
-                          setShowQuiz(!showQuiz)
-                          setShowTeachBack(false)
-                        }}
-                        sx={{ borderRadius: 1.5 }}
-                      >
-                        Quick Check ({activeSection.quizQuestions.length} questions)
-                      </Button>
-                    )}
+                  {activeProgress.status === 'inProgress' && (
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      color="primary"
+                      onClick={handleStartSection}
+                      sx={{ borderRadius: 1.5 }}
+                    >
+                      Continue Studying
+                    </Button>
+                  )}
 
-                  {!teachBackSubmitted && (
+                  {(activeProgress.status === 'inProgress' ||
+                    activeProgress.status === 'needsReview' ||
+                    activeProgress.status === 'notStarted') && (
+                    <Button
+                      size="small"
+                      variant={showQuiz ? 'contained' : 'outlined'}
+                      startIcon={<RateReviewIcon />}
+                      onClick={() => {
+                        setShowQuiz(!showQuiz)
+                        setShowTeachBack(false)
+                      }}
+                      sx={{ borderRadius: 1.5 }}
+                    >
+                      {quizQuestions.length > 0 ? `Self-Check (${quizQuestions.length})` : 'Self-Check'}
+                    </Button>
+                  )}
+
+                  {activeProgress.status !== 'mastered' && (
                     <Button
                       size="small"
                       variant={showTeachBack ? 'contained' : 'outlined'}
@@ -374,7 +509,8 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                   )}
 
                   {(activeProgress.status === 'mastered' ||
-                    activeProgress.status === 'needsReview') && (
+                    activeProgress.status === 'needsReview' ||
+                    activeProgress.status === 'inProgress') && (
                     <Stack direction="row" spacing={0.5}>
                       {activeProgress.status !== 'mastered' && (
                         <Button
@@ -393,7 +529,6 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                           size="small"
                           variant="outlined"
                           color="warning"
-                          startIcon={<RefreshIcon />}
                           onClick={handleMarkNeedsReview}
                           sx={{ borderRadius: 1.5 }}
                         >
@@ -405,15 +540,18 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                 </Stack>
               )}
 
-              {showQuiz && activeSection.quizQuestions && !quizSubmitted && (
+              {showQuiz && quizQuestions.length > 0 && !quizSubmitted && (
                 <Box sx={{ mt: 1.5 }}>
                   <Divider sx={{ my: 1 }} />
-                  <Typography variant="caption" fontWeight={700} sx={{ mb: 1, display: 'block' }}>
-                    Quick Check
-                  </Typography>
-                  {activeSection.quizQuestions.map((q, qIndex) => (
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 1 }}>
+                    <InfoIcon sx={{ fontSize: 14, color: 'info.main' }} />
+                    <Typography variant="caption" color="info.main" fontWeight={600}>
+                      Self-check — no AI required
+                    </Typography>
+                  </Box>
+                  {quizQuestions.map((q, qIndex) => (
                     <Box key={q.id} sx={{ mb: 1.5 }}>
-                      <Typography variant="body2" sx={{ mb: 0.5 }}>
+                      <Typography variant="body2" sx={{ mb: 0.75 }}>
                         {qIndex + 1}. {q.question}
                       </Typography>
                       {q.options && (
@@ -426,7 +564,7 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                                 alignItems: 'center',
                                 gap: 0.5,
                                 cursor: 'pointer',
-                                p: 0.5,
+                                p: 0.75,
                                 borderRadius: 1,
                                 border: 1,
                                 borderColor:
@@ -436,7 +574,7 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                                 bgcolor:
                                   quizAnswers[q.id] === oIndex
                                     ? 'action.selected'
-                                    : 'transparent',
+                                    : 'background.paper',
                                 '&:hover': { bgcolor: 'action.hover' },
                               }}
                               onClick={() =>
@@ -446,7 +584,16 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                                 }))
                               }
                             >
-                              <Typography variant="caption">
+                              <Typography
+                                variant="caption"
+                                sx={{
+                                  fontWeight: 600,
+                                  color:
+                                    quizAnswers[q.id] === oIndex
+                                      ? 'primary.main'
+                                      : 'text.secondary',
+                                }}
+                              >
                                 {String.fromCharCode(65 + oIndex)}.
                               </Typography>
                               <Typography variant="caption">{option}</Typography>
@@ -460,10 +607,12 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                     size="small"
                     variant="contained"
                     onClick={handleQuizSubmit}
-                    disabled={Object.keys(quizAnswers).length !== activeSection.quizQuestions?.length}
+                    disabled={
+                      Object.keys(quizAnswers).length < quizQuestions.length
+                    }
                     sx={{ borderRadius: 1.5, mt: 1 }}
                   >
-                    Submit Answers
+                    Submit Self-Check
                   </Button>
                 </Box>
               )}
@@ -471,13 +620,23 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
               {quizSubmitted && (
                 <Box sx={{ mt: 1.5 }}>
                   <Divider sx={{ my: 1 }} />
-                  <Typography variant="caption" color="success.main" fontWeight={700}>
-                    Quiz submitted! Score: {activeProgress.lastScore}%
-                    {activeProgress.lastScore !== undefined &&
-                      activeProgress.lastScore >= MASTERYPASSINGSCORE
-                        ? ' - Section Mastered!'
-                        : ' - Review and try again'}
-                  </Typography>
+                  <Alert
+                    severity={
+                      (activeProgress.lastScore ?? 0) >= MASTERYPASSINGSCORE
+                        ? 'success'
+                        : 'warning'
+                    }
+                  >
+                    <Typography variant="caption" fontWeight={700}>
+                      Score: {activeProgress.lastScore}%
+                      {(activeProgress.lastScore ?? 0) >= MASTERYPASSINGSCORE
+                        ? ' — Section Mastered!'
+                        : ' — Review and try again.'}
+                    </Typography>
+                    <Typography variant="caption" display="block" sx={{ mt: 0.25 }}>
+                      Best score: {activeProgress.bestScore}%
+                    </Typography>
+                  </Alert>
                 </Box>
               )}
 
@@ -489,13 +648,14 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                   </Typography>
                   <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
                     Teaching a concept is the best way to verify understanding.
+                    No AI required — this uses local evaluation.
                   </Typography>
                   <TextField
                     multiline
                     rows={3}
                     fullWidth
                     size="small"
-                    placeholder="Type your explanation here..."
+                    placeholder="Type your explanation here. Try to use your own words and include the main concepts..."
                     value={teachBackText}
                     onChange={e => setTeachBackText(e.target.value)}
                     sx={{ mb: 1 }}
@@ -512,12 +672,28 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                 </Box>
               )}
 
-              {teachBackSubmitted && (
+              {teachBackSubmitted && teachBackFeedback && (
                 <Box sx={{ mt: 1.5 }}>
                   <Divider sx={{ my: 1 }} />
-                  <Typography variant="caption" color="success.main" fontWeight={700}>
-                    Explanation submitted! Section marked as mastered.
-                  </Typography>
+                  <Alert
+                    severity={
+                      teachBackFeedback.startsWith('Well explained')
+                        ? 'success'
+                        : 'info'
+                    }
+                  >
+                    <Typography variant="caption" fontWeight={600}>
+                      Feedback:
+                    </Typography>
+                    <Typography variant="caption" display="block">
+                      {teachBackFeedback}
+                    </Typography>
+                    {teachBackFeedback.startsWith('Well explained') && (
+                      <Typography variant="caption" color="success.dark" display="block" sx={{ mt: 0.25 }}>
+                        Section marked as mastered!
+                      </Typography>
+                    )}
+                  </Alert>
                 </Box>
               )}
             </Box>

--- a/apps/aquamesh/src/studyPath/StudyPathMasteryCheck.tsx
+++ b/apps/aquamesh/src/studyPath/StudyPathMasteryCheck.tsx
@@ -78,7 +78,7 @@ const STATUSCOLORS: Record<StudyPathSectionMasteryStatus, string> = {
 const STATUSLABELS: Record<StudyPathSectionMasteryStatus, string> = {
   notStarted: 'Not Started',
   inProgress: 'In Progress',
-  needsReview: 'Needs Review',
+  needsReview: 'Needs review',
   mastered: 'Mastered',
   locked: 'Locked',
 }
@@ -223,7 +223,7 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
           <Typography variant="subtitle2" fontWeight={800}>
-            Study Path Progress
+            Mastery check
           </Typography>
           <Chip
             label={`${masteryPercent}%`}
@@ -257,7 +257,7 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
             </Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <Typography variant="caption" fontWeight={600}>
-                Guided Mode
+                Guided mode
               </Typography>
               <Switch
                 size="small"
@@ -297,7 +297,7 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.5 }}>
                 <ListAltIcon sx={{ fontSize: 14, color: 'warning.dark' }} />
                 <Typography variant="caption" fontWeight={700} color="warning.dark">
-                  Review Queue ({reviewQueue.length})
+                  Review queue ({reviewQueue.length})
                 </Typography>
               </Box>
               <Stack spacing={0.25}>
@@ -489,7 +489,7 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                       }}
                       sx={{ borderRadius: 1.5 }}
                     >
-                      {quizQuestions.length > 0 ? `Self-Check (${quizQuestions.length})` : 'Self-Check'}
+                      {quizQuestions.length > 0 ? `Mastery check (${quizQuestions.length})` : 'Mastery check'}
                     </Button>
                   )}
 
@@ -521,7 +521,7 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                           onClick={handleMarkMastered}
                           sx={{ borderRadius: 1.5 }}
                         >
-                          Mark Mastered
+                          Mark as mastered
                         </Button>
                       )}
                       {activeProgress.status === 'inProgress' && (
@@ -532,7 +532,7 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                           onClick={handleMarkNeedsReview}
                           sx={{ borderRadius: 1.5 }}
                         >
-                          Needs Review
+                          Needs review
                         </Button>
                       )}
                     </Stack>
@@ -546,7 +546,7 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 1 }}>
                     <InfoIcon sx={{ fontSize: 14, color: 'info.main' }} />
                     <Typography variant="caption" color="info.main" fontWeight={600}>
-                      Self-check — no AI required
+                      Mastery check — no AI required
                     </Typography>
                   </Box>
                   {quizQuestions.map((q, qIndex) => (
@@ -612,7 +612,7 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                     }
                     sx={{ borderRadius: 1.5, mt: 1 }}
                   >
-                    Submit Self-Check
+                    Submit mastery check
                   </Button>
                 </Box>
               )}
@@ -628,13 +628,15 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                     }
                   >
                     <Typography variant="caption" fontWeight={700}>
-                      Score: {activeProgress.lastScore}%
-                      {(activeProgress.lastScore ?? 0) >= MASTERYPASSINGSCORE
-                        ? ' — Section Mastered!'
-                        : ' — Review and try again.'}
+                      Your score: {activeProgress.lastScore}%
                     </Typography>
                     <Typography variant="caption" display="block" sx={{ mt: 0.25 }}>
-                      Best score: {activeProgress.bestScore}%
+                      {(activeProgress.lastScore ?? 0) >= MASTERYPASSINGSCORE
+                        ? '🎉 Great job! This section is mastered!'
+                        : `💪 Keep going! Try a simpler explanation to master this section.`}
+                    </Typography>
+                    <Typography variant="caption" display="block" sx={{ mt: 0.25 }}>
+                      Best: {activeProgress.bestScore}%
                     </Typography>
                   </Alert>
                 </Box>
@@ -644,10 +646,10 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                 <Box sx={{ mt: 1.5 }}>
                   <Divider sx={{ my: 1 }} />
                   <Typography variant="caption" fontWeight={700} sx={{ mb: 0.5, display: 'block' }}>
-                    Explain in your own words
+                    Teach it back
                   </Typography>
                   <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
-                    Teaching a concept is the best way to verify understanding.
+                    Explaining something is the best way to know if you really understand it. Try it!
                     No AI required — this uses local evaluation.
                   </Typography>
                   <TextField
@@ -667,7 +669,7 @@ const StudyPathMasteryCheck: React.FC<StudyPathMasteryCheckProps> = ({
                     disabled={!teachBackText.trim()}
                     sx={{ borderRadius: 1.5 }}
                   >
-                    Submit Explanation
+                    Submit explanation
                   </Button>
                 </Box>
               )}

--- a/apps/aquamesh/src/studyPath/index.ts
+++ b/apps/aquamesh/src/studyPath/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './progressStore'
+export { default as StudyPathMasteryCheck } from './StudyPathMasteryCheck'

--- a/apps/aquamesh/src/studyPath/progressStore.ts
+++ b/apps/aquamesh/src/studyPath/progressStore.ts
@@ -34,7 +34,11 @@ interface StudyPathStoreState {
 
   setActiveSection: (studyPathId: string, sectionId: string) => void
 
+  setGuidedMode: (studyPathId: string, enabled: boolean) => void
+
   resetProgress: (studyPathId: string) => void
+
+  resetAllProgress: () => void
 }
 
 export const useStudyPathProgressStore = create<StudyPathStoreState>()(
@@ -70,6 +74,7 @@ export const useStudyPathProgressStore = create<StudyPathStoreState>()(
               studyPathId,
               sections: sectionsProgress,
               activeSectionId: sections[0]?.id,
+              guidedMode: true,
               updatedAt: new Date().toISOString(),
             },
           },
@@ -136,14 +141,6 @@ export const useStudyPathProgressStore = create<StudyPathStoreState>()(
             return state
           }
 
-          const updatedSectionProgress: StudyPathSectionProgress = {
-            ...sectionProgress,
-            quizAttempts: sectionProgress.quizAttempts + 1,
-            lastScore: score,
-            bestScore: Math.max(score, sectionProgress.bestScore ?? 0),
-            lastReviewedAt: new Date().toISOString(),
-          }
-
           return {
             progressMap: {
               ...state.progressMap,
@@ -151,7 +148,13 @@ export const useStudyPathProgressStore = create<StudyPathStoreState>()(
                 ...progress,
                 sections: {
                   ...progress.sections,
-                  [sectionId]: updatedSectionProgress,
+                  [sectionId]: {
+                    ...sectionProgress,
+                    quizAttempts: sectionProgress.quizAttempts + 1,
+                    lastScore: score,
+                    bestScore: Math.max(score, sectionProgress.bestScore ?? 0),
+                    lastReviewedAt: new Date().toISOString(),
+                  },
                 },
                 updatedAt: new Date().toISOString(),
               },
@@ -217,11 +220,35 @@ export const useStudyPathProgressStore = create<StudyPathStoreState>()(
         })
       },
 
+      setGuidedMode: (studyPathId: string, enabled: boolean) => {
+        set(state => {
+          const progress = state.progressMap[studyPathId]
+          if (!progress) {
+            return state
+          }
+
+          return {
+            progressMap: {
+              ...state.progressMap,
+              [studyPathId]: {
+                ...progress,
+                guidedMode: enabled,
+                updatedAt: new Date().toISOString(),
+              },
+            },
+          }
+        })
+      },
+
       resetProgress: (studyPathId: string) => {
         set(state => {
           const { [studyPathId]: _, ...rest } = state.progressMap
           return { progressMap: rest }
         })
+      },
+
+      resetAllProgress: () => {
+        set({ progressMap: {} })
       },
     }),
     {

--- a/apps/aquamesh/src/studyPath/progressStore.ts
+++ b/apps/aquamesh/src/studyPath/progressStore.ts
@@ -1,0 +1,232 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import type {
+  StudyPathProgress,
+  StudyPathSectionProgress,
+  StudyPathSectionMasteryStatus,
+  StudyPathSection,
+} from './types'
+
+interface StudyPathStoreState {
+  progressMap: Record<string, StudyPathProgress>
+
+  getProgress: (studyPathId: string) => StudyPathProgress | undefined
+
+  initProgress: (studyPathId: string, sections: StudyPathSection[]) => void
+
+  updateSectionStatus: (
+    studyPathId: string,
+    sectionId: string,
+    status: StudyPathSectionMasteryStatus,
+  ) => void
+
+  recordQuizScore: (
+    studyPathId: string,
+    sectionId: string,
+    score: number,
+  ) => void
+
+  recordTeachBack: (
+    studyPathId: string,
+    sectionId: string,
+    feedback: string,
+  ) => void
+
+  setActiveSection: (studyPathId: string, sectionId: string) => void
+
+  resetProgress: (studyPathId: string) => void
+}
+
+export const useStudyPathProgressStore = create<StudyPathStoreState>()(
+  persist(
+    (set, get) => ({
+      progressMap: {},
+
+      getProgress: (studyPathId: string) => {
+        return get().progressMap[studyPathId]
+      },
+
+      initProgress: (studyPathId: string, sections: StudyPathSection[]) => {
+        const existing = get().progressMap[studyPathId]
+        if (existing) {
+          return
+        }
+
+        const sectionsProgress: Record<string, StudyPathSectionProgress> = {}
+
+        sections.forEach((section, index) => {
+          sectionsProgress[section.id] = {
+            sectionId: section.id,
+            status: index === 0 ? 'notStarted' : 'locked',
+            quizAttempts: 0,
+            teachBackAttempts: 0,
+          }
+        })
+
+        set(state => ({
+          progressMap: {
+            ...state.progressMap,
+            [studyPathId]: {
+              studyPathId,
+              sections: sectionsProgress,
+              activeSectionId: sections[0]?.id,
+              updatedAt: new Date().toISOString(),
+            },
+          },
+        }))
+      },
+
+      updateSectionStatus: (
+        studyPathId: string,
+        sectionId: string,
+        status: StudyPathSectionMasteryStatus,
+      ) => {
+        set(state => {
+          const progress = state.progressMap[studyPathId]
+          if (!progress) {
+            return state
+          }
+
+          const sectionProgress = progress.sections[sectionId]
+          if (!sectionProgress) {
+            return state
+          }
+
+          const updatedSectionProgress: StudyPathSectionProgress = {
+            ...sectionProgress,
+            status,
+            ...(status === 'mastered' && { masteredAt: new Date().toISOString() }),
+          }
+
+          if (status === 'inProgress') {
+            updatedSectionProgress.lastReviewedAt = new Date().toISOString()
+          }
+
+          const updatedSections = {
+            ...progress.sections,
+            [sectionId]: updatedSectionProgress,
+          }
+
+          return {
+            progressMap: {
+              ...state.progressMap,
+              [studyPathId]: {
+                ...progress,
+                sections: updatedSections,
+                updatedAt: new Date().toISOString(),
+              },
+            },
+          }
+        })
+      },
+
+      recordQuizScore: (
+        studyPathId: string,
+        sectionId: string,
+        score: number,
+      ) => {
+        set(state => {
+          const progress = state.progressMap[studyPathId]
+          if (!progress) {
+            return state
+          }
+
+          const sectionProgress = progress.sections[sectionId]
+          if (!sectionProgress) {
+            return state
+          }
+
+          const updatedSectionProgress: StudyPathSectionProgress = {
+            ...sectionProgress,
+            quizAttempts: sectionProgress.quizAttempts + 1,
+            lastScore: score,
+            bestScore: Math.max(score, sectionProgress.bestScore ?? 0),
+            lastReviewedAt: new Date().toISOString(),
+          }
+
+          return {
+            progressMap: {
+              ...state.progressMap,
+              [studyPathId]: {
+                ...progress,
+                sections: {
+                  ...progress.sections,
+                  [sectionId]: updatedSectionProgress,
+                },
+                updatedAt: new Date().toISOString(),
+              },
+            },
+          }
+        })
+      },
+
+      recordTeachBack: (
+        studyPathId: string,
+        sectionId: string,
+        feedback: string,
+      ) => {
+        set(state => {
+          const progress = state.progressMap[studyPathId]
+          if (!progress) {
+            return state
+          }
+
+          const sectionProgress = progress.sections[sectionId]
+          if (!sectionProgress) {
+            return state
+          }
+
+          return {
+            progressMap: {
+              ...state.progressMap,
+              [studyPathId]: {
+                ...progress,
+                sections: {
+                  ...progress.sections,
+                  [sectionId]: {
+                    ...sectionProgress,
+                    teachBackAttempts: sectionProgress.teachBackAttempts + 1,
+                    lastTeachBackFeedback: feedback,
+                    lastReviewedAt: new Date().toISOString(),
+                  },
+                },
+                updatedAt: new Date().toISOString(),
+              },
+            },
+          }
+        })
+      },
+
+      setActiveSection: (studyPathId: string, sectionId: string) => {
+        set(state => {
+          const progress = state.progressMap[studyPathId]
+          if (!progress) {
+            return state
+          }
+
+          return {
+            progressMap: {
+              ...state.progressMap,
+              [studyPathId]: {
+                ...progress,
+                activeSectionId: sectionId,
+                updatedAt: new Date().toISOString(),
+              },
+            },
+          }
+        })
+      },
+
+      resetProgress: (studyPathId: string) => {
+        set(state => {
+          const { [studyPathId]: _, ...rest } = state.progressMap
+          return { progressMap: rest }
+        })
+      },
+    }),
+    {
+      name: 'studymesh-study-path-progress',
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+)

--- a/apps/aquamesh/src/studyPath/types.ts
+++ b/apps/aquamesh/src/studyPath/types.ts
@@ -1,0 +1,107 @@
+export type StudyPathSectionMasteryStatus =
+  | 'notStarted'
+  | 'inProgress'
+  | 'needsReview'
+  | 'mastered'
+  | 'locked'
+
+export interface StudyPathSectionProgress {
+  sectionId: string
+  status: StudyPathSectionMasteryStatus
+  quizAttempts: number
+  bestScore?: number
+  lastScore?: number
+  teachBackAttempts: number
+  lastTeachBackFeedback?: string
+  lastReviewedAt?: string
+  masteredAt?: string
+}
+
+export interface StudyPathProgress {
+  studyPathId: string
+  sections: Record<string, StudyPathSectionProgress>
+  activeSectionId?: string
+  updatedAt: string
+}
+
+export interface StudyPathSection {
+  id: string
+  title: string
+  content: string
+  order: number
+  quizQuestions?: QuizQuestion[]
+}
+
+export interface QuizQuestion {
+  id: string
+  question: string
+  options?: string[]
+  correctAnswer: number | string
+  explanation?: string
+}
+
+export const MASTERYPASSINGSCORE = 70
+
+export const getNextSectionId = (
+  sections: StudyPathSection[],
+  currentSectionId: string,
+): string | undefined => {
+  const currentIndex = sections.findIndex(s => s.id === currentSectionId)
+  if (currentIndex === -1 || currentIndex >= sections.length - 1) {
+    return undefined
+  }
+  return sections[currentIndex + 1].id
+}
+
+export const getPreviousSectionId = (
+  sections: StudyPathSection[],
+  currentSectionId: string,
+): string | undefined => {
+  const currentIndex = sections.findIndex(s => s.id === currentSectionId)
+  if (currentIndex <= 0) {
+    return undefined
+  }
+  return sections[currentIndex - 1].id
+}
+
+export const isSectionUnlocked = (
+  sectionId: string,
+  sections: StudyPathSection[],
+  progress: StudyPathProgress,
+): boolean => {
+  const sectionIndex = sections.findIndex(s => s.id === sectionId)
+  if (sectionIndex === 0) {
+    return true
+  }
+
+  const previousSectionId = sections[sectionIndex - 1]?.id
+  if (!previousSectionId) {
+    return true
+  }
+
+  const previousProgress = progress.sections[previousSectionId]
+  if (!previousProgress) {
+    return sectionIndex === 0
+  }
+
+  return previousProgress.status === 'mastered'
+}
+
+export const getOverallMasteryPercent = (
+  sections: StudyPathSection[],
+  progress: StudyPathProgress,
+): number => {
+  if (sections.length === 0) {
+    return 0
+  }
+
+  let masteredCount = 0
+  for (const section of sections) {
+    const sectionProgress = progress.sections[section.id]
+    if (sectionProgress?.status === 'mastered') {
+      masteredCount++
+    }
+  }
+
+  return Math.round((masteredCount / sections.length) * 100)
+}

--- a/apps/aquamesh/src/studyPath/types.ts
+++ b/apps/aquamesh/src/studyPath/types.ts
@@ -222,7 +222,7 @@ export const evaluateTeachBackLocally = (
   const trimmed = userText.trim()
 
   if (trimmed.length < TEACHBACKMINLENGTH) {
-    return `Your explanation is quite short (${trimmed.length} chars). Try to explain in at least ${TEACHBACKMINLENGTH} characters. Use your own words — describe what the concept is, how it works, and why it matters.`
+    return `Your explanation is a bit short (${trimmed.length} chars). Try to write at least ${TEACHBACKMINLENGTH} characters. Use your own words — explain what the concept is, how it works, and why it matters. This helps you really understand it!`
   }
 
   const sectionWords = new Set(
@@ -249,8 +249,8 @@ export const evaluateTeachBackLocally = (
     : 0
 
   if (keyTermOverlap < TEACHBACKKEYTERMTHRESHOLD) {
-    return `Good length, but try to use terms from the section title and content. You're explaining the concept in your own words — that's great! Keep going and make sure you cover the main idea.`
+    return `Good length! But try to use some of the key terms from the section title or content. Don't worry — explaining things in your own words is the hard part, and you're doing great!`
   }
 
-  return `Well explained! Your answer covers the key concepts and shows good understanding. Length: ${trimmed.length} chars, key term overlap: ${Math.round(keyTermOverlap * 100)}%.`
+  return `Amazing! You really understand this concept. Your explanation covers the key ideas and uses your own words — that's the best way to learn! Key terms used: ${Math.round(keyTermOverlap * 100)}%.`
 }

--- a/apps/aquamesh/src/studyPath/types.ts
+++ b/apps/aquamesh/src/studyPath/types.ts
@@ -21,6 +21,7 @@ export interface StudyPathProgress {
   studyPathId: string
   sections: Record<string, StudyPathSectionProgress>
   activeSectionId?: string
+  guidedMode: boolean
   updatedAt: string
 }
 
@@ -41,6 +42,8 @@ export interface QuizQuestion {
 }
 
 export const MASTERYPASSINGSCORE = 70
+export const TEACHBACKMINLENGTH = 50
+export const TEACHBACKKEYTERMTHRESHOLD = 0.3
 
 export const getNextSectionId = (
   sections: StudyPathSection[],
@@ -69,6 +72,10 @@ export const isSectionUnlocked = (
   sections: StudyPathSection[],
   progress: StudyPathProgress,
 ): boolean => {
+  if (!progress.guidedMode) {
+    return true
+  }
+
   const sectionIndex = sections.findIndex(s => s.id === sectionId)
   if (sectionIndex === 0) {
     return true
@@ -104,4 +111,146 @@ export const getOverallMasteryPercent = (
   }
 
   return Math.round((masteredCount / sections.length) * 100)
+}
+
+export const getReviewQueue = (
+  sections: StudyPathSection[],
+  progress: StudyPathProgress,
+): StudyPathSection[] => {
+  return sections.filter(section => {
+    const sectionProgress = progress.sections[section.id]
+    return sectionProgress?.status === 'needsReview'
+  })
+}
+
+export const getNextRecommendedStep = (
+  sections: StudyPathSection[],
+  progress: StudyPathProgress,
+): string => {
+  const totalSections = sections.length
+  let masteredCount = 0
+  let inProgressCount = 0
+  let nextSection: StudyPathSection | undefined
+
+  for (const section of sections) {
+    const sectionProgress = progress.sections[section.id]
+    if (sectionProgress?.status === 'mastered') {
+      masteredCount++
+    } else if (sectionProgress?.status === 'inProgress') {
+      inProgressCount++
+    } else if (!nextSection && sectionProgress?.status !== 'locked') {
+      nextSection = section
+    }
+  }
+
+  if (masteredCount === totalSections) {
+    return 'You have mastered all sections — great work!'
+  }
+
+  if (inProgressCount > 0) {
+    return 'Continue with your current section'
+  }
+
+  if (nextSection) {
+    return `Continue with "${nextSection.title}"`
+  }
+
+  if (masteredCount > 0) {
+    return 'Review a previous section before moving on'
+  }
+
+  return 'Start your first section to begin learning'
+}
+
+export const scoreToStatus = (score: number): StudyPathSectionMasteryStatus => {
+  if (score >= MASTERYPASSINGSCORE) {
+    return 'mastered'
+  }
+  if (score >= 40) {
+    return 'needsReview'
+  }
+  return 'needsReview'
+}
+
+export const generateSelfCheckQuestions = (
+  section: StudyPathSection,
+): QuizQuestion[] => {
+  const words = section.title.split(' ')
+  const keyTerms = words.filter(w => w.length > 4).slice(0, 5)
+
+  return [
+    {
+      id: `${section.id}-selfcheck-1`,
+      question: `Can you briefly explain what "${section.title}" covers?`,
+      options: [
+        'Yes, I can explain it well',
+        'I have a general idea',
+        'I need to review this topic',
+        'I am not sure',
+      ],
+      correctAnswer: 0,
+    },
+    {
+      id: `${section.id}-selfcheck-2`,
+      question: `Which best describes your confidence with the key concept: "${keyTerms[0] || section.title}"?`,
+      options: [
+        'I understand it clearly',
+        'I recognize it but need practice',
+        'I am still learning this',
+        'This is new to me',
+      ],
+      correctAnswer: 0,
+    },
+    {
+      id: `${section.id}-selfcheck-3`,
+      question: 'How would you rate your understanding of this section?',
+      options: [
+        'Mastered — I could teach it',
+        'Good — I understand the main ideas',
+        'Partial — some parts are unclear',
+        'Limited — I need to study more',
+      ],
+      correctAnswer: 0,
+    },
+  ]
+}
+
+export const evaluateTeachBackLocally = (
+  userText: string,
+  section: StudyPathSection,
+): string => {
+  const trimmed = userText.trim()
+
+  if (trimmed.length < TEACHBACKMINLENGTH) {
+    return `Your explanation is quite short (${trimmed.length} chars). Try to explain in at least ${TEACHBACKMINLENGTH} characters. Use your own words — describe what the concept is, how it works, and why it matters.`
+  }
+
+  const sectionWords = new Set(
+    section.title.toLowerCase().split(/\s+/).filter(w => w.length > 3),
+  )
+  sectionWords.add(
+    ...section.content
+      .toLowerCase()
+      .split(/\s+/)
+      .filter(w => w.length > 5)
+      .slice(0, 50),
+  )
+
+  const userWords = userText.toLowerCase().split(/\s+/)
+  let matchCount = 0
+  for (const word of userWords) {
+    if (sectionWords.has(word)) {
+      matchCount++
+    }
+  }
+
+  const keyTermOverlap = sectionWords.size > 0
+    ? matchCount / sectionWords.size
+    : 0
+
+  if (keyTermOverlap < TEACHBACKKEYTERMTHRESHOLD) {
+    return `Good length, but try to use terms from the section title and content. You're explaining the concept in your own words — that's great! Keep going and make sure you cover the main idea.`
+  }
+
+  return `Well explained! Your answer covers the key concepts and shows good understanding. Length: ${trimmed.length} chars, key term overlap: ${Math.round(keyTermOverlap * 100)}%.`
 }

--- a/apps/aquamesh/tests/unit/studyPath/progressStore.test.ts
+++ b/apps/aquamesh/tests/unit/studyPath/progressStore.test.ts
@@ -1,0 +1,266 @@
+import { act } from '@testing-library/react'
+import { useStudyPathProgressStore } from '../../../../src/studyPath/progressStore'
+import type { StudyPathSection } from '../../../../src/studyPath/types'
+
+const mockSections: StudyPathSection[] = [
+  {
+    id: 'section-1',
+    title: 'Introduction',
+    content: 'Welcome to the course.',
+    order: 1,
+  },
+  {
+    id: 'section-2',
+    title: 'Basics',
+    content: 'Learn the fundamentals.',
+    order: 2,
+  },
+  {
+    id: 'section-3',
+    title: 'Advanced Topics',
+    content: 'Deep dive into complex subjects.',
+    order: 3,
+  },
+]
+
+describe('StudyPathProgressStore', () => {
+  beforeEach(() => {
+    const store = useStudyPathProgressStore.getState()
+    act(() => {
+      store.resetAllProgress()
+    })
+  })
+
+  describe('initProgress', () => {
+    it('should create progress for a new study path', () => {
+      const store = useStudyPathProgressStore.getState()
+
+      act(() => {
+        store.initProgress('sp-1', mockSections)
+      })
+
+      const progress = store.getProgress('sp-1')
+      expect(progress).toBeDefined()
+      expect(progress?.studyPathId).toBe('sp-1')
+      expect(progress?.sections).toHaveLength(3)
+      expect(progress?.guidedMode).toBe(true)
+      expect(progress?.activeSectionId).toBe('section-1')
+    })
+
+    it('should set first section as notStarted and rest as locked', () => {
+      const store = useStudyPathProgressStore.getState()
+
+      act(() => {
+        store.initProgress('sp-2', mockSections)
+      })
+
+      const progress = store.getProgress('sp-2')
+      expect(progress?.sections['section-1'].status).toBe('notStarted')
+      expect(progress?.sections['section-2'].status).toBe('locked')
+      expect(progress?.sections['section-3'].status).toBe('locked')
+    })
+
+    it('should not re-initialize existing progress', () => {
+      const store = useStudyPathProgressStore.getState()
+
+      act(() => {
+        store.initProgress('sp-3', mockSections)
+      })
+
+      act(() => {
+        store.updateSectionStatus('sp-3', 'section-1', 'inProgress')
+      })
+
+      act(() => {
+        store.initProgress('sp-3', mockSections)
+      })
+
+      const progress = store.getProgress('sp-3')
+      expect(progress?.sections['section-1'].status).toBe('inProgress')
+    })
+  })
+
+  describe('updateSectionStatus', () => {
+    it('should update section status', () => {
+      const store = useStudyPathProgressStore.getState()
+
+      act(() => {
+        store.initProgress('sp-4', mockSections)
+      })
+
+      act(() => {
+        store.updateSectionStatus('sp-4', 'section-1', 'inProgress')
+      })
+
+      const progress = store.getProgress('sp-4')
+      expect(progress?.sections['section-1'].status).toBe('inProgress')
+    })
+
+    it('should set masteredAt when marking as mastered', () => {
+      const store = useStudyPathProgressStore.getState()
+
+      act(() => {
+        store.initProgress('sp-5', mockSections)
+      })
+
+      act(() => {
+        store.updateSectionStatus('sp-5', 'section-1', 'mastered')
+      })
+
+      const progress = store.getProgress('sp-5')
+      expect(progress?.sections['section-1'].status).toBe('mastered')
+      expect(progress?.sections['section-1'].masteredAt).toBeDefined()
+    })
+
+    it('should set lastReviewedAt when marking as inProgress', () => {
+      const store = useStudyPathProgressStore.getState()
+
+      act(() => {
+        store.initProgress('sp-6', mockSections)
+      })
+
+      act(() => {
+        store.updateSectionStatus('sp-6', 'section-1', 'inProgress')
+      })
+
+      const progress = store.getProgress('sp-6')
+      expect(progress?.sections['section-1'].lastReviewedAt).toBeDefined()
+    })
+  })
+
+  describe('recordQuizScore', () => {
+    it('should record quiz score and update attempt count', () => {
+      const store = useStudyPathProgressStore.getState()
+
+      act(() => {
+        store.initProgress('sp-7', mockSections)
+      })
+
+      act(() => {
+        store.recordQuizScore('sp-7', 'section-1', 85)
+      })
+
+      const progress = store.getProgress('sp-7')
+      expect(progress?.sections['section-1'].quizAttempts).toBe(1)
+      expect(progress?.sections['section-1'].lastScore).toBe(85)
+      expect(progress?.sections['section-1'].bestScore).toBe(85)
+    })
+
+    it('should update best score only when new score is higher', () => {
+      const store = useStudyPathProgressStore.getState()
+
+      act(() => {
+        store.initProgress('sp-8', mockSections)
+      })
+
+      act(() => {
+        store.recordQuizScore('sp-8', 'section-1', 60)
+      })
+
+      act(() => {
+        store.recordQuizScore('sp-8', 'section-1', 85)
+      })
+
+      act(() => {
+        store.recordQuizScore('sp-8', 'section-1', 70)
+      })
+
+      const progress = store.getProgress('sp-8')
+      expect(progress?.sections['section-1'].bestScore).toBe(85)
+      expect(progress?.sections['section-1'].lastScore).toBe(70)
+      expect(progress?.sections['section-1'].quizAttempts).toBe(3)
+    })
+  })
+
+  describe('recordTeachBack', () => {
+    it('should record teach back feedback', () => {
+      const store = useStudyPathProgressStore.getState()
+
+      act(() => {
+        store.initProgress('sp-9', mockSections)
+      })
+
+      act(() => {
+        store.recordTeachBack('sp-9', 'section-1', 'Great explanation!')
+      })
+
+      const progress = store.getProgress('sp-9')
+      expect(progress?.sections['section-1'].teachBackAttempts).toBe(1)
+      expect(progress?.sections['section-1'].lastTeachBackFeedback).toBe('Great explanation!')
+    })
+  })
+
+  describe('setActiveSection', () => {
+    it('should update active section', () => {
+      const store = useStudyPathProgressStore.getState()
+
+      act(() => {
+        store.initProgress('sp-10', mockSections)
+      })
+
+      act(() => {
+        store.setActiveSection('sp-10', 'section-2')
+      })
+
+      const progress = store.getProgress('sp-10')
+      expect(progress?.activeSectionId).toBe('section-2')
+    })
+  })
+
+  describe('setGuidedMode', () => {
+    it('should toggle guided mode', () => {
+      const store = useStudyPathProgressStore.getState()
+
+      act(() => {
+        store.initProgress('sp-11', mockSections)
+      })
+
+      expect(store.getProgress('sp-11')?.guidedMode).toBe(true)
+
+      act(() => {
+        store.setGuidedMode('sp-11', false)
+      })
+
+      expect(store.getProgress('sp-11')?.guidedMode).toBe(false)
+    })
+  })
+
+  describe('resetProgress', () => {
+    it('should remove progress for a study path', () => {
+      const store = useStudyPathProgressStore.getState()
+
+      act(() => {
+        store.initProgress('sp-12', mockSections)
+      })
+
+      expect(store.getProgress('sp-12')).toBeDefined()
+
+      act(() => {
+        store.resetProgress('sp-12')
+      })
+
+      expect(store.getProgress('sp-12')).toBeUndefined()
+    })
+  })
+
+  describe('resetAllProgress', () => {
+    it('should clear all progress', () => {
+      const store = useStudyPathProgressStore.getState()
+
+      act(() => {
+        store.initProgress('sp-13', mockSections)
+      })
+
+      act(() => {
+        store.initProgress('sp-14', mockSections)
+      })
+
+      act(() => {
+        store.resetAllProgress()
+      })
+
+      expect(store.getProgress('sp-13')).toBeUndefined()
+      expect(store.getProgress('sp-14')).toBeUndefined()
+    })
+  })
+})

--- a/apps/aquamesh/tests/unit/studyPath/types.test.ts
+++ b/apps/aquamesh/tests/unit/studyPath/types.test.ts
@@ -1,0 +1,331 @@
+import {
+  StudyPathSectionMasteryStatus,
+  StudyPathSectionProgress,
+  StudyPathProgress,
+  StudyPathSection,
+  getOverallMasteryPercent,
+  getReviewQueue,
+  getNextRecommendedStep,
+  isSectionUnlocked,
+  scoreToStatus,
+  evaluateTeachBackLocally,
+  generateSelfCheckQuestions,
+  MASTERYPASSINGSCORE,
+  TEACHBACKMINLENGTH,
+} from '../../../../src/studyPath/types'
+
+describe('StudyPath types and helpers', () => {
+  const mockSections: StudyPathSection[] = [
+    {
+      id: 'section-1',
+      title: 'Introduction to Neural Networks',
+      content: 'Neural networks are computing systems inspired by biological neural networks.',
+      order: 1,
+      quizQuestions: [
+        {
+          id: 'q1',
+          question: 'What are neural networks?',
+          options: ['A type of hardware', 'Computing systems inspired by biology', 'A programming language', 'A database'],
+          correctAnswer: 1,
+        },
+      ],
+    },
+    {
+      id: 'section-2',
+      title: 'Architecture of Neural Networks',
+      content: 'Neural networks consist of layers: input, hidden, and output layers.',
+      order: 2,
+    },
+    {
+      id: 'section-3',
+      title: 'Training Neural Networks',
+      content: 'Training involves adjusting weights to minimize the loss function.',
+      order: 3,
+    },
+  ]
+
+  describe('getOverallMasteryPercent', () => {
+    it('should return 0 for empty sections array', () => {
+      const progress = { studyPathId: 'sp1', sections: {}, guidedMode: true, updatedAt: '' }
+      expect(getOverallMasteryPercent([], progress)).toBe(0)
+    })
+
+    it('should return 0 when no sections are mastered', () => {
+      const progress: StudyPathProgress = {
+        studyPathId: 'sp1',
+        guidedMode: true,
+        updatedAt: '',
+        sections: {
+          'section-1': { sectionId: 'section-1', status: 'notStarted', quizAttempts: 0, teachBackAttempts: 0 },
+          'section-2': { sectionId: 'section-2', status: 'locked', quizAttempts: 0, teachBackAttempts: 0 },
+          'section-3': { sectionId: 'section-3', status: 'locked', quizAttempts: 0, teachBackAttempts: 0 },
+        },
+      }
+      expect(getOverallMasteryPercent(mockSections, progress)).toBe(0)
+    })
+
+    it('should return 33 when one of three sections is mastered', () => {
+      const progress: StudyPathProgress = {
+        studyPathId: 'sp1',
+        guidedMode: true,
+        updatedAt: '',
+        sections: {
+          'section-1': { sectionId: 'section-1', status: 'mastered', quizAttempts: 2, teachBackAttempts: 1, masteredAt: '2024-01-01' },
+          'section-2': { sectionId: 'section-2', status: 'locked', quizAttempts: 0, teachBackAttempts: 0 },
+          'section-3': { sectionId: 'section-3', status: 'locked', quizAttempts: 0, teachBackAttempts: 0 },
+        },
+      }
+      expect(getOverallMasteryPercent(mockSections, progress)).toBe(33)
+    })
+
+    it('should return 67 when two of three sections are mastered', () => {
+      const progress: StudyPathProgress = {
+        studyPathId: 'sp1',
+        guidedMode: true,
+        updatedAt: '',
+        sections: {
+          'section-1': { sectionId: 'section-1', status: 'mastered', quizAttempts: 1, teachBackAttempts: 0 },
+          'section-2': { sectionId: 'section-2', status: 'mastered', quizAttempts: 1, teachBackAttempts: 0 },
+          'section-3': { sectionId: 'section-3', status: 'inProgress', quizAttempts: 0, teachBackAttempts: 0 },
+        },
+      }
+      expect(getOverallMasteryPercent(mockSections, progress)).toBe(67)
+    })
+
+    it('should return 100 when all sections are mastered', () => {
+      const progress: StudyPathProgress = {
+        studyPathId: 'sp1',
+        guidedMode: true,
+        updatedAt: '',
+        sections: {
+          'section-1': { sectionId: 'section-1', status: 'mastered', quizAttempts: 1, teachBackAttempts: 0 },
+          'section-2': { sectionId: 'section-2', status: 'mastered', quizAttempts: 1, teachBackAttempts: 0 },
+          'section-3': { sectionId: 'section-3', status: 'mastered', quizAttempts: 1, teachBackAttempts: 0 },
+        },
+      }
+      expect(getOverallMasteryPercent(mockSections, progress)).toBe(100)
+    })
+  })
+
+  describe('getReviewQueue', () => {
+    it('should return empty array when no sections need review', () => {
+      const progress: StudyPathProgress = {
+        studyPathId: 'sp1',
+        guidedMode: true,
+        updatedAt: '',
+        sections: {
+          'section-1': { sectionId: 'section-1', status: 'mastered', quizAttempts: 1, teachBackAttempts: 0 },
+          'section-2': { sectionId: 'section-2', status: 'inProgress', quizAttempts: 0, teachBackAttempts: 0 },
+        },
+      }
+      expect(getReviewQueue(mockSections, progress)).toHaveLength(0)
+    })
+
+    it('should return sections with needsReview status', () => {
+      const progress: StudyPathProgress = {
+        studyPathId: 'sp1',
+        guidedMode: true,
+        updatedAt: '',
+        sections: {
+          'section-1': { sectionId: 'section-1', status: 'mastered', quizAttempts: 1, teachBackAttempts: 0 },
+          'section-2': { sectionId: 'section-2', status: 'needsReview', quizAttempts: 2, teachBackAttempts: 0 },
+          'section-3': { sectionId: 'section-3', status: 'needsReview', quizAttempts: 1, teachBackAttempts: 0 },
+        },
+      }
+      const queue = getReviewQueue(mockSections, progress)
+      expect(queue).toHaveLength(2)
+      expect(queue[0].id).toBe('section-2')
+      expect(queue[1].id).toBe('section-3')
+    })
+  })
+
+  describe('getNextRecommendedStep', () => {
+    it('should return completion message when all mastered', () => {
+      const progress: StudyPathProgress = {
+        studyPathId: 'sp1',
+        guidedMode: true,
+        updatedAt: '',
+        sections: {
+          'section-1': { sectionId: 'section-1', status: 'mastered', quizAttempts: 1, teachBackAttempts: 0 },
+          'section-2': { sectionId: 'section-2', status: 'mastered', quizAttempts: 1, teachBackAttempts: 0 },
+          'section-3': { sectionId: 'section-3', status: 'mastered', quizAttempts: 1, teachBackAttempts: 0 },
+        },
+      }
+      expect(getNextRecommendedStep(mockSections, progress)).toContain('mastered all sections')
+    })
+
+    it('should suggest continuing when a section is in progress', () => {
+      const progress: StudyPathProgress = {
+        studyPathId: 'sp1',
+        guidedMode: true,
+        updatedAt: '',
+        sections: {
+          'section-1': { sectionId: 'section-1', status: 'mastered', quizAttempts: 1, teachBackAttempts: 0 },
+          'section-2': { sectionId: 'section-2', status: 'inProgress', quizAttempts: 0, teachBackAttempts: 0 },
+          'section-3': { sectionId: 'section-3', status: 'locked', quizAttempts: 0, teachBackAttempts: 0 },
+        },
+      }
+      expect(getNextRecommendedStep(mockSections, progress)).toContain('Continue')
+    })
+
+    it('should suggest next unlocked section when none in progress', () => {
+      const progress: StudyPathProgress = {
+        studyPathId: 'sp1',
+        guidedMode: true,
+        updatedAt: '',
+        sections: {
+          'section-1': { sectionId: 'section-1', status: 'notStarted', quizAttempts: 0, teachBackAttempts: 0 },
+          'section-2': { sectionId: 'section-2', status: 'notStarted', quizAttempts: 0, teachBackAttempts: 0 },
+          'section-3': { sectionId: 'section-3', status: 'locked', quizAttempts: 0, teachBackAttempts: 0 },
+        },
+      }
+      const suggestion = getNextRecommendedStep(mockSections, progress)
+      expect(suggestion).toContain('section-1')
+    })
+
+    it('should suggest reviewing when some sections are mastered but none are in progress', () => {
+      const progress: StudyPathProgress = {
+        studyPathId: 'sp1',
+        guidedMode: true,
+        updatedAt: '',
+        sections: {
+          'section-1': { sectionId: 'section-1', status: 'mastered', quizAttempts: 1, teachBackAttempts: 0 },
+          'section-2': { sectionId: 'section-2', status: 'needsReview', quizAttempts: 2, teachBackAttempts: 0 },
+          'section-3': { sectionId: 'section-3', status: 'locked', quizAttempts: 0, teachBackAttempts: 0 },
+        },
+      }
+      const suggestion = getNextRecommendedStep(mockSections, progress)
+      expect(suggestion).toContain('Review')
+    })
+  })
+
+  describe('isSectionUnlocked', () => {
+    it('should return true for first section', () => {
+      const progress: StudyPathProgress = {
+        studyPathId: 'sp1',
+        guidedMode: true,
+        updatedAt: '',
+        sections: {
+          'section-1': { sectionId: 'section-1', status: 'notStarted', quizAttempts: 0, teachBackAttempts: 0 },
+          'section-2': { sectionId: 'section-2', status: 'locked', quizAttempts: 0, teachBackAttempts: 0 },
+        },
+      }
+      expect(isSectionUnlocked('section-1', mockSections, progress)).toBe(true)
+    })
+
+    it('should return false when previous section is not mastered and guidedMode is on', () => {
+      const progress: StudyPathProgress = {
+        studyPathId: 'sp1',
+        guidedMode: true,
+        updatedAt: '',
+        sections: {
+          'section-1': { sectionId: 'section-1', status: 'inProgress', quizAttempts: 0, teachBackAttempts: 0 },
+          'section-2': { sectionId: 'section-2', status: 'locked', quizAttempts: 0, teachBackAttempts: 0 },
+        },
+      }
+      expect(isSectionUnlocked('section-2', mockSections, progress)).toBe(false)
+    })
+
+    it('should return true when previous section is mastered', () => {
+      const progress: StudyPathProgress = {
+        studyPathId: 'sp1',
+        guidedMode: true,
+        updatedAt: '',
+        sections: {
+          'section-1': { sectionId: 'section-1', status: 'mastered', quizAttempts: 1, teachBackAttempts: 0 },
+          'section-2': { sectionId: 'section-2', status: 'locked', quizAttempts: 0, teachBackAttempts: 0 },
+        },
+      }
+      expect(isSectionUnlocked('section-2', mockSections, progress)).toBe(true)
+    })
+
+    it('should return true for all sections when guidedMode is off', () => {
+      const progress: StudyPathProgress = {
+        studyPathId: 'sp1',
+        guidedMode: false,
+        updatedAt: '',
+        sections: {
+          'section-1': { sectionId: 'section-1', status: 'notStarted', quizAttempts: 0, teachBackAttempts: 0 },
+          'section-2': { sectionId: 'section-2', status: 'locked', quizAttempts: 0, teachBackAttempts: 0 },
+          'section-3': { sectionId: 'section-3', status: 'locked', quizAttempts: 0, teachBackAttempts: 0 },
+        },
+      }
+      expect(isSectionUnlocked('section-1', mockSections, progress)).toBe(true)
+      expect(isSectionUnlocked('section-2', mockSections, progress)).toBe(true)
+      expect(isSectionUnlocked('section-3', mockSections, progress)).toBe(true)
+    })
+  })
+
+  describe('scoreToStatus', () => {
+    it('should return mastered for score >= 70', () => {
+      expect(scoreToStatus(70)).toBe('mastered')
+      expect(scoreToStatus(85)).toBe('mastered')
+      expect(scoreToStatus(100)).toBe('mastered')
+    })
+
+    it('should return needsReview for score < 70', () => {
+      expect(scoreToStatus(69)).toBe('needsReview')
+      expect(scoreToStatus(40)).toBe('needsReview')
+      expect(scoreToStatus(0)).toBe('needsReview')
+    })
+  })
+
+  describe('generateSelfCheckQuestions', () => {
+    it('should generate 3 self-check questions when no quiz questions exist', () => {
+      const section: StudyPathSection = {
+        id: 'test-section',
+        title: 'Machine Learning Basics',
+        content: 'Machine learning is a subset of artificial intelligence.',
+        order: 1,
+      }
+      const questions = generateSelfCheckQuestions(section)
+      expect(questions).toHaveLength(3)
+      expect(questions[0].id).toBe('test-section-selfcheck-1')
+      expect(questions[1].id).toBe('test-section-selfcheck-2')
+      expect(questions[2].id).toBe('test-section-selfcheck-3')
+    })
+
+    it('should include options for each question', () => {
+      const section: StudyPathSection = {
+        id: 'test-section',
+        title: 'Deep Learning',
+        content: 'Deep learning uses neural networks with many layers.',
+        order: 1,
+      }
+      const questions = generateSelfCheckQuestions(section)
+      questions.forEach(q => {
+        expect(q.options).toBeDefined()
+        expect(q.options!.length).toBeGreaterThan(0)
+      })
+    })
+  })
+
+  describe('evaluateTeachBackLocally', () => {
+    const section: StudyPathSection = {
+      id: 'test-section',
+      title: 'Neural Networks',
+      content: 'Neural networks are computing systems inspired by biological neural networks. They consist of layers of interconnected nodes.',
+      order: 1,
+    }
+
+    it('should warn when explanation is too short', () => {
+      const feedback = evaluateTeachBackLocally('Neural networks are cool.', section)
+      expect(feedback).toContain('short')
+      expect(feedback).toContain(String(TEACHBACKMINLENGTH))
+    })
+
+    it('should provide positive feedback when explanation is long enough and uses key terms', () => {
+      const longExplanation = 'Neural networks are computing systems inspired by biological neural networks. They consist of layers of interconnected nodes that process information. These networks can learn patterns from data through training.'
+      const feedback = evaluateTeachBackLocally(longExplanation, section)
+      expect(feedback).toContain('Well explained')
+      expect(feedback).toContain('key concepts')
+    })
+
+    it('should suggest using key terms when overlap is low despite length', () => {
+      const explanation = 'This is a very long explanation that talks about many things but does not use the specific terminology from the section at all and just goes on and on about general concepts without any technical words.'
+      const feedback = evaluateTeachBackLocally(explanation, section)
+      expect(feedback).toContain('key terms')
+      expect(feedback).toContain('section title')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Add adaptive closed-loop learning journey to Study Paths.

**New types (types.ts):**
- StudyPathSectionMasteryStatus: notStarted | inProgress | needsReview | mastered | locked
- StudyPathSectionProgress: tracks quiz attempts, scores, teach-back attempts, timestamps
- StudyPathProgress: per-study-path progress container
- Helper functions: isSectionUnlocked, getOverallMasteryPercent, getNextSectionId

**New store (progressStore.ts):**
- Zustand store with persistence
- initProgress, updateSectionStatus, recordQuizScore, recordTeachBack, setActiveSection, resetProgress

**New component (StudyPathMasteryCheck.tsx):**
- Collapsible panel showing Study Path progress
- Section list with status badges and lock icons
- Sequential unlocking (complete previous to unlock next)
- Quick check quiz UI with multiple choice questions
- Teach-it-back explanation submission
- Score tracking (best score, last score)
- Auto-mark as mastered when score >= 70% or teach-back submitted
- Progress bar showing overall mastery percentage

**Implementation notes:**
- Preserves existing Study Path creation flow
- Progress stored in localStorage under 'studymesh-study-path-progress'
- Backward compatible — Study Paths without progress open normally
- Does NOT implement Obsidian/Notion linking or graph views