### PR TITLE
Feature/add customizable empty dashboard in a whole new page

### DIFF
--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -89,7 +89,6 @@ import {
   getUniqueDashboardName,
   type SavedDashboard,
 } from './dashboardStorage'
-import { DEFAULT_DASHBOARD as BLANK_DASHBOARD_TEMPLATE } from './fixture'
 import {
   addKnowledgeReferencesToLayout,
   appendKnowledgeLinkWidgetToLayout,
@@ -764,7 +763,9 @@ const Dashboards = () => {
   const createStudyLinksHomeDashboard = (openPicker = false) => {
     const savedTemplate = getSavedStudyLinksTemplate()
     if (savedTemplate) {
+      DashboardStorage.setDefaultEmptyDashboard(savedTemplate.id)
       openSavedDashboardInWorkspace(savedTemplate)
+      loadDashboardOptions()
       return
     }
 
@@ -943,14 +944,10 @@ const Dashboards = () => {
     DashboardStorage.clearDefaultEmptyDashboard()
     const current = openDashboards[selectedDashboard]
     if (current?.layout && layoutHasStudyLinksWidget(current.layout)) {
-      const nextDashboardId = replaceDashboard(selectedDashboard, {
-        name: BLANK_DASHBOARD_TEMPLATE.name,
-        layout: cloneLayout(BLANK_DASHBOARD_TEMPLATE.layout),
-      })
+      closeAllDashboards()
       setStudyLinksEditModes((currentModes) => {
         const nextModes = { ...currentModes }
         delete nextModes[current.id]
-        delete nextModes[nextDashboardId]
         return nextModes
       })
     }

--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -187,6 +187,9 @@ const Dashboards = () => {
   const [studyLinksEditModes, setStudyLinksEditModes] = useState<
     Record<string, boolean | undefined>
   >({})
+  const [studyLinksTitleOverrides, setStudyLinksTitleOverrides] = useState<
+    Record<string, string | undefined>
+  >({})
   const [dashboardChatOpen, setDashboardChatOpen] = useState(false)
   const [workspaceTabsSlot, setWorkspaceTabsSlot] =
     useState<HTMLElement | null>(null)
@@ -705,6 +708,23 @@ const Dashboards = () => {
     return undefined
   }
 
+  const getStudyLinksLayoutVersion = (
+    layout: DashboardLayout | undefined,
+  ): string => {
+    if (!layout) {
+      return ''
+    }
+
+    if (layout.component === 'KnowledgeLinkWidget') {
+      return JSON.stringify(layout.config?.customProps || {})
+    }
+
+    return (layout.children || [])
+      .map((child) => getStudyLinksLayoutVersion(child))
+      .filter(Boolean)
+      .join('|')
+  }
+
   const saveStudyLinksTemplate = (
     name: string,
     layout: DashboardLayout,
@@ -876,7 +896,7 @@ const Dashboards = () => {
 
   const applyKnowledgeLinkWidgetRenderOptions = (
     layout: DashboardLayout | undefined,
-    options: { editMode: boolean },
+    options: { editMode: boolean; title?: string },
   ): DashboardLayout | undefined => {
     if (!layout) {
       return layout
@@ -885,6 +905,7 @@ const Dashboards = () => {
     if (layout.component === 'KnowledgeLinkWidget') {
       return {
         ...layout,
+        name: options.title || layout.name,
         className: 'studymesh-study-links-flex-tab',
         enableClose: false,
         enableDrag: false,
@@ -894,6 +915,7 @@ const Dashboards = () => {
           customProps: {
             ...(layout.config?.customProps || {}),
             editMode: options.editMode,
+            ...(options.title ? { title: options.title } : {}),
           },
         },
       }
@@ -1056,13 +1078,34 @@ const Dashboards = () => {
   }
 
   const openKnowledgeReferenceTarget = (target: KnowledgeReferenceTarget) => {
+    const sourceDashboard = openDashboards[selectedDashboard]
+    const shouldCloseSourceDashboard = Boolean(
+      sourceDashboard && layoutHasStudyLinksWidget(sourceDashboard.layout),
+    )
+
+    const selectOpenTargetAndCloseSource = (targetIndex: number) => {
+      if (
+        shouldCloseSourceDashboard &&
+        sourceDashboard &&
+        openDashboards[targetIndex]?.id !== sourceDashboard.id
+      ) {
+        const nextTargetIndex =
+          targetIndex > selectedDashboard ? targetIndex - 1 : targetIndex
+        removeDashboard(sourceDashboard.id)
+        setSelectedDashboard(Math.max(0, nextTargetIndex))
+        return
+      }
+
+      setSelectedDashboard(targetIndex)
+    }
+
     if (target.type === 'dashboard') {
       const openDashboardIndex = openDashboards.findIndex(
         (dashboard) => dashboard.id === target.id,
       )
 
       if (openDashboardIndex >= 0) {
-        setSelectedDashboard(openDashboardIndex)
+        selectOpenTargetAndCloseSource(openDashboardIndex)
         return
       }
 
@@ -1070,6 +1113,14 @@ const Dashboards = () => {
         (dashboard) => dashboard.id === target.id,
       )
       if (savedDashboard) {
+        if (shouldCloseSourceDashboard) {
+          replaceDashboard(selectedDashboard, {
+            name: savedDashboard.name,
+            layout: savedDashboard.layout,
+          })
+          return
+        }
+
         openSavedDashboardInWorkspace(savedDashboard)
       }
       return
@@ -1118,7 +1169,7 @@ const Dashboards = () => {
         openStudyPath.id,
         target.type === 'studyPathSection' ? target.id : undefined,
       )
-      setSelectedDashboard(openStudyPathIndex)
+      selectOpenTargetAndCloseSource(openStudyPathIndex)
       return
     }
 
@@ -1139,10 +1190,21 @@ const Dashboards = () => {
             (lesson) => lesson.dashboardKey === target.id,
           )
         : -1
-    addStudyPathContainer({
+    const studyPathToOpen = {
       ...studyPath,
       selectedIndex: sectionIndex >= 0 ? sectionIndex : 0,
-    })
+    }
+
+    if (shouldCloseSourceDashboard) {
+      replaceDashboard(selectedDashboard, {
+        name: studyPathToOpen.title || studyPathToOpen.folderName,
+        kind: 'studyPathContainer',
+        studyPath: studyPathToOpen,
+      })
+      return
+    }
+
+    addStudyPathContainer(studyPathToOpen)
   }
 
   const openSavedDashboardInWorkspace = (dashboard: SavedDashboard) => {
@@ -1585,7 +1647,7 @@ const Dashboards = () => {
         handleOpenKnowledgeReference,
       )
     }
-  }, [openDashboards])
+  }, [openDashboards, selectedDashboard])
 
   useEffect(() => {
     window.addEventListener(
@@ -1627,6 +1689,10 @@ const Dashboards = () => {
           result.layout,
         )
         if (customEvent.detail.options.title) {
+          setStudyLinksTitleOverrides((currentOverrides) => ({
+            ...currentOverrides,
+            [current.id]: customEvent.detail.options.title,
+          }))
           renameDashboard(current.id, customEvent.detail.options.title)
         }
       }
@@ -2389,12 +2455,19 @@ const Dashboards = () => {
             const studyLinksEditMode =
               studyLinksEditModes[dashboard.id] ??
               getStudyLinksEditModeFromLayout(dashboard.layout) === true
+            const studyLinksTitleOverride =
+              studyLinksTitleOverrides[dashboard.id]
             const renderLayout =
               isStudyLinksDashboard && !isStudyPathContainer
                 ? applyKnowledgeLinkWidgetRenderOptions(dashboard.layout, {
                     editMode: studyLinksEditMode,
+                    title: studyLinksTitleOverride,
                   })
                 : dashboard.layout
+            const dashboardLayoutRenderKey =
+              isStudyLinksDashboard && !isStudyPathContainer
+                ? `${dashboard.id}-${getStudyLinksLayoutVersion(renderLayout)}`
+                : dashboard.id
             return (
               <TabPanel key={dashboard.id} forceRender={isMobileDashboardView}>
                 <Box
@@ -2510,6 +2583,7 @@ const Dashboards = () => {
                       />
                     ) : (
                       <DashboardLayoutView
+                        key={dashboardLayoutRenderKey}
                         layout={renderLayout}
                         mobileView={isMobileDashboardView}
                         readOnly={isMobileDashboardView}

--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -33,7 +33,6 @@ import ExtensionIcon from '@mui/icons-material/Extension'
 import FolderOpenIcon from '@mui/icons-material/FolderOpen'
 import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser'
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline'
-import AddLinkIcon from '@mui/icons-material/AddLink'
 import VisibilityIcon from '@mui/icons-material/Visibility'
 import DashboardLayoutView from '../Layout/Layout'
 import { useLayout } from '../Layout/LayoutProvider'
@@ -857,6 +856,10 @@ const Dashboards = () => {
     if (layout.component === 'KnowledgeLinkWidget') {
       return {
         ...layout,
+        className: 'studymesh-study-links-flex-tab',
+        enableClose: false,
+        enableDrag: false,
+        enableFloat: false,
         config: {
           ...layout.config,
           customProps: {
@@ -871,8 +874,24 @@ const Dashboards = () => {
       return layout
     }
 
+    const containsStudyLinksWidget = layoutHasStudyLinksWidget(layout)
+
     return {
       ...layout,
+      classNameTabStrip:
+        containsStudyLinksWidget && layout.type === 'tabset'
+          ? 'studymesh-study-links-flex-tabstrip'
+          : layout.classNameTabStrip,
+      enableDrop: containsStudyLinksWidget ? false : layout.enableDrop,
+      enableDivide: containsStudyLinksWidget ? false : layout.enableDivide,
+      enableMaximize:
+        containsStudyLinksWidget && layout.type === 'tabset'
+          ? false
+          : layout.enableMaximize,
+      enableClose:
+        containsStudyLinksWidget && layout.type === 'tabset'
+          ? false
+          : layout.enableClose,
       children: layout.children.map(
         (child) =>
           applyKnowledgeLinkWidgetRenderOptions(child, options) || child,
@@ -2326,7 +2345,7 @@ const Dashboards = () => {
             )
             const studyLinksEditMode =
               studyLinksEditModes[dashboard.id] ??
-              (getStudyLinksEditModeFromLayout(dashboard.layout) === true)
+              getStudyLinksEditModeFromLayout(dashboard.layout) === true
             const renderLayout =
               isStudyLinksDashboard && !isStudyPathContainer
                 ? applyKnowledgeLinkWidgetRenderOptions(dashboard.layout, {

--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -18,7 +18,6 @@ import {
   MenuItem,
   Switch,
   Chip,
-  Paper,
   Stack,
   Autocomplete,
 } from '@mui/material'
@@ -34,6 +33,8 @@ import ExtensionIcon from '@mui/icons-material/Extension'
 import FolderOpenIcon from '@mui/icons-material/FolderOpen'
 import OpenInBrowserIcon from '@mui/icons-material/OpenInBrowser'
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline'
+import AddLinkIcon from '@mui/icons-material/AddLink'
+import VisibilityIcon from '@mui/icons-material/Visibility'
 import DashboardLayoutView from '../Layout/Layout'
 import { useLayout } from '../Layout/LayoutProvider'
 import { DashboardLayout, StateDashboard } from '../../state/store'
@@ -83,11 +84,30 @@ import {
   hasDashboardContent,
 } from './dashboardLayoutUtils'
 import {
+  CUSTOM_EMPTY_DASHBOARD_FOLDER,
   DashboardStorage,
   DEFAULT_DASHBOARD_NAME,
   getUniqueDashboardName,
   type SavedDashboard,
 } from './dashboardStorage'
+import {
+  addKnowledgeReferencesToLayout,
+  appendKnowledgeLinkWidgetToLayout,
+  createKnowledgeReference,
+  KnowledgeReference,
+  KnowledgeReferenceTarget,
+  OPEN_KNOWLEDGE_REFERENCE_EVENT,
+  OPEN_STUDY_LINK_PICKER_EVENT,
+  OpenKnowledgeReferenceEventDetail,
+  RESET_DEFAULT_EMPTY_DASHBOARD_EVENT,
+  SAVE_KNOWLEDGE_LINK_DASHBOARD_AS_DEFAULT_EVENT,
+  UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT,
+  UpdateKnowledgeLinkWidgetEventDetail,
+} from '../../knowledgeReferences'
+import {
+  StudyLinkPicker,
+  StudyLinkPickerOption,
+} from '../knowledge/StudyLinkPicker'
 import './tabs.scss'
 const DEFAULT_STUDY_PATH_OPENED_KEY = 'studymesh-default-study-path-opened-v1'
 const USER_ROLE_CHANGED_EVENT = 'studymesh-user-role-changed'
@@ -161,6 +181,13 @@ const Dashboards = () => {
   const [dashboardLibraryMode, setDashboardLibraryMode] = useState<
     'workspace' | 'builder'
   >('workspace')
+  const [referenceDialogOpen, setReferenceDialogOpen] = useState(false)
+  const [selectedReferenceTargetIds, setSelectedReferenceTargetIds] = useState<
+    string[]
+  >([])
+  const [studyLinksEditModes, setStudyLinksEditModes] = useState<
+    Record<string, boolean | undefined>
+  >({})
   const [dashboardChatOpen, setDashboardChatOpen] = useState(false)
   const [workspaceTabsSlot, setWorkspaceTabsSlot] =
     useState<HTMLElement | null>(null)
@@ -526,12 +553,550 @@ const Dashboards = () => {
     addDashboard()
   }
 
+  const referenceTargetOptions = useMemo<StudyLinkPickerOption[]>(() => {
+    const options: StudyLinkPickerOption[] = []
+    const addTarget = (
+      target: KnowledgeReferenceTarget,
+      description?: string,
+      parentTitle?: string,
+    ) => {
+      const id = [target.type, target.parentId || '', target.id].join('|')
+
+      if (options.some((option) => option.id === id)) {
+        return
+      }
+
+      options.push({
+        id,
+        target,
+        description,
+        parentTitle,
+      })
+    }
+
+    const currentDashboard = openDashboards[selectedDashboard]
+
+    openDashboards.forEach((dashboard) => {
+      if (dashboard.kind === 'studyPathContainer' && dashboard.studyPath) {
+        addTarget(
+          {
+            type: 'studyPath',
+            id: dashboard.studyPath.pathId,
+            title: dashboard.studyPath.title,
+            subtitle: `${dashboard.studyPath.dashboards.length} sections`,
+          },
+          dashboard.studyPath.folderName,
+        )
+        dashboard.studyPath.dashboards.forEach((lesson) => {
+          addTarget(
+            {
+              type: 'studyPathSection',
+              id: lesson.dashboardKey,
+              parentId: dashboard.studyPath?.pathId,
+              title: lesson.name,
+              subtitle: dashboard.studyPath?.title,
+            },
+            `Section ${lesson.dashboardIndex}/${lesson.dashboardCount}`,
+            dashboard.studyPath?.title,
+          )
+        })
+        return
+      }
+
+      if (dashboard.id === currentDashboard?.id) {
+        return
+      }
+
+      addTarget({
+        type: 'dashboard',
+        id: dashboard.id,
+        title: dashboard.name,
+      })
+    })
+
+    const savedByPath = new Map<string, SavedDashboard[]>()
+    dashboardOptions.forEach((dashboard) => {
+      const meta = getStudyPathMetaFromLayout(dashboard.layout)
+      if (!meta) {
+        return
+      }
+
+      savedByPath.set(meta.studyPathId, [
+        ...(savedByPath.get(meta.studyPathId) || []),
+        dashboard,
+      ])
+    })
+
+    savedByPath.forEach((dashboards) => {
+      const studyPath = createStudyPathContainerState(dashboards)
+      if (!studyPath) {
+        return
+      }
+
+      addTarget(
+        {
+          type: 'studyPath',
+          id: studyPath.pathId,
+          title: studyPath.title,
+          subtitle: `${studyPath.dashboards.length} sections`,
+        },
+        studyPath.folderName,
+      )
+      studyPath.dashboards.forEach((lesson) => {
+        addTarget(
+          {
+            type: 'studyPathSection',
+            id: lesson.dashboardKey,
+            parentId: studyPath.pathId,
+            title: lesson.name,
+            subtitle: studyPath.title,
+          },
+          `Section ${lesson.dashboardIndex}/${lesson.dashboardCount}`,
+          studyPath.title,
+        )
+      })
+    })
+
+    dashboardOptions.forEach((dashboard) => {
+      if (getStudyPathMetaFromLayout(dashboard.layout)) {
+        return
+      }
+
+      if (dashboard.id === currentDashboard?.id) {
+        return
+      }
+
+      addTarget(
+        {
+          type: 'dashboard',
+          id: dashboard.id,
+          title: dashboard.name,
+          subtitle: normalizeFolderName(dashboard.folder),
+        },
+        dashboard.description,
+      )
+    })
+
+    return options
+  }, [dashboardOptions, openDashboards, selectedDashboard])
+
+  const saveStudyLinksTemplate = (
+    name: string,
+    layout: DashboardLayout,
+    options: { useForNewDashboards?: boolean } = {},
+  ) => {
+    const now = new Date().toISOString()
+    const existingDefault = DashboardStorage.getDefaultEmptyDashboard()
+    const existingTemplate = existingDefault || getSavedStudyLinksTemplate()
+    const savedDashboard: SavedDashboard = {
+      id: existingTemplate?.id || `custom-empty-dashboard-${Date.now()}`,
+      name: name || 'Study links',
+      folder: CUSTOM_EMPTY_DASHBOARD_FOLDER,
+      folderColor: DashboardStorage.getFolderColor(
+        CUSTOM_EMPTY_DASHBOARD_FOLDER,
+      ),
+      layout: cloneLayout(layout) as DashboardLayout,
+      description: 'Dashboard used as a reusable Study Links start page.',
+      tags: ['study-links', 'custom-empty-dashboard'],
+      createdAt: existingTemplate?.createdAt || now,
+      updatedAt: now,
+    }
+
+    DashboardStorage.save(savedDashboard)
+    if (options.useForNewDashboards) {
+      DashboardStorage.setDefaultEmptyDashboard(savedDashboard.id)
+    }
+    loadDashboardOptions()
+  }
+
+  const addKnowledgeReferencesToDashboardById = (
+    dashboardId: string,
+    references: KnowledgeReference[],
+  ) => {
+    const dashboardIndex = openDashboards.findIndex(
+      (dashboard) => dashboard.id === dashboardId,
+    )
+
+    if (dashboardIndex < 0 || references.length === 0) {
+      return
+    }
+
+    const dashboard = openDashboards[dashboardIndex]
+    const nextLayout = addKnowledgeReferencesToLayout(
+      dashboard.layout,
+      references,
+      'Study links',
+    )
+    updateDashboardLayout(dashboardIndex, nextLayout)
+
+    if (layoutHasStudyLinksWidget(nextLayout)) {
+      saveStudyLinksTemplate(dashboard.name, nextLayout)
+    }
+  }
+
+  const createStudyLinksHomeDashboard = (openPicker = false) => {
+    const savedTemplate = getSavedStudyLinksTemplate()
+    if (savedTemplate) {
+      openSavedDashboardInWorkspace(savedTemplate)
+      return
+    }
+
+    const layout = appendKnowledgeLinkWidgetToLayout(
+      undefined,
+      [],
+      'Study links',
+      {
+        title: 'Study links',
+        cardSize: 'standard',
+        columns: 1,
+        editMode: true,
+        showCreationActions: true,
+        showOpenStudyMaterial: true,
+      },
+    )
+    const name = 'Study links'
+    saveStudyLinksTemplate(name, layout)
+
+    const current = openDashboards[selectedDashboard]
+    if (current && !hasDashboardContent(current.layout)) {
+      updateDashboardLayout(selectedDashboard, layout)
+      renameDashboard(current.id, name)
+      setStudyLinksEditModes((currentModes) => ({
+        ...currentModes,
+        [current.id]: true,
+      }))
+      if (openPicker) {
+        setSelectedReferenceTargetIds([])
+        setReferenceDialogOpen(true)
+      }
+      return
+    }
+
+    const dashboardId = addDashboard({
+      name,
+      layout,
+    })
+    setStudyLinksEditModes((currentModes) => ({
+      ...currentModes,
+      [dashboardId]: true,
+    }))
+    if (openPicker) {
+      setSelectedReferenceTargetIds([])
+      setReferenceDialogOpen(true)
+    }
+  }
+
+  const layoutHasStudyLinksWidget = (
+    layout: DashboardLayout | undefined,
+  ): boolean => {
+    if (!layout) {
+      return false
+    }
+
+    if (layout.component === 'KnowledgeLinkWidget') {
+      return true
+    }
+
+    return Boolean(layout.children?.some(layoutHasStudyLinksWidget))
+  }
+
+  const getStudyLinksEditModeFromLayout = (
+    layout: DashboardLayout | undefined,
+  ): boolean | undefined => {
+    if (!layout) {
+      return undefined
+    }
+
+    if (layout.component === 'KnowledgeLinkWidget') {
+      return layout.config?.customProps?.editMode === true
+    }
+
+    for (const child of layout.children || []) {
+      const childMode = getStudyLinksEditModeFromLayout(child)
+      if (childMode !== undefined) {
+        return childMode
+      }
+    }
+
+    return undefined
+  }
+
+  const cloneLayout = (
+    layout?: DashboardLayout,
+  ): DashboardLayout | undefined =>
+    layout ? JSON.parse(JSON.stringify(layout)) : undefined
+
+  const getSavedStudyLinksTemplate = (): SavedDashboard | null => {
+    const defaultEmptyDashboard = DashboardStorage.getDefaultEmptyDashboard()
+    if (defaultEmptyDashboard) {
+      return defaultEmptyDashboard
+    }
+
+    return (
+      [...DashboardStorage.getAll()]
+        .filter(
+          (dashboard) =>
+            normalizeFolderName(dashboard.folder) ===
+              normalizeFolderName(CUSTOM_EMPTY_DASHBOARD_FOLDER) &&
+            layoutHasStudyLinksWidget(dashboard.layout),
+        )
+        .sort((first, second) =>
+          second.updatedAt.localeCompare(first.updatedAt),
+        )[0] || null
+    )
+  }
+
+  const applyKnowledgeLinkWidgetRenderOptions = (
+    layout: DashboardLayout | undefined,
+    options: { editMode: boolean },
+  ): DashboardLayout | undefined => {
+    if (!layout) {
+      return layout
+    }
+
+    if (layout.component === 'KnowledgeLinkWidget') {
+      return {
+        ...layout,
+        config: {
+          ...layout.config,
+          customProps: {
+            ...(layout.config?.customProps || {}),
+            editMode: options.editMode,
+          },
+        },
+      }
+    }
+
+    if (!layout.children?.length) {
+      return layout
+    }
+
+    return {
+      ...layout,
+      children: layout.children.map(
+        (child) =>
+          applyKnowledgeLinkWidgetRenderOptions(child, options) || child,
+      ),
+    }
+  }
+
+  const saveCurrentStudyLinksDashboardAsDefault = () => {
+    const current = openDashboards[selectedDashboard]
+
+    if (!current?.layout || !layoutHasStudyLinksWidget(current.layout)) {
+      return
+    }
+
+    saveStudyLinksTemplate(current.name || 'Study links', current.layout, {
+      useForNewDashboards: true,
+    })
+  }
+
+  const resetDefaultEmptyDashboard = () => {
+    DashboardStorage.clearDefaultEmptyDashboard()
+    loadDashboardOptions()
+  }
+
+  const updateKnowledgeLinkWidgetOptions = (
+    layout: DashboardLayout | undefined,
+    options: UpdateKnowledgeLinkWidgetEventDetail['options'],
+  ): { layout: DashboardLayout | undefined; updated: boolean } => {
+    if (!layout) {
+      return { layout, updated: false }
+    }
+
+    if (layout.component === 'KnowledgeLinkWidget') {
+      return {
+        layout: {
+          ...layout,
+          config: {
+            ...layout.config,
+            customProps: {
+              ...(layout.config?.customProps || {}),
+              ...options,
+            },
+          },
+        },
+        updated: true,
+      }
+    }
+
+    if (!layout.children?.length) {
+      return { layout, updated: false }
+    }
+
+    let updated = false
+    const children = layout.children.map((child) => {
+      if (updated) {
+        return child
+      }
+
+      const result = updateKnowledgeLinkWidgetOptions(child, options)
+      updated = result.updated
+      return result.layout || child
+    })
+
+    return {
+      layout: updated ? { ...layout, children } : layout,
+      updated,
+    }
+  }
+
+  const openDashboardReferenceDialog = () => {
+    setSelectedReferenceTargetIds([])
+    setReferenceDialogOpen(true)
+  }
+
+  const setStudyLinksDashboardEditMode = (
+    dashboardIndex: number,
+    dashboardId: string,
+    editMode: boolean,
+  ) => {
+    const dashboard = openDashboards[dashboardIndex]
+    if (!dashboard?.layout) {
+      return
+    }
+
+    setStudyLinksEditModes((currentModes) => ({
+      ...currentModes,
+      [dashboardId]: editMode,
+    }))
+
+    const result = updateKnowledgeLinkWidgetOptions(dashboard.layout, {
+      editMode,
+    })
+    if (result.updated && result.layout) {
+      updateDashboardLayout(dashboardIndex, result.layout)
+      saveStudyLinksTemplate(dashboard.name || 'Study links', result.layout)
+    }
+  }
+
+  const addSelectedReferenceToCurrentDashboard = () => {
+    const targetOptions = referenceTargetOptions.filter((option) =>
+      selectedReferenceTargetIds.includes(option.id),
+    )
+    const current = openDashboards[selectedDashboard]
+
+    if (targetOptions.length === 0 || !current) {
+      return
+    }
+
+    const references = targetOptions.map((targetOption) =>
+      createKnowledgeReference(targetOption.target, {
+        label: targetOption.target.title,
+        description: targetOption.description,
+      }),
+    )
+
+    addKnowledgeReferencesToDashboardById(current.id, references)
+    setReferenceDialogOpen(false)
+    setSelectedReferenceTargetIds([])
+  }
+
+  const openKnowledgeReferenceTarget = (target: KnowledgeReferenceTarget) => {
+    if (target.type === 'dashboard') {
+      const openDashboardIndex = openDashboards.findIndex(
+        (dashboard) => dashboard.id === target.id,
+      )
+
+      if (openDashboardIndex >= 0) {
+        setSelectedDashboard(openDashboardIndex)
+        return
+      }
+
+      const savedDashboard = DashboardStorage.getAll().find(
+        (dashboard) => dashboard.id === target.id,
+      )
+      if (savedDashboard) {
+        openSavedDashboardInWorkspace(savedDashboard)
+      }
+      return
+    }
+
+    if (target.type !== 'studyPath' && target.type !== 'studyPathSection') {
+      return
+    }
+
+    const pathId =
+      target.type === 'studyPathSection' ? target.parentId : target.id
+    if (!pathId) {
+      return
+    }
+
+    const openStudyPathIndex = openDashboards.findIndex(
+      (dashboard) =>
+        dashboard.kind === 'studyPathContainer' &&
+        dashboard.studyPath?.pathId === pathId,
+    )
+
+    const selectSection = (
+      dashboardId: string,
+      requestedSectionId?: string,
+    ) => {
+      updateStudyPathContainer(dashboardId, (studyPath) => {
+        if (!requestedSectionId) {
+          return studyPath
+        }
+
+        const selectedIndex = studyPath.dashboards.findIndex(
+          (lesson) => lesson.dashboardKey === requestedSectionId,
+        )
+
+        if (selectedIndex < 0) {
+          return studyPath
+        }
+
+        return { ...studyPath, selectedIndex }
+      })
+    }
+
+    if (openStudyPathIndex >= 0) {
+      const openStudyPath = openDashboards[openStudyPathIndex]
+      selectSection(
+        openStudyPath.id,
+        target.type === 'studyPathSection' ? target.id : undefined,
+      )
+      setSelectedDashboard(openStudyPathIndex)
+      return
+    }
+
+    const studyPath = createStudyPathContainerState(
+      DashboardStorage.getAll().filter((dashboard) => {
+        const meta = getStudyPathMetaFromLayout(dashboard.layout)
+        return meta?.studyPathId === pathId
+      }),
+    )
+
+    if (!studyPath) {
+      return
+    }
+
+    const sectionIndex =
+      target.type === 'studyPathSection'
+        ? studyPath.dashboards.findIndex(
+            (lesson) => lesson.dashboardKey === target.id,
+          )
+        : -1
+    addStudyPathContainer({
+      ...studyPath,
+      selectedIndex: sectionIndex >= 0 ? sectionIndex : 0,
+    })
+  }
+
   const openSavedDashboardInWorkspace = (dashboard: SavedDashboard) => {
+    const savedStudyLinksEditMode =
+      getStudyLinksEditModeFromLayout(dashboard.layout) === true
     if (openDashboards[selectedDashboard] && selectedDashboardIsEmpty) {
-      replaceDashboard(selectedDashboard, {
+      const dashboardId = replaceDashboard(selectedDashboard, {
         name: dashboard.name,
         layout: dashboard.layout,
       })
+      if (layoutHasStudyLinksWidget(dashboard.layout)) {
+        setStudyLinksEditModes((currentModes) => ({
+          ...currentModes,
+          [dashboardId]: savedStudyLinksEditMode,
+        }))
+      }
       dispatchWorkspaceOnboardingEvent({
         type: 'saved-dashboard-opened',
         dashboardId: dashboard.id,
@@ -540,10 +1105,16 @@ const Dashboards = () => {
       return
     }
 
-    addDashboard({
+    const dashboardId = addDashboard({
       name: dashboard.name,
       layout: dashboard.layout,
     })
+    if (layoutHasStudyLinksWidget(dashboard.layout)) {
+      setStudyLinksEditModes((currentModes) => ({
+        ...currentModes,
+        [dashboardId]: savedStudyLinksEditMode,
+      }))
+    }
     dispatchWorkspaceOnboardingEvent({
       type: 'saved-dashboard-opened',
       dashboardId: dashboard.id,
@@ -929,6 +1500,110 @@ const Dashboards = () => {
       )
     }
   }, [])
+
+  useEffect(() => {
+    const handleOpenKnowledgeReference = (event: Event) => {
+      const customEvent =
+        event as CustomEvent<OpenKnowledgeReferenceEventDetail>
+      const target = customEvent.detail?.target
+
+      if (target) {
+        openKnowledgeReferenceTarget(target)
+      }
+    }
+
+    window.addEventListener(
+      OPEN_KNOWLEDGE_REFERENCE_EVENT,
+      handleOpenKnowledgeReference,
+    )
+
+    return () => {
+      window.removeEventListener(
+        OPEN_KNOWLEDGE_REFERENCE_EVENT,
+        handleOpenKnowledgeReference,
+      )
+    }
+  }, [openDashboards])
+
+  useEffect(() => {
+    window.addEventListener(
+      OPEN_STUDY_LINK_PICKER_EVENT,
+      openDashboardReferenceDialog,
+    )
+
+    return () => {
+      window.removeEventListener(
+        OPEN_STUDY_LINK_PICKER_EVENT,
+        openDashboardReferenceDialog,
+      )
+    }
+  }, [referenceTargetOptions])
+
+  useEffect(() => {
+    const handleUpdateKnowledgeLinkWidget = (event: Event) => {
+      const customEvent =
+        event as CustomEvent<UpdateKnowledgeLinkWidgetEventDetail>
+      const current = openDashboards[selectedDashboard]
+
+      if (!current || !customEvent.detail?.options) {
+        return
+      }
+
+      const result = updateKnowledgeLinkWidgetOptions(
+        current.layout,
+        customEvent.detail.options,
+      )
+
+      if (result.updated) {
+        if (!result.layout) {
+          return
+        }
+
+        updateDashboardLayout(selectedDashboard, result.layout)
+        saveStudyLinksTemplate(
+          customEvent.detail.options.title || current.name || 'Study links',
+          result.layout,
+        )
+        if (customEvent.detail.options.title) {
+          renameDashboard(current.id, customEvent.detail.options.title)
+        }
+      }
+    }
+
+    window.addEventListener(
+      UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT,
+      handleUpdateKnowledgeLinkWidget,
+    )
+
+    return () => {
+      window.removeEventListener(
+        UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT,
+        handleUpdateKnowledgeLinkWidget,
+      )
+    }
+  }, [openDashboards, selectedDashboard])
+
+  useEffect(() => {
+    window.addEventListener(
+      SAVE_KNOWLEDGE_LINK_DASHBOARD_AS_DEFAULT_EVENT,
+      saveCurrentStudyLinksDashboardAsDefault,
+    )
+    window.addEventListener(
+      RESET_DEFAULT_EMPTY_DASHBOARD_EVENT,
+      resetDefaultEmptyDashboard,
+    )
+
+    return () => {
+      window.removeEventListener(
+        SAVE_KNOWLEDGE_LINK_DASHBOARD_AS_DEFAULT_EVENT,
+        saveCurrentStudyLinksDashboardAsDefault,
+      )
+      window.removeEventListener(
+        RESET_DEFAULT_EMPTY_DASHBOARD_EVENT,
+        resetDefaultEmptyDashboard,
+      )
+    }
+  }, [openDashboards, selectedDashboard])
 
   useEffect(() => {
     const handleOpenStudyPathReviewDashboard = (event: Event) => {
@@ -1641,11 +2316,23 @@ const Dashboards = () => {
           {!isMobileDashboardView &&
             workspaceTabsSlot &&
             createPortal(workspaceHeaderDashboardTabs, workspaceTabsSlot)}
-          {openDashboards.map((dashboard, index) => {
+          {openDashboards.map((dashboard, dashboardIndex) => {
             const isStudyPathContainer =
               dashboard.kind === 'studyPathContainer' && dashboard.studyPath
             const isEmptyDashboard =
               !isStudyPathContainer && !hasDashboardContent(dashboard.layout)
+            const isStudyLinksDashboard = layoutHasStudyLinksWidget(
+              dashboard.layout,
+            )
+            const studyLinksEditMode =
+              studyLinksEditModes[dashboard.id] ??
+              (getStudyLinksEditModeFromLayout(dashboard.layout) === true)
+            const renderLayout =
+              isStudyLinksDashboard && !isStudyPathContainer
+                ? applyKnowledgeLinkWidgetRenderOptions(dashboard.layout, {
+                    editMode: studyLinksEditMode,
+                  })
+                : dashboard.layout
             return (
               <TabPanel key={dashboard.id} forceRender={isMobileDashboardView}>
                 <Box
@@ -1671,6 +2358,64 @@ const Dashboards = () => {
                         : undefined,
                     }}
                   >
+                    {!isStudyPathContainer && isStudyLinksDashboard && (
+                      <Stack
+                        direction="row"
+                        spacing={0.75}
+                        sx={{
+                          position: 'absolute',
+                          top: { xs: 10, sm: 14 },
+                          right: { xs: 10, sm: 14 },
+                          zIndex: 12,
+                        }}
+                      >
+                        <IconButton
+                          size="small"
+                          aria-label={
+                            studyLinksEditMode
+                              ? 'View Study Links dashboard'
+                              : 'Edit Study Links dashboard'
+                          }
+                          onClick={() =>
+                            setStudyLinksDashboardEditMode(
+                              dashboardIndex,
+                              dashboard.id,
+                              !studyLinksEditMode,
+                            )
+                          }
+                          sx={{
+                            width: 34,
+                            height: 34,
+                            color: 'primary.contrastText',
+                            bgcolor: 'primary.main',
+                            border: 1,
+                            borderColor: 'primary.dark',
+                            boxShadow: (theme) =>
+                              theme.palette.mode === 'dark'
+                                ? `0 0 0 1px ${alpha(
+                                    theme.palette.common.white,
+                                    0.22,
+                                  )}, 0 10px 24px ${alpha(
+                                    theme.palette.common.black,
+                                    0.5,
+                                  )}`
+                                : `0 10px 24px ${alpha(
+                                    theme.palette.primary.main,
+                                    0.32,
+                                  )}`,
+                            '&:hover': {
+                              bgcolor: 'primary.dark',
+                            },
+                          }}
+                        >
+                          {studyLinksEditMode ? (
+                            <VisibilityIcon fontSize="small" />
+                          ) : (
+                            <EditIcon fontSize="small" />
+                          )}
+                        </IconButton>
+                      </Stack>
+                    )}
                     {isStudyPathContainer && dashboard.studyPath ? (
                       <StudyPathWorkspaceView
                         studyPath={dashboard.studyPath}
@@ -1694,10 +2439,13 @@ const Dashboards = () => {
                         dashboardOptions={visibleDashboardOptions}
                         onOpenDashboard={openSavedDashboardInWorkspace}
                         onOpenStudyGuide={openStudyGuideFromEmptyState}
+                        onAddStudyLink={() =>
+                          createStudyLinksHomeDashboard(true)
+                        }
                       />
                     ) : (
                       <DashboardLayoutView
-                        layout={dashboard.layout}
+                        layout={renderLayout}
                         mobileView={isMobileDashboardView}
                         readOnly={isMobileDashboardView}
                         updateLayout={(model) => {
@@ -1934,6 +2682,7 @@ const Dashboards = () => {
           dashboardOptions={visibleDashboardOptions}
           onOpenDashboard={openSavedDashboardFromEmptyState}
           onOpenStudyGuide={openStudyGuideFromEmptyState}
+          onAddStudyLink={() => createStudyLinksHomeDashboard(true)}
         />
       )}
 
@@ -2282,6 +3031,39 @@ const Dashboards = () => {
         onOpenInBuilder={loadSavedDashboardInBuilder}
         onOpenInWorkspace={openSavedDashboardFromLibrary}
       />
+
+      <Dialog
+        open={referenceDialogOpen}
+        onClose={() => setReferenceDialogOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Add study link to this dashboard</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ pt: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              Choose a Study Path, section, or dashboard for this index.
+            </Typography>
+            <StudyLinkPicker
+              options={referenceTargetOptions}
+              selectedOptionIds={selectedReferenceTargetIds}
+              onSelectedOptionIdsChange={setSelectedReferenceTargetIds}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setReferenceDialogOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            disabled={selectedReferenceTargetIds.length === 0}
+            onClick={addSelectedReferenceToCurrentDashboard}
+          >
+            {selectedReferenceTargetIds.length > 1
+              ? `Add ${selectedReferenceTargetIds.length} study links`
+              : 'Add study link'}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* Dashboard Details Dialog */}
       <Dialog

--- a/apps/studymesh/src/components/Dasboard/Dashboard.tsx
+++ b/apps/studymesh/src/components/Dasboard/Dashboard.tsx
@@ -89,6 +89,7 @@ import {
   getUniqueDashboardName,
   type SavedDashboard,
 } from './dashboardStorage'
+import { DEFAULT_DASHBOARD as BLANK_DASHBOARD_TEMPLATE } from './fixture'
 import {
   addKnowledgeReferencesToLayout,
   appendKnowledgeLinkWidgetToLayout,
@@ -679,6 +680,32 @@ const Dashboards = () => {
     return options
   }, [dashboardOptions, openDashboards, selectedDashboard])
 
+  const getStudyLinksTitleFromLayout = (
+    layout: DashboardLayout | undefined,
+  ): string | undefined => {
+    if (!layout) {
+      return undefined
+    }
+
+    if (layout.component === 'KnowledgeLinkWidget') {
+      const title = layout.config?.customProps?.title
+      if (typeof title === 'string' && title.trim()) {
+        return title.trim()
+      }
+
+      return layout.name
+    }
+
+    for (const child of layout.children || []) {
+      const childTitle = getStudyLinksTitleFromLayout(child)
+      if (childTitle) {
+        return childTitle
+      }
+    }
+
+    return undefined
+  }
+
   const saveStudyLinksTemplate = (
     name: string,
     layout: DashboardLayout,
@@ -687,9 +714,10 @@ const Dashboards = () => {
     const now = new Date().toISOString()
     const existingDefault = DashboardStorage.getDefaultEmptyDashboard()
     const existingTemplate = existingDefault || getSavedStudyLinksTemplate()
+    const titleFromLayout = getStudyLinksTitleFromLayout(layout)
     const savedDashboard: SavedDashboard = {
       id: existingTemplate?.id || `custom-empty-dashboard-${Date.now()}`,
-      name: name || 'Study links',
+      name: titleFromLayout || name || 'Study links',
       folder: CUSTOM_EMPTY_DASHBOARD_FOLDER,
       folderColor: DashboardStorage.getFolderColor(
         CUSTOM_EMPTY_DASHBOARD_FOLDER,
@@ -913,6 +941,19 @@ const Dashboards = () => {
 
   const resetDefaultEmptyDashboard = () => {
     DashboardStorage.clearDefaultEmptyDashboard()
+    const current = openDashboards[selectedDashboard]
+    if (current?.layout && layoutHasStudyLinksWidget(current.layout)) {
+      const nextDashboardId = replaceDashboard(selectedDashboard, {
+        name: BLANK_DASHBOARD_TEMPLATE.name,
+        layout: cloneLayout(BLANK_DASHBOARD_TEMPLATE.layout),
+      })
+      setStudyLinksEditModes((currentModes) => {
+        const nextModes = { ...currentModes }
+        delete nextModes[current.id]
+        delete nextModes[nextDashboardId]
+        return nextModes
+      })
+    }
     loadDashboardOptions()
   }
 
@@ -925,9 +966,14 @@ const Dashboards = () => {
     }
 
     if (layout.component === 'KnowledgeLinkWidget') {
+      const nextTitle =
+        typeof options.title === 'string' && options.title.trim()
+          ? options.title.trim()
+          : undefined
       return {
         layout: {
           ...layout,
+          name: nextTitle || layout.name,
           config: {
             ...layout.config,
             customProps: {
@@ -2461,6 +2507,9 @@ const Dashboards = () => {
                         onAddStudyLink={() =>
                           createStudyLinksHomeDashboard(true)
                         }
+                        hasIndexDashboard={Boolean(
+                          getSavedStudyLinksTemplate(),
+                        )}
                       />
                     ) : (
                       <DashboardLayoutView
@@ -2702,6 +2751,7 @@ const Dashboards = () => {
           onOpenDashboard={openSavedDashboardFromEmptyState}
           onOpenStudyGuide={openStudyGuideFromEmptyState}
           onAddStudyLink={() => createStudyLinksHomeDashboard(true)}
+          hasIndexDashboard={Boolean(getSavedStudyLinksTemplate())}
         />
       )}
 

--- a/apps/studymesh/src/components/Dasboard/DashboardEmptyState.tsx
+++ b/apps/studymesh/src/components/Dasboard/DashboardEmptyState.tsx
@@ -29,6 +29,7 @@ interface DashboardEmptyStateProps {
   onOpenDashboard: (dashboard: SavedDashboard) => void
   onOpenStudyGuide: (dashboards: SavedDashboard[]) => void
   onAddStudyLink: () => void
+  hasIndexDashboard?: boolean
 }
 
 const quickActions: Array<{
@@ -67,6 +68,7 @@ const DashboardEmptyState = ({
   onOpenDashboard,
   onOpenStudyGuide,
   onAddStudyLink,
+  hasIndexDashboard = false,
 }: DashboardEmptyStateProps) => {
   const dashboardsByFolder = dashboardOptions.reduce<
     Record<string, SavedDashboard[]>
@@ -180,7 +182,9 @@ const DashboardEmptyState = ({
               fontWeight: 900,
             }}
           >
-            Add your first study link
+            {hasIndexDashboard
+              ? 'Use your index dashboard'
+              : 'Build your index dashboard'}
           </Button>
 
           <Paper

--- a/apps/studymesh/src/components/Dasboard/DashboardEmptyState.tsx
+++ b/apps/studymesh/src/components/Dasboard/DashboardEmptyState.tsx
@@ -5,6 +5,7 @@ import AutoStoriesIcon from '@mui/icons-material/AutoStories'
 import CloudUploadIcon from '@mui/icons-material/CloudUpload'
 import ContentPasteIcon from '@mui/icons-material/ContentPaste'
 import FolderOpenIcon from '@mui/icons-material/FolderOpen'
+import AddLinkIcon from '@mui/icons-material/AddLink'
 import QuizIcon from '@mui/icons-material/Quiz'
 import RouteIcon from '@mui/icons-material/Route'
 import StyleIcon from '@mui/icons-material/Style'
@@ -27,6 +28,7 @@ interface DashboardEmptyStateProps {
   dashboardOptions: SavedDashboard[]
   onOpenDashboard: (dashboard: SavedDashboard) => void
   onOpenStudyGuide: (dashboards: SavedDashboard[]) => void
+  onAddStudyLink: () => void
 }
 
 const quickActions: Array<{
@@ -64,6 +66,7 @@ const DashboardEmptyState = ({
   dashboardOptions,
   onOpenDashboard,
   onOpenStudyGuide,
+  onAddStudyLink,
 }: DashboardEmptyStateProps) => {
   const dashboardsByFolder = dashboardOptions.reduce<
     Record<string, SavedDashboard[]>
@@ -154,17 +157,31 @@ const DashboardEmptyState = ({
                 fontSize: { xs: '1.16rem', sm: '1.48rem', md: '1.76rem' },
               }}
             >
-              What do you want to build?
+              Build an index dashboard
             </Typography>
             <Typography
               variant="body2"
               color="text.secondary"
               sx={{ mt: 1, maxWidth: 620, fontSize: '0.72rem' }}
             >
-              Create a guided Study Path, or add material to generate a quiz,
-              flashcards, or Expand on this.
+              Use this dashboard as an index page for your learning.
             </Typography>
           </Box>
+
+          <Button
+            variant="contained"
+            startIcon={<AddLinkIcon />}
+            onClick={onAddStudyLink}
+            sx={{
+              justifyContent: 'flex-start',
+              minHeight: 44,
+              borderRadius: 2,
+              textTransform: 'none',
+              fontWeight: 900,
+            }}
+          >
+            Add your first study link
+          </Button>
 
           <Paper
             component="button"

--- a/apps/studymesh/src/components/Dasboard/DashboardProvider.tsx
+++ b/apps/studymesh/src/components/Dasboard/DashboardProvider.tsx
@@ -4,6 +4,7 @@ import { useContext } from 'react'
 import { nanoid } from 'nanoid'
 
 import { DEFAULT_DASHBOARD, DefaultDashboard } from './fixture'
+import { DashboardStorage } from './dashboardStorage'
 
 import {
   useStore,
@@ -47,9 +48,25 @@ interface DashboardContextType {
 
 const DashboardContext = React.createContext<DashboardContextType | null>(null)
 
+const cloneLayout = (layout?: DashboardLayout): DashboardLayout | undefined =>
+  layout ? JSON.parse(JSON.stringify(layout)) : undefined
+
+const getEmptyDashboardTemplate = (): DefaultDashboard => {
+  const defaultEmptyDashboard = DashboardStorage.getDefaultEmptyDashboard()
+
+  if (!defaultEmptyDashboard) {
+    return DEFAULT_DASHBOARD
+  }
+
+  return {
+    name: defaultEmptyDashboard.name,
+    layout: cloneLayout(defaultEmptyDashboard.layout),
+  }
+}
+
 const createEmptyDashboard = (): StateDashboard => ({
   id: nanoid(),
-  ...DEFAULT_DASHBOARD,
+  ...getEmptyDashboardTemplate(),
 })
 
 const DashboardProvider: React.FC<DashboardProviderProps> = (props) => {
@@ -172,15 +189,18 @@ const DashboardProvider: React.FC<DashboardProviderProps> = (props) => {
     setSelectedDashboard(toIndex)
   }
 
-  const addDashboard = (dashboard = DEFAULT_DASHBOARD) => {
+  const addDashboard = (dashboard?: DefaultDashboard) => {
+    const dashboardToAdd = dashboard || getEmptyDashboardTemplate()
     const id = nanoid()
-    const newDashboard = openDashboards.concat(Object.assign({ id }, dashboard))
+    const newDashboard = openDashboards.concat(
+      Object.assign({ id }, dashboardToAdd),
+    )
     const newSelectedDashboard = openDashboards.length
 
     setDashboards(newDashboard)
     setSelectedDashboard(newSelectedDashboard)
 
-    if (!hasDashboardContent(dashboard.layout)) {
+    if (!hasDashboardContent(dashboardToAdd.layout)) {
       setDashboardEditing(id, true)
     }
 

--- a/apps/studymesh/src/components/Dasboard/DashboardProvider.tsx
+++ b/apps/studymesh/src/components/Dasboard/DashboardProvider.tsx
@@ -37,7 +37,10 @@ interface DashboardContextType {
     dashboardId: string,
     updater: (studyPath: StudyPathContainerState) => StudyPathContainerState,
   ) => void
-  replaceDashboard: (index: number, dashboard: DefaultDashboard) => string
+  replaceDashboard: (
+    index: number,
+    dashboard: DefaultDashboard | Omit<StateDashboard, 'id'>,
+  ) => string
   updateLayout: (model: Model) => void
   updateDashboardLayout: (index: number, layout: DashboardLayout) => void
   renameDashboard: (id: string, newName: string) => void
@@ -304,7 +307,10 @@ const DashboardProvider: React.FC<DashboardProviderProps> = (props) => {
     setDashboards(newOpenDashboards)
   }
 
-  const replaceDashboard = (index: number, dashboard: DefaultDashboard) => {
+  const replaceDashboard = (
+    index: number,
+    dashboard: DefaultDashboard | Omit<StateDashboard, 'id'>,
+  ) => {
     const currentDashboard = openDashboards[index]
     const id = nanoid()
     const newOpenDashboards = [...openDashboards]
@@ -317,7 +323,11 @@ const DashboardProvider: React.FC<DashboardProviderProps> = (props) => {
       setDashboardEditing(currentDashboard.id, false)
     }
 
-    setDashboardEditing(id, !hasDashboardContent(dashboard.layout))
+    setDashboardEditing(
+      id,
+      dashboard.kind !== 'studyPathContainer' &&
+        !hasDashboardContent(dashboard.layout),
+    )
 
     return id
   }

--- a/apps/studymesh/src/components/Dasboard/DashboardTabsBar.tsx
+++ b/apps/studymesh/src/components/Dasboard/DashboardTabsBar.tsx
@@ -30,6 +30,18 @@ const isEmptyDashboard = (dashboard: StateDashboard) =>
   dashboard.kind !== 'studyPathContainer' &&
   !hasDashboardContent(dashboard.layout)
 
+const hasStudyLinksWidget = (layout: StateDashboard['layout']): boolean => {
+  if (!layout) {
+    return false
+  }
+
+  if (layout.component === 'KnowledgeLinkWidget') {
+    return true
+  }
+
+  return Boolean(layout.children?.some(hasStudyLinksWidget))
+}
+
 const DashboardTabLabel = ({ dashboard }: { dashboard: StateDashboard }) => (
   <TooltipStyled
     title={dashboard.name}
@@ -216,11 +228,12 @@ const DashboardTabsBar = ({
   const renderActions = (dashboard: StateDashboard, canEdit: boolean) => {
     const isOnlyEmptyDashboard =
       dashboards.length === 1 && isEmptyDashboard(dashboard)
+    const canEditDashboard = canEdit && !hasStudyLinksWidget(dashboard.layout)
 
     return (
       <DashboardTabActions
         dashboard={dashboard}
-        canEdit={canEdit}
+        canEdit={canEditDashboard}
         canClose={!isOnlyEmptyDashboard}
         onEditDashboard={onEditDashboard}
         onRemoveDashboard={onRemoveDashboard}

--- a/apps/studymesh/src/components/Dasboard/dashboardStorage.ts
+++ b/apps/studymesh/src/components/Dasboard/dashboardStorage.ts
@@ -15,6 +15,9 @@ export interface SavedDashboard {
 }
 
 export const DEFAULT_DASHBOARD_NAME = 'New Dashboard'
+export const CUSTOM_EMPTY_DASHBOARD_FOLDER = 'Custom empty dashboards'
+export const DEFAULT_EMPTY_DASHBOARD_ID_STORAGE_KEY =
+  'studymesh-default-empty-dashboard-id'
 
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -133,5 +136,33 @@ export const DashboardStorage = {
     return (
       JSON.stringify(currentLayout) !== JSON.stringify(savedDashboard.layout)
     )
+  },
+
+  getDefaultEmptyDashboard: (): SavedDashboard | null => {
+    try {
+      const defaultDashboardId = localStorage.getItem(
+        DEFAULT_EMPTY_DASHBOARD_ID_STORAGE_KEY,
+      )
+      if (!defaultDashboardId) {
+        return null
+      }
+
+      return (
+        DashboardStorage.getAll().find(
+          (dashboard) => dashboard.id === defaultDashboardId,
+        ) || null
+      )
+    } catch (error) {
+      console.error('Failed to load default empty dashboard', error)
+      return null
+    }
+  },
+
+  setDefaultEmptyDashboard: (dashboardId: string): void => {
+    localStorage.setItem(DEFAULT_EMPTY_DASHBOARD_ID_STORAGE_KEY, dashboardId)
+  },
+
+  clearDefaultEmptyDashboard: (): void => {
+    localStorage.removeItem(DEFAULT_EMPTY_DASHBOARD_ID_STORAGE_KEY)
   },
 }

--- a/apps/studymesh/src/components/Layout/Layout.tsx
+++ b/apps/studymesh/src/components/Layout/Layout.tsx
@@ -84,7 +84,7 @@ const withDesktopTabMovementEnabled = (
     return {
       ...node,
       children,
-      enableDrag: true,
+      enableDrag: node.enableDrag === false ? false : true,
     } as DashboardLayout
   }
 
@@ -92,9 +92,9 @@ const withDesktopTabMovementEnabled = (
     return {
       ...node,
       children,
-      enableDrag: true,
-      enableDrop: true,
-      enableDivide: true,
+      enableDrag: node.enableDrag === false ? false : true,
+      enableDrop: node.enableDrop === false ? false : true,
+      enableDivide: node.enableDivide === false ? false : true,
     } as DashboardLayout
   }
 

--- a/apps/studymesh/src/components/Layout/layout.scss
+++ b/apps/studymesh/src/components/Layout/layout.scss
@@ -234,6 +234,16 @@
   }
 }
 
+.studymesh-study-links-flex-tab,
+.studymesh-study-links-flex-tabstrip {
+  .flexlayout__tab_button_trailing,
+  .flexlayout__tab_toolbar_button-close {
+    display: none !important;
+    pointer-events: none !important;
+    visibility: hidden !important;
+  }
+}
+
 .studymesh-mobile-dashboard-layout {
   width: 100%;
   min-width: 0;

--- a/apps/studymesh/src/components/knowledge/KnowledgeLinkWidget.tsx
+++ b/apps/studymesh/src/components/knowledge/KnowledgeLinkWidget.tsx
@@ -1,0 +1,791 @@
+import React from 'react'
+import {
+  Box,
+  Button,
+  ButtonBase,
+  Chip,
+  Divider,
+  FormControlLabel,
+  Paper,
+  Stack,
+  Switch,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material'
+import { alpha } from '@mui/material/styles'
+import AddLinkIcon from '@mui/icons-material/AddLink'
+import AutoStoriesIcon from '@mui/icons-material/AutoStories'
+import CloudUploadIcon from '@mui/icons-material/CloudUpload'
+import ContentPasteIcon from '@mui/icons-material/ContentPaste'
+import DashboardIcon from '@mui/icons-material/Dashboard'
+import FolderOpenIcon from '@mui/icons-material/FolderOpen'
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile'
+import LinkIcon from '@mui/icons-material/Link'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import RouteIcon from '@mui/icons-material/Route'
+import {
+  getKnowledgeReferenceKindLabel,
+  getKnowledgeReferenceTitle,
+  KnowledgeLinkWidgetCardSize,
+  KnowledgeLinkWidgetColumns,
+  KnowledgeLinkWidgetOptions,
+  KnowledgeLinkWidgetSectionId,
+  KnowledgeReference,
+  OPEN_KNOWLEDGE_REFERENCE_EVENT,
+  OPEN_STUDY_LINK_PICKER_EVENT,
+  RESET_DEFAULT_EMPTY_DASHBOARD_EVENT,
+  SAVE_KNOWLEDGE_LINK_DASHBOARD_AS_DEFAULT_EVENT,
+  UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT,
+} from '../../knowledgeReferences'
+import {
+  OPEN_CREATE_HUB_EVENT,
+  OPEN_SAVED_DASHBOARDS_EVENT,
+} from '../../customHooks/useWorkspaceActions'
+
+interface KnowledgeLinkWidgetProps {
+  references?: KnowledgeReference[]
+  title?: string
+  cardSize?: KnowledgeLinkWidgetCardSize
+  editMode?: boolean
+  showCreationActions?: boolean
+  showOpenStudyMaterial?: boolean
+  sectionOrder?: KnowledgeLinkWidgetSectionId[]
+  columns?: KnowledgeLinkWidgetColumns
+}
+
+const defaultSectionOrder: KnowledgeLinkWidgetSectionId[] = [
+  'creation',
+  'openMaterial',
+  'links',
+]
+const reorderablePanelSections: KnowledgeLinkWidgetSectionId[] = [
+  'creation',
+  'openMaterial',
+]
+
+const normalizeSectionOrder = (
+  order?: KnowledgeLinkWidgetSectionId[],
+): KnowledgeLinkWidgetSectionId[] => [
+  ...(order || []).filter((section) =>
+    reorderablePanelSections.includes(section),
+  ),
+  ...reorderablePanelSections.filter((section) => !order?.includes(section)),
+  'links',
+]
+
+const getIcon = (type: string) => {
+  if (type === 'studyPath' || type === 'studyPathSection') {
+    return <AutoStoriesIcon fontSize="small" />
+  }
+
+  if (type === 'dashboard') {
+    return <DashboardIcon fontSize="small" />
+  }
+
+  if (type === 'source') {
+    return <InsertDriveFileIcon fontSize="small" />
+  }
+
+  return <LinkIcon fontSize="small" />
+}
+
+const openReference = (reference: KnowledgeReference) => {
+  window.dispatchEvent(
+    new CustomEvent(OPEN_KNOWLEDGE_REFERENCE_EVENT, {
+      detail: { target: reference.target },
+    }),
+  )
+}
+
+const getActionLabel = (reference: KnowledgeReference): string => {
+  if (reference.target.type === 'studyPath') {
+    return 'Open study path'
+  }
+
+  if (reference.target.type === 'studyPathSection') {
+    return 'Open section'
+  }
+
+  if (reference.target.type === 'dashboard') {
+    return 'Open dashboard'
+  }
+
+  return 'Open link'
+}
+
+const updateWidgetOptions = (options: KnowledgeLinkWidgetOptions) => {
+  window.dispatchEvent(
+    new CustomEvent(UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT, {
+      detail: { options },
+    }),
+  )
+}
+
+const openCreateHub = (
+  detail:
+    | { intent: 'study-path' }
+    | {
+        intent: 'improvedNotes'
+        openQuickOptions: boolean
+        quickSourceFocus: 'upload' | 'paste'
+      },
+) => {
+  window.dispatchEvent(new CustomEvent(OPEN_CREATE_HUB_EVENT, { detail }))
+}
+
+const saveAsDefaultEmptyDashboard = () => {
+  window.dispatchEvent(
+    new CustomEvent(SAVE_KNOWLEDGE_LINK_DASHBOARD_AS_DEFAULT_EVENT),
+  )
+}
+
+const resetDefaultEmptyDashboard = () => {
+  window.dispatchEvent(new CustomEvent(RESET_DEFAULT_EMPTY_DASHBOARD_EVENT))
+}
+
+const openStudyLinkPicker = () => {
+  window.dispatchEvent(new CustomEvent(OPEN_STUDY_LINK_PICKER_EVENT))
+}
+
+export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
+  references = [],
+  title = 'Study links',
+  cardSize = 'standard',
+  editMode = false,
+  showCreationActions = false,
+  showOpenStudyMaterial = false,
+  sectionOrder,
+  columns = 1,
+}) => {
+  const compact = cardSize === 'compact'
+  const detailed = cardSize === 'detailed'
+  const orderedSections = normalizeSectionOrder(sectionOrder)
+  const [editingTitle, setEditingTitle] = React.useState(false)
+  const [draftTitle, setDraftTitle] = React.useState(title)
+  const [draggedSection, setDraggedSection] =
+    React.useState<KnowledgeLinkWidgetSectionId | null>(null)
+  const [draggedReferenceId, setDraggedReferenceId] = React.useState<
+    string | null
+  >(null)
+
+  React.useEffect(() => {
+    setDraftTitle(title)
+  }, [title])
+
+  const handleCardSizeChange = (
+    _: React.MouseEvent<HTMLElement>,
+    value: KnowledgeLinkWidgetCardSize | null,
+  ) => {
+    if (!value) {
+      return
+    }
+
+    updateWidgetOptions({ cardSize: value })
+  }
+
+  const handleColumnsChange = (
+    _: React.MouseEvent<HTMLElement>,
+    value: KnowledgeLinkWidgetColumns | null,
+  ) => {
+    if (!value) {
+      return
+    }
+
+    updateWidgetOptions({ columns: value })
+  }
+
+  const commitTitle = () => {
+    const nextTitle = draftTitle.trim() || 'Study links'
+    setDraftTitle(nextTitle)
+    setEditingTitle(false)
+    if (nextTitle !== title) {
+      updateWidgetOptions({ title: nextTitle })
+    }
+  }
+
+  const moveSection = (
+    targetSection: KnowledgeLinkWidgetSectionId,
+    sourceSection: KnowledgeLinkWidgetSectionId | null,
+  ) => {
+    if (
+      !sourceSection ||
+      sourceSection === targetSection ||
+      !reorderablePanelSections.includes(sourceSection) ||
+      !reorderablePanelSections.includes(targetSection)
+    ) {
+      return
+    }
+
+    const nextOrder = orderedSections.filter(
+      (section) => section !== sourceSection,
+    )
+    const targetIndex = nextOrder.indexOf(targetSection)
+    nextOrder.splice(targetIndex, 0, sourceSection)
+    updateWidgetOptions({ sectionOrder: nextOrder })
+  }
+
+  const moveReference = (
+    targetReferenceId: string,
+    sourceReferenceId: string | null,
+  ) => {
+    if (!sourceReferenceId || sourceReferenceId === targetReferenceId) {
+      return
+    }
+
+    const sourceReference = references.find(
+      (reference) => reference.id === sourceReferenceId,
+    )
+    if (!sourceReference) {
+      return
+    }
+
+    const nextReferences = references.filter(
+      (reference) => reference.id !== sourceReferenceId,
+    )
+    const targetIndex = nextReferences.findIndex(
+      (reference) => reference.id === targetReferenceId,
+    )
+    nextReferences.splice(Math.max(0, targetIndex), 0, sourceReference)
+    updateWidgetOptions({ references: nextReferences })
+  }
+
+  const sectionDragProps = (section: KnowledgeLinkWidgetSectionId) =>
+    editMode && reorderablePanelSections.includes(section)
+      ? {
+          draggable: true,
+          onDragStart: () => setDraggedSection(section),
+          onDragOver: (event: React.DragEvent) => {
+            event.preventDefault()
+          },
+          onDrop: () => {
+            moveSection(section, draggedSection)
+            setDraggedSection(null)
+          },
+          onDragEnd: () => setDraggedSection(null),
+        }
+      : {}
+
+  const renderCreationSection = () =>
+    showCreationActions ? (
+      <Paper
+        key="creation"
+        variant="outlined"
+        {...sectionDragProps('creation')}
+        sx={{
+          width:
+            showCreationActions && showOpenStudyMaterial
+              ? 'calc(50% - 4px)'
+              : '100%',
+          minWidth: 0,
+          boxSizing: 'border-box',
+          p: 1.25,
+          borderRadius: 1,
+          bgcolor: 'background.default',
+          cursor: editMode ? 'grab' : 'default',
+        }}
+      >
+        <Stack spacing={1}>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <RouteIcon color="primary" fontSize="small" />
+            <Typography variant="subtitle2" fontWeight={900}>
+              Build
+            </Typography>
+          </Stack>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
+            <Button
+              size="small"
+              variant="contained"
+              startIcon={<RouteIcon />}
+              onClick={() => openCreateHub({ intent: 'study-path' })}
+              sx={{ textTransform: 'none', fontWeight: 800 }}
+            >
+              Study Path
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<CloudUploadIcon />}
+              onClick={() =>
+                openCreateHub({
+                  intent: 'improvedNotes',
+                  openQuickOptions: true,
+                  quickSourceFocus: 'upload',
+                })
+              }
+              sx={{ textTransform: 'none', fontWeight: 800 }}
+            >
+              Upload
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<ContentPasteIcon />}
+              onClick={() =>
+                openCreateHub({
+                  intent: 'improvedNotes',
+                  openQuickOptions: true,
+                  quickSourceFocus: 'paste',
+                })
+              }
+              sx={{ textTransform: 'none', fontWeight: 800 }}
+            >
+              Paste
+            </Button>
+          </Stack>
+        </Stack>
+      </Paper>
+    ) : null
+
+  const renderOpenMaterialSection = () =>
+    showOpenStudyMaterial ? (
+      <Paper
+        key="openMaterial"
+        variant="outlined"
+        {...sectionDragProps('openMaterial')}
+        sx={{
+          width:
+            showCreationActions && showOpenStudyMaterial
+              ? 'calc(50% - 4px)'
+              : '100%',
+          minWidth: 0,
+          boxSizing: 'border-box',
+          p: 1.25,
+          borderRadius: 1,
+          bgcolor: 'background.default',
+          cursor: editMode ? 'grab' : 'default',
+        }}
+      >
+        <Stack spacing={1}>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <FolderOpenIcon color="primary" fontSize="small" />
+            <Typography variant="subtitle2" fontWeight={900}>
+              Open study material
+            </Typography>
+          </Stack>
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<FolderOpenIcon />}
+            onClick={() =>
+              window.dispatchEvent(new CustomEvent(OPEN_SAVED_DASHBOARDS_EVENT))
+            }
+            sx={{
+              alignSelf: 'flex-start',
+              textTransform: 'none',
+              fontWeight: 800,
+            }}
+          >
+            Open library
+          </Button>
+        </Stack>
+      </Paper>
+    ) : null
+
+  const renderLinksSection = () => (
+    <Box
+      key="links"
+      sx={{
+        width: '100%',
+        minWidth: 0,
+      }}
+    >
+      {editMode && (
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={1}
+          sx={{ mb: 1.25 }}
+          alignItems={{ xs: 'stretch', sm: 'center' }}
+        >
+          <Button
+            variant="contained"
+            startIcon={<AddLinkIcon />}
+            onClick={openStudyLinkPicker}
+            sx={{
+              alignSelf: { xs: 'stretch', sm: 'flex-start' },
+              textTransform: 'none',
+              fontWeight: 850,
+            }}
+          >
+            Add study link
+          </Button>
+          <ToggleButtonGroup
+            size="small"
+            exclusive
+            value={columns}
+            onChange={handleColumnsChange}
+            aria-label="Study link columns per row"
+            sx={(theme) => ({
+              alignSelf: { xs: 'stretch', sm: 'flex-start' },
+              '& .MuiToggleButton-root': {
+                color: 'text.primary',
+                borderColor: 'divider',
+                bgcolor:
+                  theme.palette.mode === 'dark'
+                    ? alpha(theme.palette.common.white, 0.08)
+                    : alpha(theme.palette.common.black, 0.04),
+                fontWeight: 850,
+                minWidth: 38,
+                '&:hover': {
+                  bgcolor:
+                    theme.palette.mode === 'dark'
+                      ? alpha(theme.palette.common.white, 0.14)
+                      : alpha(theme.palette.common.black, 0.08),
+                },
+                '&.Mui-selected': {
+                  color: 'primary.contrastText',
+                  bgcolor: 'primary.main',
+                  borderColor: 'primary.dark',
+                  '&:hover': {
+                    bgcolor: 'primary.dark',
+                  },
+                },
+              },
+            })}
+          >
+            {[1, 2, 3, 4].map((columnCount) => (
+              <ToggleButton
+                key={columnCount}
+                value={columnCount}
+                aria-label={`${columnCount} column${
+                  columnCount === 1 ? '' : 's'
+                } per row`}
+              >
+                {columnCount}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+        </Stack>
+      )}
+      {editMode && (
+        <Typography variant="caption" color="text.secondary">
+          Drag study links to reorder them.
+        </Typography>
+      )}
+      {references.length === 0 ? (
+        <Paper
+          variant="outlined"
+          sx={{
+            p: 2,
+            borderRadius: 1,
+            display: 'grid',
+            placeItems: 'center',
+            minHeight: 96,
+            color: 'text.secondary',
+            bgcolor: 'background.default',
+          }}
+        >
+          <Stack spacing={0.75} alignItems="center" textAlign="center">
+            <AddLinkIcon color="primary" />
+            <Typography variant="body2" fontWeight={800}>
+              No study links yet.
+            </Typography>
+          </Stack>
+        </Paper>
+      ) : (
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: {
+              xs: '1fr',
+              sm: `repeat(${columns}, minmax(0, 1fr))`,
+            },
+            gap: 1.25,
+            mt: editMode ? 0.75 : 0,
+          }}
+        >
+          {references.map((reference) => (
+            <ButtonBase
+              key={reference.id}
+              draggable={editMode}
+              onDragStart={() => setDraggedReferenceId(reference.id)}
+              onDragOver={(event) => {
+                if (editMode) {
+                  event.preventDefault()
+                }
+              }}
+              onDrop={() => {
+                if (editMode) {
+                  moveReference(reference.id, draggedReferenceId)
+                  setDraggedReferenceId(null)
+                }
+              }}
+              onDragEnd={() => setDraggedReferenceId(null)}
+              onClick={() => openReference(reference)}
+              sx={{
+                display: 'block',
+                width: '100%',
+                textAlign: 'left',
+                borderRadius: 1,
+                cursor: editMode ? 'grab' : 'pointer',
+                '&:focus-visible': {
+                  outline: '2px solid',
+                  outlineColor: 'primary.main',
+                  outlineOffset: 2,
+                },
+              }}
+            >
+              <Box
+                sx={(theme) => ({
+                  p: compact ? 1 : 1.5,
+                  border: 1,
+                  borderColor: 'divider',
+                  borderRadius: 1,
+                  bgcolor:
+                    theme.palette.mode === 'dark'
+                      ? alpha(theme.palette.common.white, 0.04)
+                      : alpha(theme.palette.primary.main, 0.035),
+                  transition: 'border-color 120ms ease, background 120ms ease',
+                  '&:hover': {
+                    borderColor: 'primary.main',
+                    bgcolor: alpha(theme.palette.primary.main, 0.1),
+                  },
+                })}
+              >
+                <Stack direction="row" spacing={1.25} alignItems="flex-start">
+                  <Box
+                    sx={{
+                      width: compact ? 28 : 32,
+                      height: compact ? 28 : 32,
+                      borderRadius: 1,
+                      display: 'grid',
+                      placeItems: 'center',
+                      bgcolor: 'primary.main',
+                      color: 'primary.contrastText',
+                      flex: '0 0 auto',
+                    }}
+                  >
+                    {getIcon(reference.target.type)}
+                  </Box>
+                  <Box sx={{ minWidth: 0, flex: 1 }}>
+                    <Stack
+                      direction="row"
+                      spacing={0.75}
+                      alignItems="center"
+                      sx={{ mb: 0.5, minWidth: 0 }}
+                    >
+                      <Typography
+                        variant="subtitle2"
+                        fontWeight={800}
+                        noWrap
+                        sx={{ minWidth: 0, flex: 1 }}
+                      >
+                        {getKnowledgeReferenceTitle(reference)}
+                      </Typography>
+                      {!compact && (
+                        <OpenInNewIcon
+                          fontSize="small"
+                          sx={{ color: 'text.secondary', flex: '0 0 auto' }}
+                        />
+                      )}
+                    </Stack>
+                    <Stack direction="row" spacing={0.75} alignItems="center">
+                      <Chip
+                        size="small"
+                        label={getKnowledgeReferenceKindLabel(reference.target)}
+                        sx={{ height: 22, fontWeight: 700 }}
+                      />
+                      {!compact && reference.target.subtitle && (
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          noWrap
+                        >
+                          {reference.target.subtitle}
+                        </Typography>
+                      )}
+                    </Stack>
+                    {detailed && reference.description && (
+                      <Typography variant="body2" color="text.secondary">
+                        {reference.description}
+                      </Typography>
+                    )}
+                    {!compact && (
+                      <Typography
+                        variant="caption"
+                        color="primary"
+                        fontWeight={800}
+                        sx={{ display: 'block', mt: 0.75 }}
+                      >
+                        {getActionLabel(reference)}
+                      </Typography>
+                    )}
+                  </Box>
+                </Stack>
+              </Box>
+            </ButtonBase>
+          ))}
+        </Box>
+      )}
+    </Box>
+  )
+
+  const sectionRenderers: Record<
+    KnowledgeLinkWidgetSectionId,
+    () => React.ReactNode
+  > = {
+    creation: renderCreationSection,
+    openMaterial: renderOpenMaterialSection,
+    links: renderLinksSection,
+  }
+
+  return (
+    <Paper
+      sx={{
+        p: 2,
+        height: '100%',
+        boxSizing: 'border-box',
+        overflow: 'auto',
+        bgcolor: 'background.paper',
+      }}
+    >
+      <Stack spacing={1.25} sx={{ minWidth: 0 }}>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={1}
+          justifyContent="space-between"
+          alignItems={{ xs: 'stretch', sm: 'center' }}
+        >
+          <Box sx={{ minWidth: 0 }}>
+            {editMode && editingTitle ? (
+              <TextField
+                autoFocus
+                size="small"
+                value={draftTitle}
+                onChange={(event) => setDraftTitle(event.target.value)}
+                onBlur={commitTitle}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    commitTitle()
+                  }
+                }}
+                inputProps={{ 'aria-label': 'Study links dashboard name' }}
+              />
+            ) : (
+              <Typography
+                variant="subtitle1"
+                fontWeight={900}
+                onClick={() => {
+                  if (editMode) {
+                    setEditingTitle(true)
+                  }
+                }}
+                sx={{ cursor: editMode ? 'text' : 'default' }}
+              >
+                {title}
+              </Typography>
+            )}
+          </Box>
+          {editMode && (
+            <ToggleButtonGroup
+              size="small"
+              exclusive
+              value={cardSize}
+              onChange={handleCardSizeChange}
+              aria-label="Study link card size"
+              sx={(theme) => ({
+                '& .MuiToggleButton-root': {
+                  color: 'text.primary',
+                  borderColor: 'divider',
+                  bgcolor:
+                    theme.palette.mode === 'dark'
+                      ? alpha(theme.palette.common.white, 0.08)
+                      : alpha(theme.palette.common.black, 0.04),
+                  fontWeight: 800,
+                  textTransform: 'none',
+                  '&:hover': {
+                    bgcolor:
+                      theme.palette.mode === 'dark'
+                        ? alpha(theme.palette.common.white, 0.14)
+                        : alpha(theme.palette.common.black, 0.08),
+                  },
+                  '&.Mui-selected': {
+                    color: 'primary.contrastText',
+                    bgcolor: 'primary.main',
+                    borderColor: 'primary.dark',
+                    '&:hover': {
+                      bgcolor: 'primary.dark',
+                    },
+                  },
+                },
+              })}
+            >
+              <ToggleButton value="compact" aria-label="Compact cards">
+                Compact
+              </ToggleButton>
+              <ToggleButton value="standard" aria-label="Standard cards">
+                Standard
+              </ToggleButton>
+              <ToggleButton value="detailed" aria-label="Detailed cards">
+                Detailed
+              </ToggleButton>
+            </ToggleButtonGroup>
+          )}
+        </Stack>
+
+        {editMode && (
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            <Button
+              size="small"
+              variant="contained"
+              onClick={saveAsDefaultEmptyDashboard}
+              sx={{ textTransform: 'none', fontWeight: 800 }}
+            >
+              Use for new dashboards
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={resetDefaultEmptyDashboard}
+              sx={{ textTransform: 'none', fontWeight: 800 }}
+            >
+              Restore blank default
+            </Button>
+            <FormControlLabel
+              control={
+                <Switch
+                  size="small"
+                  checked={showCreationActions}
+                  onChange={(event) =>
+                    updateWidgetOptions({
+                      showCreationActions: event.target.checked,
+                    })
+                  }
+                />
+              }
+              label="Creation"
+            />
+            <FormControlLabel
+              control={
+                <Switch
+                  size="small"
+                  checked={showOpenStudyMaterial}
+                  onChange={(event) =>
+                    updateWidgetOptions({
+                      showOpenStudyMaterial: event.target.checked,
+                    })
+                  }
+                />
+              }
+              label="Open material"
+            />
+          </Stack>
+        )}
+
+        <Divider />
+
+        <Box
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 1,
+            alignItems: 'stretch',
+          }}
+        >
+          {orderedSections.map((section) => sectionRenderers[section]())}
+        </Box>
+      </Stack>
+    </Paper>
+  )
+}

--- a/apps/studymesh/src/components/knowledge/KnowledgeLinkWidget.tsx
+++ b/apps/studymesh/src/components/knowledge/KnowledgeLinkWidget.tsx
@@ -40,7 +40,6 @@ import {
   OPEN_KNOWLEDGE_REFERENCE_EVENT,
   OPEN_STUDY_LINK_PICKER_EVENT,
   RESET_DEFAULT_EMPTY_DASHBOARD_EVENT,
-  SAVE_KNOWLEDGE_LINK_DASHBOARD_AS_DEFAULT_EVENT,
   UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT,
 } from '../../knowledgeReferences'
 import {
@@ -137,12 +136,6 @@ const openCreateHub = (
       },
 ) => {
   window.dispatchEvent(new CustomEvent(OPEN_CREATE_HUB_EVENT, { detail }))
-}
-
-const saveAsDefaultEmptyDashboard = () => {
-  window.dispatchEvent(
-    new CustomEvent(SAVE_KNOWLEDGE_LINK_DASHBOARD_AS_DEFAULT_EVENT),
-  )
 }
 
 const resetDefaultEmptyDashboard = () => {
@@ -845,14 +838,6 @@ export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
 
         {editMode && (
           <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-            <Button
-              size="small"
-              variant="contained"
-              onClick={saveAsDefaultEmptyDashboard}
-              sx={{ textTransform: 'none', fontWeight: 800 }}
-            >
-              Use for new dashboards
-            </Button>
             <Button
               size="small"
               variant="outlined"

--- a/apps/studymesh/src/components/knowledge/KnowledgeLinkWidget.tsx
+++ b/apps/studymesh/src/components/knowledge/KnowledgeLinkWidget.tsx
@@ -227,6 +227,7 @@ export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
   const [editingTitle, setEditingTitle] = React.useState(false)
   const [displayTitle, setDisplayTitle] = React.useState(title)
   const [draftTitle, setDraftTitle] = React.useState(title)
+  const pendingCommittedTitleRef = React.useRef<string | null>(null)
   const [draggedSection, setDraggedSection] =
     React.useState<KnowledgeLinkWidgetSectionId | null>(null)
   const [draggedReferenceId, setDraggedReferenceId] = React.useState<
@@ -234,6 +235,17 @@ export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
   >(null)
 
   React.useEffect(() => {
+    if (
+      pendingCommittedTitleRef.current &&
+      title !== pendingCommittedTitleRef.current
+    ) {
+      return
+    }
+
+    if (title === pendingCommittedTitleRef.current) {
+      pendingCommittedTitleRef.current = null
+    }
+
     setDisplayTitle(title)
     setDraftTitle(title)
   }, [title])
@@ -262,6 +274,7 @@ export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
 
   const commitTitle = () => {
     const nextTitle = draftTitle.trim() || 'Study links'
+    pendingCommittedTitleRef.current = nextTitle
     setDisplayTitle(nextTitle)
     setDraftTitle(nextTitle)
     setEditingTitle(false)

--- a/apps/studymesh/src/components/knowledge/KnowledgeLinkWidget.tsx
+++ b/apps/studymesh/src/components/knowledge/KnowledgeLinkWidget.tsx
@@ -6,6 +6,7 @@ import {
   Chip,
   Divider,
   FormControlLabel,
+  IconButton,
   Paper,
   Stack,
   Switch,
@@ -16,6 +17,8 @@ import {
 } from '@mui/material'
 import { alpha } from '@mui/material/styles'
 import AddLinkIcon from '@mui/icons-material/AddLink'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import AutoStoriesIcon from '@mui/icons-material/AutoStories'
 import CloudUploadIcon from '@mui/icons-material/CloudUpload'
 import ContentPasteIcon from '@mui/icons-material/ContentPaste'
@@ -25,6 +28,7 @@ import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile'
 import LinkIcon from '@mui/icons-material/Link'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import RouteIcon from '@mui/icons-material/Route'
+import CloseIcon from '@mui/icons-material/Close'
 import {
   getKnowledgeReferenceKindLabel,
   getKnowledgeReferenceTitle,
@@ -149,6 +153,33 @@ const openStudyLinkPicker = () => {
   window.dispatchEvent(new CustomEvent(OPEN_STUDY_LINK_PICKER_EVENT))
 }
 
+const editToggleSx = (theme: import('@mui/material/styles').Theme) => ({
+  '& .MuiToggleButton-root': {
+    color: 'text.primary',
+    borderColor: 'divider',
+    bgcolor:
+      theme.palette.mode === 'dark'
+        ? alpha(theme.palette.common.white, 0.08)
+        : alpha(theme.palette.common.black, 0.04),
+    fontWeight: 850,
+    textTransform: 'none',
+    '&:hover': {
+      bgcolor:
+        theme.palette.mode === 'dark'
+          ? alpha(theme.palette.common.white, 0.14)
+          : alpha(theme.palette.common.black, 0.08),
+    },
+    '&.Mui-selected': {
+      color: 'primary.contrastText',
+      bgcolor: 'primary.main',
+      borderColor: 'primary.dark',
+      '&:hover': {
+        bgcolor: 'primary.dark',
+      },
+    },
+  },
+})
+
 export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
   references = [],
   title = 'Study links',
@@ -249,6 +280,31 @@ export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
     )
     nextReferences.splice(Math.max(0, targetIndex), 0, sourceReference)
     updateWidgetOptions({ references: nextReferences })
+  }
+
+  const moveReferenceByIndex = (sourceIndex: number, targetIndex: number) => {
+    if (
+      sourceIndex < 0 ||
+      sourceIndex >= references.length ||
+      targetIndex < 0 ||
+      targetIndex >= references.length ||
+      sourceIndex === targetIndex
+    ) {
+      return
+    }
+
+    const nextReferences = [...references]
+    const [movedReference] = nextReferences.splice(sourceIndex, 1)
+    nextReferences.splice(targetIndex, 0, movedReference)
+    updateWidgetOptions({ references: nextReferences })
+  }
+
+  const removeReference = (referenceId: string) => {
+    updateWidgetOptions({
+      references: references.filter(
+        (reference) => reference.id !== referenceId,
+      ),
+    })
   }
 
   const sectionDragProps = (section: KnowledgeLinkWidgetSectionId) =>
@@ -410,52 +466,52 @@ export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
           >
             Add study link
           </Button>
-          <ToggleButtonGroup
-            size="small"
-            exclusive
-            value={columns}
-            onChange={handleColumnsChange}
-            aria-label="Study link columns per row"
-            sx={(theme) => ({
-              alignSelf: { xs: 'stretch', sm: 'flex-start' },
-              '& .MuiToggleButton-root': {
-                color: 'text.primary',
-                borderColor: 'divider',
-                bgcolor:
-                  theme.palette.mode === 'dark'
-                    ? alpha(theme.palette.common.white, 0.08)
-                    : alpha(theme.palette.common.black, 0.04),
-                fontWeight: 850,
-                minWidth: 38,
-                '&:hover': {
-                  bgcolor:
-                    theme.palette.mode === 'dark'
-                      ? alpha(theme.palette.common.white, 0.14)
-                      : alpha(theme.palette.common.black, 0.08),
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            <ToggleButtonGroup
+              size="small"
+              exclusive
+              value={columns}
+              onChange={handleColumnsChange}
+              aria-label="Study link columns per row"
+              sx={(theme) => ({
+                ...editToggleSx(theme),
+                '& .MuiToggleButton-root': {
+                  ...editToggleSx(theme)['& .MuiToggleButton-root'],
+                  minWidth: 38,
                 },
-                '&.Mui-selected': {
-                  color: 'primary.contrastText',
-                  bgcolor: 'primary.main',
-                  borderColor: 'primary.dark',
-                  '&:hover': {
-                    bgcolor: 'primary.dark',
-                  },
-                },
-              },
-            })}
-          >
-            {[1, 2, 3, 4].map((columnCount) => (
-              <ToggleButton
-                key={columnCount}
-                value={columnCount}
-                aria-label={`${columnCount} column${
-                  columnCount === 1 ? '' : 's'
-                } per row`}
-              >
-                {columnCount}
+              })}
+            >
+              {[1, 2, 3, 4].map((columnCount) => (
+                <ToggleButton
+                  key={columnCount}
+                  value={columnCount}
+                  aria-label={`${columnCount} column${
+                    columnCount === 1 ? '' : 's'
+                  } per row`}
+                >
+                  {columnCount}
+                </ToggleButton>
+              ))}
+            </ToggleButtonGroup>
+            <ToggleButtonGroup
+              size="small"
+              exclusive
+              value={cardSize}
+              onChange={handleCardSizeChange}
+              aria-label="Study link card size"
+              sx={editToggleSx}
+            >
+              <ToggleButton value="compact" aria-label="Compact cards">
+                Compact
               </ToggleButton>
-            ))}
-          </ToggleButtonGroup>
+              <ToggleButton value="standard" aria-label="Standard cards">
+                Standard
+              </ToggleButton>
+              <ToggleButton value="detailed" aria-label="Detailed cards">
+                Detailed
+              </ToggleButton>
+            </ToggleButtonGroup>
+          </Stack>
         </Stack>
       )}
       {editMode && (
@@ -495,7 +551,7 @@ export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
             mt: editMode ? 0.75 : 0,
           }}
         >
-          {references.map((reference) => (
+          {references.map((reference, referenceIndex) => (
             <ButtonBase
               key={reference.id}
               draggable={editMode}
@@ -611,6 +667,55 @@ export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
                         {getActionLabel(reference)}
                       </Typography>
                     )}
+                    {editMode && (
+                      <Stack
+                        direction="row"
+                        spacing={0.5}
+                        sx={{ mt: 1 }}
+                        onClick={(event) => event.stopPropagation()}
+                        onMouseDown={(event) => event.stopPropagation()}
+                      >
+                        <IconButton
+                          size="small"
+                          aria-label={`Move ${getKnowledgeReferenceTitle(
+                            reference,
+                          )} left`}
+                          disabled={referenceIndex === 0}
+                          onClick={() =>
+                            moveReferenceByIndex(
+                              referenceIndex,
+                              referenceIndex - 1,
+                            )
+                          }
+                        >
+                          <ArrowBackIcon fontSize="small" />
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          aria-label={`Move ${getKnowledgeReferenceTitle(
+                            reference,
+                          )} right`}
+                          disabled={referenceIndex === references.length - 1}
+                          onClick={() =>
+                            moveReferenceByIndex(
+                              referenceIndex,
+                              referenceIndex + 1,
+                            )
+                          }
+                        >
+                          <ArrowForwardIcon fontSize="small" />
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          aria-label={`Remove ${getKnowledgeReferenceTitle(
+                            reference,
+                          )}`}
+                          onClick={() => removeReference(reference.id)}
+                        >
+                          <CloseIcon fontSize="small" />
+                        </IconButton>
+                      </Stack>
+                    )}
                   </Box>
                 </Stack>
               </Box>
@@ -677,51 +782,6 @@ export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
               </Typography>
             )}
           </Box>
-          {editMode && (
-            <ToggleButtonGroup
-              size="small"
-              exclusive
-              value={cardSize}
-              onChange={handleCardSizeChange}
-              aria-label="Study link card size"
-              sx={(theme) => ({
-                '& .MuiToggleButton-root': {
-                  color: 'text.primary',
-                  borderColor: 'divider',
-                  bgcolor:
-                    theme.palette.mode === 'dark'
-                      ? alpha(theme.palette.common.white, 0.08)
-                      : alpha(theme.palette.common.black, 0.04),
-                  fontWeight: 800,
-                  textTransform: 'none',
-                  '&:hover': {
-                    bgcolor:
-                      theme.palette.mode === 'dark'
-                        ? alpha(theme.palette.common.white, 0.14)
-                        : alpha(theme.palette.common.black, 0.08),
-                  },
-                  '&.Mui-selected': {
-                    color: 'primary.contrastText',
-                    bgcolor: 'primary.main',
-                    borderColor: 'primary.dark',
-                    '&:hover': {
-                      bgcolor: 'primary.dark',
-                    },
-                  },
-                },
-              })}
-            >
-              <ToggleButton value="compact" aria-label="Compact cards">
-                Compact
-              </ToggleButton>
-              <ToggleButton value="standard" aria-label="Standard cards">
-                Standard
-              </ToggleButton>
-              <ToggleButton value="detailed" aria-label="Detailed cards">
-                Detailed
-              </ToggleButton>
-            </ToggleButtonGroup>
-          )}
         </Stack>
 
         {editMode && (

--- a/apps/studymesh/src/components/knowledge/KnowledgeLinkWidget.tsx
+++ b/apps/studymesh/src/components/knowledge/KnowledgeLinkWidget.tsx
@@ -180,6 +180,44 @@ const editToggleSx = (theme: import('@mui/material/styles').Theme) => ({
   },
 })
 
+const editIconButtonSx = (theme: import('@mui/material/styles').Theme) => ({
+  width: 30,
+  height: 30,
+  color: 'text.primary',
+  border: 1,
+  borderColor:
+    theme.palette.mode === 'dark'
+      ? alpha(theme.palette.common.white, 0.32)
+      : alpha(theme.palette.common.black, 0.28),
+  bgcolor:
+    theme.palette.mode === 'dark'
+      ? alpha(theme.palette.common.white, 0.12)
+      : alpha(theme.palette.common.white, 0.92),
+  boxShadow:
+    theme.palette.mode === 'dark'
+      ? `0 1px 0 ${alpha(theme.palette.common.white, 0.12)} inset`
+      : `0 1px 3px ${alpha(theme.palette.common.black, 0.12)}`,
+  '&:hover': {
+    color: 'primary.contrastText',
+    borderColor: 'primary.main',
+    bgcolor: 'primary.main',
+  },
+  '&.Mui-disabled': {
+    color:
+      theme.palette.mode === 'dark'
+        ? alpha(theme.palette.common.white, 0.34)
+        : alpha(theme.palette.common.black, 0.34),
+    borderColor:
+      theme.palette.mode === 'dark'
+        ? alpha(theme.palette.common.white, 0.14)
+        : alpha(theme.palette.common.black, 0.12),
+    bgcolor:
+      theme.palette.mode === 'dark'
+        ? alpha(theme.palette.common.white, 0.04)
+        : alpha(theme.palette.common.black, 0.04),
+  },
+})
+
 export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
   references = [],
   title = 'Study links',
@@ -194,6 +232,7 @@ export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
   const detailed = cardSize === 'detailed'
   const orderedSections = normalizeSectionOrder(sectionOrder)
   const [editingTitle, setEditingTitle] = React.useState(false)
+  const [displayTitle, setDisplayTitle] = React.useState(title)
   const [draftTitle, setDraftTitle] = React.useState(title)
   const [draggedSection, setDraggedSection] =
     React.useState<KnowledgeLinkWidgetSectionId | null>(null)
@@ -202,6 +241,7 @@ export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
   >(null)
 
   React.useEffect(() => {
+    setDisplayTitle(title)
     setDraftTitle(title)
   }, [title])
 
@@ -229,6 +269,7 @@ export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
 
   const commitTitle = () => {
     const nextTitle = draftTitle.trim() || 'Study links'
+    setDisplayTitle(nextTitle)
     setDraftTitle(nextTitle)
     setEditingTitle(false)
     if (nextTitle !== title) {
@@ -439,6 +480,157 @@ export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
       </Paper>
     ) : null
 
+  const renderReferenceCardContent = (
+    reference: KnowledgeReference,
+    referenceIndex: number,
+  ) => (
+    <Box
+      sx={(theme) => ({
+        p: compact ? 1 : 1.5,
+        border: 1,
+        borderColor: 'divider',
+        borderRadius: 1,
+        bgcolor:
+          theme.palette.mode === 'dark'
+            ? alpha(theme.palette.common.white, 0.04)
+            : alpha(theme.palette.primary.main, 0.035),
+        transition: 'border-color 120ms ease, background 120ms ease',
+        '&:hover': {
+          borderColor: 'primary.main',
+          bgcolor: alpha(theme.palette.primary.main, 0.1),
+        },
+      })}
+    >
+      <Stack direction="row" spacing={1.25} alignItems="flex-start">
+        <Box
+          sx={{
+            width: compact ? 28 : 32,
+            height: compact ? 28 : 32,
+            borderRadius: 1,
+            display: 'grid',
+            placeItems: 'center',
+            bgcolor: 'primary.main',
+            color: 'primary.contrastText',
+            flex: '0 0 auto',
+          }}
+        >
+          {getIcon(reference.target.type)}
+        </Box>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Stack
+            direction="row"
+            spacing={0.75}
+            alignItems="center"
+            sx={{ mb: 0.5, minWidth: 0 }}
+          >
+            <Typography
+              variant="subtitle2"
+              fontWeight={800}
+              noWrap
+              sx={{ minWidth: 0, flex: 1 }}
+            >
+              {getKnowledgeReferenceTitle(reference)}
+            </Typography>
+            {!compact && !editMode && (
+              <OpenInNewIcon
+                fontSize="small"
+                sx={{ color: 'text.secondary', flex: '0 0 auto' }}
+              />
+            )}
+          </Stack>
+          <Stack direction="row" spacing={0.75} alignItems="center">
+            <Chip
+              size="small"
+              label={getKnowledgeReferenceKindLabel(reference.target)}
+              sx={{ height: 22, fontWeight: 700 }}
+            />
+            {!compact && reference.target.subtitle && (
+              <Typography variant="caption" color="text.secondary" noWrap>
+                {reference.target.subtitle}
+              </Typography>
+            )}
+          </Stack>
+          {detailed && reference.description && (
+            <Typography variant="body2" color="text.secondary">
+              {reference.description}
+            </Typography>
+          )}
+          {!compact && !editMode && (
+            <Typography
+              variant="caption"
+              color="primary"
+              fontWeight={800}
+              sx={{ display: 'block', mt: 0.75 }}
+            >
+              {getActionLabel(reference)}
+            </Typography>
+          )}
+          {editMode && (
+            <Stack direction="row" spacing={0.5} sx={{ mt: 1 }}>
+              <IconButton
+                size="small"
+                aria-label={`Move ${getKnowledgeReferenceTitle(
+                  reference,
+                )} left`}
+                disabled={referenceIndex === 0}
+                onClick={() =>
+                  moveReferenceByIndex(referenceIndex, referenceIndex - 1)
+                }
+                sx={editIconButtonSx}
+              >
+                <ArrowBackIcon fontSize="small" />
+              </IconButton>
+              <IconButton
+                size="small"
+                aria-label={`Move ${getKnowledgeReferenceTitle(
+                  reference,
+                )} right`}
+                disabled={referenceIndex === references.length - 1}
+                onClick={() =>
+                  moveReferenceByIndex(referenceIndex, referenceIndex + 1)
+                }
+                sx={editIconButtonSx}
+              >
+                <ArrowForwardIcon fontSize="small" />
+              </IconButton>
+              <IconButton
+                size="small"
+                aria-label={`Remove ${getKnowledgeReferenceTitle(reference)}`}
+                onClick={() => removeReference(reference.id)}
+                sx={(theme) => ({
+                  ...editIconButtonSx(theme),
+                  '&:hover': {
+                    color: theme.palette.error.contrastText,
+                    borderColor: 'error.main',
+                    bgcolor: 'error.main',
+                  },
+                })}
+              >
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </Stack>
+          )}
+        </Box>
+      </Stack>
+    </Box>
+  )
+
+  const referenceDragProps = (referenceId: string) =>
+    editMode
+      ? {
+          draggable: true,
+          onDragStart: () => setDraggedReferenceId(referenceId),
+          onDragOver: (event: React.DragEvent) => {
+            event.preventDefault()
+          },
+          onDrop: () => {
+            moveReference(referenceId, draggedReferenceId)
+            setDraggedReferenceId(null)
+          },
+          onDragEnd: () => setDraggedReferenceId(null),
+        }
+      : {}
+
   const renderLinksSection = () => (
     <Box
       key="links"
@@ -551,176 +743,43 @@ export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
             mt: editMode ? 0.75 : 0,
           }}
         >
-          {references.map((reference, referenceIndex) => (
-            <ButtonBase
-              key={reference.id}
-              draggable={editMode}
-              onDragStart={() => setDraggedReferenceId(reference.id)}
-              onDragOver={(event) => {
-                if (editMode) {
-                  event.preventDefault()
-                }
-              }}
-              onDrop={() => {
-                if (editMode) {
-                  moveReference(reference.id, draggedReferenceId)
-                  setDraggedReferenceId(null)
-                }
-              }}
-              onDragEnd={() => setDraggedReferenceId(null)}
-              onClick={() => openReference(reference)}
-              sx={{
-                display: 'block',
-                width: '100%',
-                textAlign: 'left',
-                borderRadius: 1,
-                cursor: editMode ? 'grab' : 'pointer',
-                '&:focus-visible': {
-                  outline: '2px solid',
-                  outlineColor: 'primary.main',
-                  outlineOffset: 2,
-                },
-              }}
-            >
+          {references.map((reference, referenceIndex) =>
+            editMode ? (
               <Box
-                sx={(theme) => ({
-                  p: compact ? 1 : 1.5,
-                  border: 1,
-                  borderColor: 'divider',
+                key={reference.id}
+                data-testid={`study-link-card-${reference.id}`}
+                {...referenceDragProps(reference.id)}
+                sx={{
+                  width: '100%',
+                  minWidth: 0,
                   borderRadius: 1,
-                  bgcolor:
-                    theme.palette.mode === 'dark'
-                      ? alpha(theme.palette.common.white, 0.04)
-                      : alpha(theme.palette.primary.main, 0.035),
-                  transition: 'border-color 120ms ease, background 120ms ease',
-                  '&:hover': {
-                    borderColor: 'primary.main',
-                    bgcolor: alpha(theme.palette.primary.main, 0.1),
-                  },
-                })}
+                  cursor: 'grab',
+                }}
               >
-                <Stack direction="row" spacing={1.25} alignItems="flex-start">
-                  <Box
-                    sx={{
-                      width: compact ? 28 : 32,
-                      height: compact ? 28 : 32,
-                      borderRadius: 1,
-                      display: 'grid',
-                      placeItems: 'center',
-                      bgcolor: 'primary.main',
-                      color: 'primary.contrastText',
-                      flex: '0 0 auto',
-                    }}
-                  >
-                    {getIcon(reference.target.type)}
-                  </Box>
-                  <Box sx={{ minWidth: 0, flex: 1 }}>
-                    <Stack
-                      direction="row"
-                      spacing={0.75}
-                      alignItems="center"
-                      sx={{ mb: 0.5, minWidth: 0 }}
-                    >
-                      <Typography
-                        variant="subtitle2"
-                        fontWeight={800}
-                        noWrap
-                        sx={{ minWidth: 0, flex: 1 }}
-                      >
-                        {getKnowledgeReferenceTitle(reference)}
-                      </Typography>
-                      {!compact && (
-                        <OpenInNewIcon
-                          fontSize="small"
-                          sx={{ color: 'text.secondary', flex: '0 0 auto' }}
-                        />
-                      )}
-                    </Stack>
-                    <Stack direction="row" spacing={0.75} alignItems="center">
-                      <Chip
-                        size="small"
-                        label={getKnowledgeReferenceKindLabel(reference.target)}
-                        sx={{ height: 22, fontWeight: 700 }}
-                      />
-                      {!compact && reference.target.subtitle && (
-                        <Typography
-                          variant="caption"
-                          color="text.secondary"
-                          noWrap
-                        >
-                          {reference.target.subtitle}
-                        </Typography>
-                      )}
-                    </Stack>
-                    {detailed && reference.description && (
-                      <Typography variant="body2" color="text.secondary">
-                        {reference.description}
-                      </Typography>
-                    )}
-                    {!compact && (
-                      <Typography
-                        variant="caption"
-                        color="primary"
-                        fontWeight={800}
-                        sx={{ display: 'block', mt: 0.75 }}
-                      >
-                        {getActionLabel(reference)}
-                      </Typography>
-                    )}
-                    {editMode && (
-                      <Stack
-                        direction="row"
-                        spacing={0.5}
-                        sx={{ mt: 1 }}
-                        onClick={(event) => event.stopPropagation()}
-                        onMouseDown={(event) => event.stopPropagation()}
-                      >
-                        <IconButton
-                          size="small"
-                          aria-label={`Move ${getKnowledgeReferenceTitle(
-                            reference,
-                          )} left`}
-                          disabled={referenceIndex === 0}
-                          onClick={() =>
-                            moveReferenceByIndex(
-                              referenceIndex,
-                              referenceIndex - 1,
-                            )
-                          }
-                        >
-                          <ArrowBackIcon fontSize="small" />
-                        </IconButton>
-                        <IconButton
-                          size="small"
-                          aria-label={`Move ${getKnowledgeReferenceTitle(
-                            reference,
-                          )} right`}
-                          disabled={referenceIndex === references.length - 1}
-                          onClick={() =>
-                            moveReferenceByIndex(
-                              referenceIndex,
-                              referenceIndex + 1,
-                            )
-                          }
-                        >
-                          <ArrowForwardIcon fontSize="small" />
-                        </IconButton>
-                        <IconButton
-                          size="small"
-                          aria-label={`Remove ${getKnowledgeReferenceTitle(
-                            reference,
-                          )}`}
-                          onClick={() => removeReference(reference.id)}
-                        >
-                          <CloseIcon fontSize="small" />
-                        </IconButton>
-                      </Stack>
-                    )}
-                  </Box>
-                </Stack>
+                {renderReferenceCardContent(reference, referenceIndex)}
               </Box>
-            </ButtonBase>
-          ))}
+            ) : (
+              <ButtonBase
+                key={reference.id}
+                data-testid={`study-link-card-${reference.id}`}
+                onClick={() => openReference(reference)}
+                sx={{
+                  display: 'block',
+                  width: '100%',
+                  textAlign: 'left',
+                  borderRadius: 1,
+                  cursor: 'pointer',
+                  '&:focus-visible': {
+                    outline: '2px solid',
+                    outlineColor: 'primary.main',
+                    outlineOffset: 2,
+                  },
+                }}
+              >
+                {renderReferenceCardContent(reference, referenceIndex)}
+              </ButtonBase>
+            ),
+          )}
         </Box>
       )}
     </Box>
@@ -778,7 +837,7 @@ export const KnowledgeLinkWidget: React.FC<KnowledgeLinkWidgetProps> = ({
                 }}
                 sx={{ cursor: editMode ? 'text' : 'default' }}
               >
-                {title}
+                {displayTitle}
               </Typography>
             )}
           </Box>

--- a/apps/studymesh/src/components/knowledge/StudyLinkPicker.tsx
+++ b/apps/studymesh/src/components/knowledge/StudyLinkPicker.tsx
@@ -1,0 +1,222 @@
+import React, { useMemo, useState } from 'react'
+import {
+  Box,
+  ButtonBase,
+  Checkbox,
+  Chip,
+  Stack,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material'
+import AutoStoriesIcon from '@mui/icons-material/AutoStories'
+import DashboardIcon from '@mui/icons-material/Dashboard'
+import { KnowledgeReferenceTarget } from '../../knowledgeReferences'
+
+export type StudyLinkPickerTab = 'studyPaths' | 'sections' | 'dashboards'
+
+export interface StudyLinkPickerOption {
+  id: string
+  target: KnowledgeReferenceTarget
+  description?: string
+  parentTitle?: string
+}
+
+interface StudyLinkPickerProps {
+  options: StudyLinkPickerOption[]
+  selectedOptionIds: string[]
+  onSelectedOptionIdsChange: (optionIds: string[]) => void
+  initialTab?: StudyLinkPickerTab
+}
+
+const tabLabels: Record<StudyLinkPickerTab, string> = {
+  studyPaths: 'Study Paths',
+  sections: 'Sections',
+  dashboards: 'Dashboards',
+}
+
+const getOptionTab = (option: StudyLinkPickerOption): StudyLinkPickerTab => {
+  if (option.target.type === 'studyPath') {
+    return 'studyPaths'
+  }
+
+  if (option.target.type === 'studyPathSection') {
+    return 'sections'
+  }
+
+  return 'dashboards'
+}
+
+const getOptionIcon = (option: StudyLinkPickerOption) =>
+  option.target.type === 'dashboard' ? (
+    <DashboardIcon fontSize="small" />
+  ) : (
+    <AutoStoriesIcon fontSize="small" />
+  )
+
+export const StudyLinkPicker = ({
+  options,
+  selectedOptionIds,
+  onSelectedOptionIdsChange,
+  initialTab,
+}: StudyLinkPickerProps) => {
+  const selectedOption = options.find(
+    (option) => option.id === selectedOptionIds[0],
+  )
+  const [activeTab, setActiveTab] = useState<StudyLinkPickerTab>(
+    initialTab ||
+      (selectedOption ? getOptionTab(selectedOption) : 'studyPaths'),
+  )
+
+  const optionsByTab = useMemo(
+    () =>
+      options.reduce<Record<StudyLinkPickerTab, StudyLinkPickerOption[]>>(
+        (groups, option) => {
+          groups[getOptionTab(option)].push(option)
+          return groups
+        },
+        { studyPaths: [], sections: [], dashboards: [] },
+      ),
+    [options],
+  )
+
+  const visibleOptions = optionsByTab[activeTab]
+  const sectionGroups = useMemo(() => {
+    if (activeTab !== 'sections') {
+      return []
+    }
+
+    const groups = new Map<string, StudyLinkPickerOption[]>()
+    visibleOptions.forEach((option) => {
+      const parentTitle =
+        option.parentTitle || option.target.subtitle || 'Study Path'
+      groups.set(parentTitle, [...(groups.get(parentTitle) || []), option])
+    })
+    return Array.from(groups.entries())
+  }, [activeTab, visibleOptions])
+
+  const renderOption = (option: StudyLinkPickerOption) => {
+    const selected = selectedOptionIds.includes(option.id)
+
+    return (
+      <ButtonBase
+        key={option.id}
+        onClick={() => {
+          onSelectedOptionIdsChange(
+            selected
+              ? selectedOptionIds.filter((optionId) => optionId !== option.id)
+              : [...selectedOptionIds, option.id],
+          )
+        }}
+        sx={{
+          width: '100%',
+          display: 'block',
+          textAlign: 'left',
+          border: 1,
+          borderColor: selected ? 'primary.main' : 'divider',
+          borderRadius: 1,
+          p: 1.25,
+          bgcolor: selected ? 'action.selected' : 'background.paper',
+          '&:hover': {
+            borderColor: 'primary.main',
+            bgcolor: 'action.hover',
+          },
+          '&:focus-visible': {
+            outline: '2px solid',
+            outlineColor: 'primary.main',
+            outlineOffset: 2,
+          },
+        }}
+      >
+        <Stack direction="row" spacing={1} alignItems="flex-start">
+          <Box
+            sx={{
+              width: 30,
+              height: 30,
+              borderRadius: 1,
+              display: 'grid',
+              placeItems: 'center',
+              bgcolor: selected ? 'primary.main' : 'action.hover',
+              color: selected ? 'primary.contrastText' : 'text.secondary',
+              flex: '0 0 auto',
+            }}
+          >
+            {getOptionIcon(option)}
+          </Box>
+          <Box sx={{ minWidth: 0, flex: 1 }}>
+            <Typography variant="body2" fontWeight={850} noWrap>
+              {option.target.title}
+            </Typography>
+            {(option.description || option.target.subtitle) && (
+              <Typography variant="caption" color="text.secondary" noWrap>
+                {option.description || option.target.subtitle}
+              </Typography>
+            )}
+          </Box>
+          <Checkbox
+            checked={selected}
+            tabIndex={-1}
+            disableRipple
+            inputProps={{
+              'aria-label': selected
+                ? `Remove ${option.target.title}`
+                : `Select ${option.target.title}`,
+            }}
+            sx={{ p: 0.25, flex: '0 0 auto' }}
+          />
+        </Stack>
+      </ButtonBase>
+    )
+  }
+
+  return (
+    <Stack spacing={1.5}>
+      <Tabs
+        value={activeTab}
+        onChange={(_, value: StudyLinkPickerTab) => setActiveTab(value)}
+        variant="fullWidth"
+      >
+        {(Object.keys(tabLabels) as StudyLinkPickerTab[]).map((tab) => (
+          <Tab
+            key={tab}
+            value={tab}
+            label={`${tabLabels[tab]} (${optionsByTab[tab].length})`}
+            sx={{ textTransform: 'none', fontWeight: 800 }}
+          />
+        ))}
+      </Tabs>
+
+      {visibleOptions.length === 0 ? (
+        <Box
+          sx={{
+            border: 1,
+            borderColor: 'divider',
+            borderRadius: 1,
+            p: 2,
+            textAlign: 'center',
+            color: 'text.secondary',
+          }}
+        >
+          <Typography variant="body2">
+            No {tabLabels[activeTab].toLowerCase()} available.
+          </Typography>
+        </Box>
+      ) : activeTab === 'sections' ? (
+        <Stack spacing={1.25}>
+          {sectionGroups.map(([parentTitle, groupOptions]) => (
+            <Stack key={parentTitle} spacing={0.75}>
+              <Chip
+                label={parentTitle}
+                size="small"
+                sx={{ alignSelf: 'flex-start', fontWeight: 800 }}
+              />
+              {groupOptions.map(renderOption)}
+            </Stack>
+          ))}
+        </Stack>
+      ) : (
+        <Stack spacing={0.75}>{visibleOptions.map(renderOption)}</Stack>
+      )}
+    </Stack>
+  )
+}

--- a/apps/studymesh/src/knowledgeReferences.ts
+++ b/apps/studymesh/src/knowledgeReferences.ts
@@ -1,0 +1,343 @@
+import { DashboardLayout, StateDashboard } from './state/store'
+
+export type KnowledgeReferenceTargetType =
+  | 'dashboard'
+  | 'studyPath'
+  | 'studyPathSection'
+  | 'widget'
+  | 'note'
+  | 'source'
+
+export interface KnowledgeReferenceTarget {
+  type: KnowledgeReferenceTargetType
+  id: string
+  parentId?: string
+  title: string
+  subtitle?: string
+}
+
+export interface KnowledgeReference {
+  id: string
+  target: KnowledgeReferenceTarget
+  label?: string
+  description?: string
+  createdAt: string
+}
+
+export interface KnowledgeBacklink {
+  reference: KnowledgeReference
+  dashboardId: string
+  dashboardName: string
+  widgetName?: string
+}
+
+export type KnowledgeLinkWidgetCardSize = 'compact' | 'standard' | 'detailed'
+export type KnowledgeLinkWidgetSectionId = 'creation' | 'openMaterial' | 'links'
+export type KnowledgeLinkWidgetColumns = 1 | 2 | 3 | 4
+
+export interface KnowledgeLinkWidgetOptions {
+  title?: string
+  editMode?: boolean
+  cardSize?: KnowledgeLinkWidgetCardSize
+  columns?: KnowledgeLinkWidgetColumns
+  references?: KnowledgeReference[]
+  showCreationActions?: boolean
+  showOpenStudyMaterial?: boolean
+  sectionOrder?: KnowledgeLinkWidgetSectionId[]
+}
+
+export const OPEN_KNOWLEDGE_REFERENCE_EVENT =
+  'studymesh-open-knowledge-reference'
+export const UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT =
+  'studymesh-update-knowledge-link-widget'
+export const OPEN_STUDY_LINK_PICKER_EVENT = 'studymesh-open-study-link-picker'
+export const SAVE_KNOWLEDGE_LINK_DASHBOARD_AS_DEFAULT_EVENT =
+  'studymesh-save-knowledge-link-dashboard-as-default'
+export const RESET_DEFAULT_EMPTY_DASHBOARD_EVENT =
+  'studymesh-reset-default-empty-dashboard'
+
+export interface OpenKnowledgeReferenceEventDetail {
+  target: KnowledgeReferenceTarget
+}
+
+export interface UpdateKnowledgeLinkWidgetEventDetail {
+  options: KnowledgeLinkWidgetOptions
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+export const createKnowledgeReference = (
+  target: KnowledgeReferenceTarget,
+  options: {
+    label?: string
+    description?: string
+    createdAt?: string
+    id?: string
+  } = {},
+): KnowledgeReference => ({
+  id:
+    options.id ||
+    `knowledge-reference-${Date.now()}-${Math.floor(Math.random() * 100000)}`,
+  target,
+  label: options.label,
+  description: options.description,
+  createdAt: options.createdAt || new Date().toISOString(),
+})
+
+export const getKnowledgeReferenceTitle = (
+  reference: KnowledgeReference,
+): string => reference.label || reference.target.title
+
+export const getKnowledgeReferenceKindLabel = (
+  target: KnowledgeReferenceTarget,
+): string => {
+  if (target.type === 'studyPath') {
+    return 'Study Path'
+  }
+
+  if (target.type === 'studyPathSection') {
+    return 'Section'
+  }
+
+  if (target.type === 'dashboard') {
+    return 'Dashboard'
+  }
+
+  if (target.type === 'widget') {
+    return 'Widget'
+  }
+
+  if (target.type === 'source') {
+    return 'Source'
+  }
+
+  return 'Note'
+}
+
+export const createKnowledgeLinkWidgetLayout = (
+  references: KnowledgeReference[],
+  name = 'Study links',
+  options: KnowledgeLinkWidgetOptions = {},
+): DashboardLayout => ({
+  type: 'tab',
+  name,
+  component: 'KnowledgeLinkWidget',
+  config: {
+    customProps: {
+      references,
+      ...options,
+    },
+  },
+})
+
+export const appendKnowledgeLinkWidgetToLayout = (
+  layout: DashboardLayout | undefined,
+  references: KnowledgeReference[],
+  name = 'Study links',
+  options: KnowledgeLinkWidgetOptions = {},
+): DashboardLayout => {
+  const tab = createKnowledgeLinkWidgetLayout(references, name, options)
+
+  if (!layout?.children?.length) {
+    return {
+      type: 'row',
+      weight: 100,
+      children: [
+        {
+          type: 'tabset',
+          weight: 100,
+          active: true,
+          children: [tab],
+        },
+      ],
+    }
+  }
+
+  return {
+    ...layout,
+    children: [
+      ...(layout.children || []),
+      {
+        type: 'tabset',
+        weight: 100,
+        active: true,
+        children: [tab],
+      },
+    ],
+  }
+}
+
+export const appendReferencesToExistingKnowledgeWidget = (
+  layout: DashboardLayout | undefined,
+  references: KnowledgeReference[],
+): { layout: DashboardLayout | undefined; updated: boolean } => {
+  if (!layout) {
+    return { layout, updated: false }
+  }
+
+  if (layout.component === 'KnowledgeLinkWidget') {
+    const customProps = isRecord(layout.config?.customProps)
+      ? layout.config?.customProps
+      : {}
+    const existingReferences = Array.isArray(customProps.references)
+      ? customProps.references
+          .map(normalizeReference)
+          .filter((reference): reference is KnowledgeReference =>
+            Boolean(reference),
+          )
+      : []
+
+    return {
+      layout: {
+        ...layout,
+        config: {
+          ...layout.config,
+          customProps: {
+            ...customProps,
+            references: [...existingReferences, ...references],
+          },
+        },
+      },
+      updated: true,
+    }
+  }
+
+  if (!layout.children?.length) {
+    return { layout, updated: false }
+  }
+
+  let updated = false
+  const children = layout.children.map((child) => {
+    if (updated) {
+      return child
+    }
+
+    const result = appendReferencesToExistingKnowledgeWidget(child, references)
+    updated = result.updated
+    return result.layout || child
+  })
+
+  return {
+    layout: updated ? { ...layout, children } : layout,
+    updated,
+  }
+}
+
+export const addKnowledgeReferencesToLayout = (
+  layout: DashboardLayout | undefined,
+  references: KnowledgeReference[],
+  name = 'Study links',
+): DashboardLayout => {
+  const existingResult = appendReferencesToExistingKnowledgeWidget(
+    layout,
+    references,
+  )
+
+  if (existingResult.updated) {
+    return existingResult.layout as DashboardLayout
+  }
+
+  return appendKnowledgeLinkWidgetToLayout(layout, references, name)
+}
+
+const normalizeReference = (value: unknown): KnowledgeReference | null => {
+  if (!isRecord(value) || !isRecord(value.target)) {
+    return null
+  }
+
+  const target = value.target
+  const type = target.type
+  const id = target.id
+  const title = target.title
+
+  if (
+    typeof type !== 'string' ||
+    typeof id !== 'string' ||
+    typeof title !== 'string'
+  ) {
+    return null
+  }
+
+  return {
+    id: typeof value.id === 'string' ? value.id : `${type}:${id}`,
+    target: {
+      type: type as KnowledgeReferenceTargetType,
+      id,
+      parentId:
+        typeof target.parentId === 'string' ? target.parentId : undefined,
+      title,
+      subtitle:
+        typeof target.subtitle === 'string' ? target.subtitle : undefined,
+    },
+    label: typeof value.label === 'string' ? value.label : undefined,
+    description:
+      typeof value.description === 'string' ? value.description : undefined,
+    createdAt:
+      typeof value.createdAt === 'string'
+        ? value.createdAt
+        : new Date(0).toISOString(),
+  }
+}
+
+export const getKnowledgeReferencesFromLayout = (
+  layout?: DashboardLayout,
+): Array<{ reference: KnowledgeReference; widgetName?: string }> => {
+  if (!layout) {
+    return []
+  }
+
+  const customProps = isRecord(layout.config?.customProps)
+    ? layout.config?.customProps
+    : undefined
+  const references = Array.isArray(customProps?.references)
+    ? customProps.references
+        .map(normalizeReference)
+        .filter((reference): reference is KnowledgeReference =>
+          Boolean(reference),
+        )
+        .map((reference) => ({ reference, widgetName: layout.name }))
+    : []
+
+  return [
+    ...references,
+    ...(layout.children || []).flatMap((child) =>
+      getKnowledgeReferencesFromLayout(child),
+    ),
+  ]
+}
+
+export const targetMatchesKnowledgeReference = (
+  target: KnowledgeReferenceTarget,
+  reference: KnowledgeReference,
+): boolean => {
+  if (
+    target.type !== reference.target.type ||
+    target.id !== reference.target.id
+  ) {
+    return false
+  }
+
+  if (target.type === 'studyPathSection') {
+    return target.parentId === reference.target.parentId
+  }
+
+  return true
+}
+
+export const getKnowledgeBacklinks = (
+  dashboards: StateDashboard[],
+  target: KnowledgeReferenceTarget,
+): KnowledgeBacklink[] =>
+  dashboards.flatMap((dashboard) =>
+    getKnowledgeReferencesFromLayout(dashboard.layout)
+      .filter(({ reference }) =>
+        targetMatchesKnowledgeReference(target, reference),
+      )
+      .map(({ reference, widgetName }) => ({
+        reference,
+        dashboardId: dashboard.id,
+        dashboardName: dashboard.name,
+        widgetName,
+      })),
+  )

--- a/apps/studymesh/src/knowledgeReferences.ts
+++ b/apps/studymesh/src/knowledgeReferences.ts
@@ -123,6 +123,10 @@ export const createKnowledgeLinkWidgetLayout = (
   type: 'tab',
   name,
   component: 'KnowledgeLinkWidget',
+  className: 'studymesh-study-links-flex-tab',
+  enableClose: false,
+  enableDrag: false,
+  enableFloat: false,
   config: {
     customProps: {
       references,
@@ -143,11 +147,18 @@ export const appendKnowledgeLinkWidgetToLayout = (
     return {
       type: 'row',
       weight: 100,
+      enableDivide: false,
+      enableDrop: false,
       children: [
         {
           type: 'tabset',
           weight: 100,
           active: true,
+          classNameTabStrip: 'studymesh-study-links-flex-tabstrip',
+          enableDrop: false,
+          enableDivide: false,
+          enableMaximize: false,
+          enableClose: false,
           children: [tab],
         },
       ],
@@ -162,6 +173,11 @@ export const appendKnowledgeLinkWidgetToLayout = (
         type: 'tabset',
         weight: 100,
         active: true,
+        classNameTabStrip: 'studymesh-study-links-flex-tabstrip',
+        enableDrop: false,
+        enableDivide: false,
+        enableMaximize: false,
+        enableClose: false,
         children: [tab],
       },
     ],

--- a/apps/studymesh/src/moduleFederation/DynamicMicrofrontend.tsx
+++ b/apps/studymesh/src/moduleFederation/DynamicMicrofrontend.tsx
@@ -9,6 +9,13 @@ import ModuleLoader from './ModuleLoader'
 import WidgetEditor from '../components/WidgetEditor/WidgetEditor'
 import CustomWidget from '../components/WidgetEditor/CustomWidget'
 import WidgetStorage from '../components/WidgetEditor/WidgetStorage'
+import { KnowledgeLinkWidget } from '../components/knowledge/KnowledgeLinkWidget'
+import type {
+  KnowledgeLinkWidgetCardSize,
+  KnowledgeLinkWidgetColumns,
+  KnowledgeLinkWidgetSectionId,
+  KnowledgeReference,
+} from '../knowledgeReferences'
 
 // Define the ComponentData type
 interface ComponentData {
@@ -116,6 +123,39 @@ const DynamicMicrofrontend: React.FC<DynamicMicrofrontendProps> = (props) => {
           }
         }
         name={props.name}
+      />
+    )
+  }
+
+  if (props.component === 'KnowledgeLinkWidget') {
+    return (
+      <KnowledgeLinkWidget
+        references={
+          Array.isArray(props.customProps?.references)
+            ? (props.customProps.references as KnowledgeReference[])
+            : []
+        }
+        cardSize={
+          props.customProps?.cardSize as KnowledgeLinkWidgetCardSize | undefined
+        }
+        columns={
+          props.customProps?.columns as KnowledgeLinkWidgetColumns | undefined
+        }
+        title={
+          typeof props.customProps?.title === 'string'
+            ? props.customProps.title
+            : props.name
+        }
+        editMode={props.customProps?.editMode === true}
+        showCreationActions={props.customProps?.showCreationActions === true}
+        showOpenStudyMaterial={
+          props.customProps?.showOpenStudyMaterial === true
+        }
+        sectionOrder={
+          Array.isArray(props.customProps?.sectionOrder)
+            ? (props.customProps.sectionOrder as KnowledgeLinkWidgetSectionId[])
+            : undefined
+        }
       />
     )
   }

--- a/apps/studymesh/src/state/store.ts
+++ b/apps/studymesh/src/state/store.ts
@@ -52,9 +52,14 @@ export interface DashboardLayout {
   active?: boolean
   selected?: number
   weight?: number
+  className?: string
+  classNameTabStrip?: string
   enableDrag?: boolean
+  enableClose?: boolean
   enableDrop?: boolean
   enableDivide?: boolean
+  enableMaximize?: boolean
+  enableFloat?: boolean
   children?: DashboardLayout[]
 }
 

--- a/apps/studymesh/tests/unit/components/dashboard/Dashboard.test.tsx
+++ b/apps/studymesh/tests/unit/components/dashboard/Dashboard.test.tsx
@@ -205,7 +205,13 @@ describe('Dashboards', () => {
     render(<Dashboards />)
 
     expect(
-      screen.getByRole('heading', { name: /what do you want to build/i }),
+      screen.getByRole('heading', { name: /build an index dashboard/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/use this dashboard as an index page/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /add your first study link/i }),
     ).toBeInTheDocument()
     expect(
       screen.getByRole('heading', { name: /create study path/i }),
@@ -213,7 +219,6 @@ describe('Dashboards', () => {
     expect(
       screen.getByRole('heading', { name: /open study material/i }),
     ).toBeInTheDocument()
-    expect(screen.getByText(/fast creation from material/i)).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /create study path/i }),
     ).toBeInTheDocument()
@@ -224,18 +229,6 @@ describe('Dashboards', () => {
       screen.getByRole('button', { name: /paste notes/i }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /create quiz/i }),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: /create flashcards/i }),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: /expand on this/i }),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: /open existing dashboard/i }),
-    ).toBeInTheDocument()
-    expect(
       screen.queryByRole('button', { name: /advanced dashboard/i }),
     ).not.toBeInTheDocument()
     expect(
@@ -244,6 +237,188 @@ describe('Dashboards', () => {
     expect(
       screen.queryByRole('button', { name: /add saved widget/i }),
     ).not.toBeInTheDocument()
+  })
+
+  it('turns an empty dashboard into a configurable Study Links dashboard', () => {
+    const updateDashboardLayout = vi.fn()
+    mockDashboardProvider({ updateDashboardLayout })
+
+    render(<Dashboards />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /add your first study link/i }),
+    )
+
+    expect(updateDashboardLayout).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({
+        children: expect.arrayContaining([
+          expect.objectContaining({
+            children: expect.arrayContaining([
+              expect.objectContaining({
+                component: 'KnowledgeLinkWidget',
+                name: 'Study links',
+                config: expect.objectContaining({
+                  customProps: expect.objectContaining({
+                    cardSize: 'standard',
+                    showCreationActions: true,
+                    showOpenStudyMaterial: true,
+                  }),
+                }),
+              }),
+            ]),
+          }),
+        ]),
+      }),
+    )
+  })
+
+  it('reopens an existing customized empty dashboard from the first study link CTA', () => {
+    const replaceDashboard = vi.fn()
+    const updateDashboardLayout = vi.fn()
+    localStorage.getItem.mockImplementation((key: string) => {
+      if (key === 'userData') {
+        return JSON.stringify({
+          id: 'admin',
+          name: 'Admin User',
+          role: 'ADMIN_ROLE',
+        })
+      }
+
+      if (key === 'customDashboards') {
+        return JSON.stringify([
+          {
+            id: 'custom-empty-1',
+            name: 'My Study Links',
+            folder: 'Custom empty dashboards',
+            layout: {
+              type: 'row',
+              children: [
+                {
+                  type: 'tabset',
+                  children: [
+                    {
+                      type: 'tab',
+                      name: 'Study links',
+                      component: 'KnowledgeLinkWidget',
+                      config: {
+                        customProps: {
+                          references: [],
+                        },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+            createdAt: '2026-05-28T10:00:00.000Z',
+            updatedAt: '2026-05-28T10:00:00.000Z',
+          },
+        ])
+      }
+
+      return null
+    })
+    mockDashboardProvider({ replaceDashboard, updateDashboardLayout })
+
+    render(<Dashboards />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /add your first study link/i }),
+    )
+
+    expect(replaceDashboard).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({
+        name: 'My Study Links',
+      }),
+    )
+    expect(updateDashboardLayout).not.toHaveBeenCalled()
+    expect(
+      screen.queryByRole('dialog', {
+        name: /add study link to this dashboard/i,
+      }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('only shows Add study link on Study Links dashboards', () => {
+    mockDashboardProvider({
+      openDashboards: [
+        {
+          id: 'dash1',
+          name: 'Regular Dashboard',
+          layout: {
+            type: 'row',
+            children: [
+              {
+                type: 'tabset',
+                children: [
+                  {
+                    type: 'tab',
+                    name: 'Notes',
+                    component: 'CustomWidget',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    })
+
+    render(<Dashboards />)
+
+    expect(
+      screen.queryByRole('button', { name: /add study link/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('saves a Study Links dashboard as the default for new empty dashboards', () => {
+    mockDashboardProvider({
+      openDashboards: [
+        {
+          id: 'dash1',
+          name: 'My Start Dashboard',
+          layout: {
+            type: 'row',
+            children: [
+              {
+                type: 'tabset',
+                children: [
+                  {
+                    type: 'tab',
+                    name: 'Study links',
+                    component: 'KnowledgeLinkWidget',
+                    config: {
+                      customProps: {
+                        references: [],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    })
+
+    render(<Dashboards />)
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('studymesh-save-knowledge-link-dashboard-as-default'),
+      )
+    })
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'studymesh-default-empty-dashboard-id',
+      expect.stringMatching(/^custom-empty-dashboard-/),
+    )
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'customDashboards',
+      expect.stringContaining('Custom empty dashboards'),
+    )
   })
 
   it('opens the Study Path modal when the primary empty workspace action is used', () => {
@@ -297,36 +472,6 @@ describe('Dashboards', () => {
       intent: 'improvedNotes',
       openQuickOptions: true,
       quickSourceFocus: 'paste',
-    })
-
-    fireEvent.click(screen.getByRole('button', { name: /create quiz/i }))
-    expect(
-      createHubListener.mock.calls[createHubListener.mock.calls.length - 1][0]
-        .detail,
-    ).toEqual({
-      intent: 'quiz',
-      openQuickOptions: true,
-      quickSourceFocus: 'upload',
-    })
-
-    fireEvent.click(screen.getByRole('button', { name: /create flashcards/i }))
-    expect(
-      createHubListener.mock.calls[createHubListener.mock.calls.length - 1][0]
-        .detail,
-    ).toEqual({
-      intent: 'flashcards',
-      openQuickOptions: true,
-      quickSourceFocus: 'upload',
-    })
-
-    fireEvent.click(screen.getByRole('button', { name: /expand on this/i }))
-    expect(
-      createHubListener.mock.calls[createHubListener.mock.calls.length - 1][0]
-        .detail,
-    ).toEqual({
-      intent: 'improvedNotes',
-      openQuickOptions: true,
-      quickSourceFocus: 'upload',
     })
 
     window.removeEventListener('studymesh-open-create-hub', createHubListener)
@@ -396,7 +541,7 @@ describe('Dashboards', () => {
       screen.getByRole('button', { name: /paste notes/i }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /create quiz/i }),
+      screen.getByRole('button', { name: /add your first study link/i }),
     ).toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: /advanced dashboard/i }),

--- a/apps/studymesh/tests/unit/components/dashboard/Dashboard.test.tsx
+++ b/apps/studymesh/tests/unit/components/dashboard/Dashboard.test.tsx
@@ -333,6 +333,10 @@ describe('Dashboards', () => {
         name: 'My Study Links',
       }),
     )
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'studymesh-default-empty-dashboard-id',
+      'custom-empty-1',
+    )
     expect(updateDashboardLayout).not.toHaveBeenCalled()
     expect(
       screen.queryByRole('dialog', {
@@ -493,11 +497,9 @@ describe('Dashboards', () => {
   })
 
   it('restores the blank empty dashboard view immediately from a Study Links dashboard', () => {
-    const updateDashboardLayout = vi.fn()
-    const renameDashboard = vi.fn()
+    const closeAllDashboards = vi.fn()
     mockDashboardProvider({
-      updateDashboardLayout,
-      renameDashboard,
+      closeAllDashboards,
       openDashboards: [
         {
           id: 'dash1',
@@ -538,12 +540,7 @@ describe('Dashboards', () => {
     expect(localStorage.removeItem).toHaveBeenCalledWith(
       'studymesh-default-empty-dashboard-id',
     )
-    expect(updateDashboardLayout).toHaveBeenCalledWith(0, {
-      type: 'row',
-      weight: 100,
-      children: [],
-    })
-    expect(renameDashboard).toHaveBeenCalledWith('dash1', 'New Dashboard')
+    expect(closeAllDashboards).toHaveBeenCalledTimes(1)
   })
 
   it('opens the Study Path modal when the primary empty workspace action is used', () => {

--- a/apps/studymesh/tests/unit/components/dashboard/Dashboard.test.tsx
+++ b/apps/studymesh/tests/unit/components/dashboard/Dashboard.test.tsx
@@ -211,7 +211,7 @@ describe('Dashboards', () => {
       screen.getByText(/use this dashboard as an index page/i),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /add your first study link/i }),
+      screen.getByRole('button', { name: /build your index dashboard/i }),
     ).toBeInTheDocument()
     expect(
       screen.getByRole('heading', { name: /create study path/i }),
@@ -246,7 +246,7 @@ describe('Dashboards', () => {
     render(<Dashboards />)
 
     fireEvent.click(
-      screen.getByRole('button', { name: /add your first study link/i }),
+      screen.getByRole('button', { name: /build your index dashboard/i }),
     )
 
     expect(updateDashboardLayout).toHaveBeenCalledWith(
@@ -324,7 +324,7 @@ describe('Dashboards', () => {
     render(<Dashboards />)
 
     fireEvent.click(
-      screen.getByRole('button', { name: /add your first study link/i }),
+      screen.getByRole('button', { name: /use your index dashboard/i }),
     )
 
     expect(replaceDashboard).toHaveBeenCalledWith(
@@ -419,6 +419,131 @@ describe('Dashboards', () => {
       'customDashboards',
       expect.stringContaining('Custom empty dashboards'),
     )
+  })
+
+  it('uses the edited Study Links title as the dashboard name', () => {
+    const updateDashboardLayout = vi.fn()
+    const renameDashboard = vi.fn()
+    mockDashboardProvider({
+      updateDashboardLayout,
+      renameDashboard,
+      openDashboards: [
+        {
+          id: 'dash1',
+          name: 'Dashboard',
+          layout: {
+            type: 'row',
+            children: [
+              {
+                type: 'tabset',
+                children: [
+                  {
+                    type: 'tab',
+                    name: 'Study links',
+                    component: 'KnowledgeLinkWidget',
+                    config: {
+                      customProps: {
+                        title: 'Study links',
+                        references: [],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    })
+
+    render(<Dashboards />)
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('studymesh-update-knowledge-link-widget', {
+          detail: { options: { title: 'My Exam Index' } },
+        }),
+      )
+    })
+
+    expect(renameDashboard).toHaveBeenCalledWith('dash1', 'My Exam Index')
+    expect(updateDashboardLayout).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({
+        children: expect.arrayContaining([
+          expect.objectContaining({
+            children: expect.arrayContaining([
+              expect.objectContaining({
+                name: 'My Exam Index',
+                config: expect.objectContaining({
+                  customProps: expect.objectContaining({
+                    title: 'My Exam Index',
+                  }),
+                }),
+              }),
+            ]),
+          }),
+        ]),
+      }),
+    )
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'customDashboards',
+      expect.stringContaining('My Exam Index'),
+    )
+  })
+
+  it('restores the blank empty dashboard view immediately from a Study Links dashboard', () => {
+    const updateDashboardLayout = vi.fn()
+    const renameDashboard = vi.fn()
+    mockDashboardProvider({
+      updateDashboardLayout,
+      renameDashboard,
+      openDashboards: [
+        {
+          id: 'dash1',
+          name: 'My Exam Index',
+          layout: {
+            type: 'row',
+            children: [
+              {
+                type: 'tabset',
+                children: [
+                  {
+                    type: 'tab',
+                    name: 'My Exam Index',
+                    component: 'KnowledgeLinkWidget',
+                    config: {
+                      customProps: {
+                        title: 'My Exam Index',
+                        references: [],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    })
+
+    render(<Dashboards />)
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('studymesh-reset-default-empty-dashboard'),
+      )
+    })
+
+    expect(localStorage.removeItem).toHaveBeenCalledWith(
+      'studymesh-default-empty-dashboard-id',
+    )
+    expect(updateDashboardLayout).toHaveBeenCalledWith(0, {
+      type: 'row',
+      weight: 100,
+      children: [],
+    })
+    expect(renameDashboard).toHaveBeenCalledWith('dash1', 'New Dashboard')
   })
 
   it('opens the Study Path modal when the primary empty workspace action is used', () => {
@@ -541,7 +666,7 @@ describe('Dashboards', () => {
       screen.getByRole('button', { name: /paste notes/i }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: /add your first study link/i }),
+      screen.getByRole('button', { name: /build your index dashboard/i }),
     ).toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: /advanced dashboard/i }),

--- a/apps/studymesh/tests/unit/components/dashboard/Dashboard.test.tsx
+++ b/apps/studymesh/tests/unit/components/dashboard/Dashboard.test.tsx
@@ -377,6 +377,81 @@ describe('Dashboards', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('closes the Study Links dashboard when opening one of its dashboard links', () => {
+    const removeDashboard = vi.fn()
+    const setSelectedDashboard = vi.fn()
+    mockDashboardProvider({
+      removeDashboard,
+      setSelectedDashboard,
+      openDashboards: [
+        {
+          id: 'index-dashboard',
+          name: 'My Index',
+          layout: {
+            type: 'row',
+            children: [
+              {
+                type: 'tabset',
+                children: [
+                  {
+                    type: 'tab',
+                    name: 'My Index',
+                    component: 'KnowledgeLinkWidget',
+                    config: {
+                      customProps: {
+                        title: 'My Index',
+                        references: [],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          id: 'target-dashboard',
+          name: 'Exam Dashboard',
+          layout: {
+            type: 'row',
+            children: [
+              {
+                type: 'tabset',
+                children: [
+                  {
+                    type: 'tab',
+                    name: 'Notes',
+                    component: 'CustomWidget',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+      selectedDashboard: 0,
+    })
+
+    render(<Dashboards />)
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('studymesh-open-knowledge-reference', {
+          detail: {
+            target: {
+              type: 'dashboard',
+              id: 'target-dashboard',
+              title: 'Exam Dashboard',
+            },
+          },
+        }),
+      )
+    })
+
+    expect(removeDashboard).toHaveBeenCalledWith('index-dashboard')
+    expect(setSelectedDashboard).toHaveBeenCalledWith(0)
+  })
+
   it('saves a Study Links dashboard as the default for new empty dashboards', () => {
     mockDashboardProvider({
       openDashboards: [

--- a/apps/studymesh/tests/unit/components/knowledge/KnowledgeLinkWidget.test.tsx
+++ b/apps/studymesh/tests/unit/components/knowledge/KnowledgeLinkWidget.test.tsx
@@ -70,6 +70,11 @@ describe('KnowledgeLinkWidget', () => {
       showOpenStudyMaterial: true,
     })
 
+    fireEvent.click(screen.getByRole('button', { name: /3 columns per row/i }))
+    expect(listener.mock.calls[3][0].detail.options).toEqual({
+      columns: 3,
+    })
+
     window.removeEventListener(UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT, listener)
   })
 

--- a/apps/studymesh/tests/unit/components/knowledge/KnowledgeLinkWidget.test.tsx
+++ b/apps/studymesh/tests/unit/components/knowledge/KnowledgeLinkWidget.test.tsx
@@ -92,6 +92,28 @@ describe('KnowledgeLinkWidget', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('shows the committed title immediately after renaming', () => {
+    const listener = vi.fn()
+    window.addEventListener(UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT, listener)
+
+    render(<KnowledgeLinkWidget references={[]} editMode />)
+
+    fireEvent.click(screen.getByText('Study links'))
+    const titleInput = screen.getByRole('textbox', {
+      name: /study links dashboard name/i,
+    })
+    fireEvent.change(titleInput, { target: { value: 'My Exam Index' } })
+    fireEvent.blur(titleInput)
+
+    expect(screen.getByText('My Exam Index')).toBeInTheDocument()
+    expect(screen.queryByText('Study links')).not.toBeInTheDocument()
+    expect(listener.mock.calls.at(-1)?.[0].detail.options).toEqual({
+      title: 'My Exam Index',
+    })
+
+    window.removeEventListener(UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT, listener)
+  })
+
   it('reorders study link cards in edit mode', () => {
     const listener = vi.fn()
     window.addEventListener(UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT, listener)
@@ -122,8 +144,8 @@ describe('KnowledgeLinkWidget', () => {
       />,
     )
 
-    fireEvent.dragStart(screen.getByRole('button', { name: /exam dashboard/i }))
-    fireEvent.drop(screen.getByRole('button', { name: /biology/i }))
+    fireEvent.dragStart(screen.getByTestId('study-link-card-ref-2'))
+    fireEvent.drop(screen.getByTestId('study-link-card-ref-1'))
 
     expect(listener).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -140,6 +162,51 @@ describe('KnowledgeLinkWidget', () => {
     expect(
       listener.mock.calls.at(-1)?.[0].detail.options.references[0].id,
     ).toBe('ref-2')
+
+    window.removeEventListener(UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT, listener)
+  })
+
+  it('moves and removes study links with edit controls', () => {
+    const listener = vi.fn()
+    window.addEventListener(UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT, listener)
+
+    render(
+      <KnowledgeLinkWidget
+        editMode
+        references={[
+          {
+            id: 'ref-1',
+            target: {
+              type: 'studyPath',
+              id: 'path-1',
+              title: 'Biology',
+            },
+            createdAt: '2026-05-28T10:00:00.000Z',
+          },
+          {
+            id: 'ref-2',
+            target: {
+              type: 'dashboard',
+              id: 'dashboard-1',
+              title: 'Exam dashboard',
+            },
+            createdAt: '2026-05-28T10:01:00.000Z',
+          },
+        ]}
+      />,
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /move exam dashboard left/i }),
+    )
+    expect(
+      listener.mock.calls.at(-1)?.[0].detail.options.references[0].id,
+    ).toBe('ref-2')
+
+    fireEvent.click(screen.getByRole('button', { name: /remove biology/i }))
+    expect(listener.mock.calls.at(-1)?.[0].detail.options.references).toEqual([
+      expect.objectContaining({ id: 'ref-2' }),
+    ])
 
     window.removeEventListener(UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT, listener)
   })

--- a/apps/studymesh/tests/unit/components/knowledge/KnowledgeLinkWidget.test.tsx
+++ b/apps/studymesh/tests/unit/components/knowledge/KnowledgeLinkWidget.test.tsx
@@ -100,7 +100,9 @@ describe('KnowledgeLinkWidget', () => {
     const listener = vi.fn()
     window.addEventListener(UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT, listener)
 
-    render(<KnowledgeLinkWidget references={[]} editMode />)
+    const { rerender } = render(
+      <KnowledgeLinkWidget references={[]} editMode />,
+    )
 
     fireEvent.click(screen.getByText('Study links'))
     const titleInput = screen.getByRole('textbox', {
@@ -114,6 +116,15 @@ describe('KnowledgeLinkWidget', () => {
     expect(listener.mock.calls.at(-1)?.[0].detail.options).toEqual({
       title: 'My Exam Index',
     })
+
+    rerender(<KnowledgeLinkWidget references={[]} editMode />)
+    expect(screen.getByText('My Exam Index')).toBeInTheDocument()
+    expect(screen.queryByText('Study links')).not.toBeInTheDocument()
+
+    rerender(
+      <KnowledgeLinkWidget references={[]} editMode title="My Exam Index" />,
+    )
+    expect(screen.getByText('My Exam Index')).toBeInTheDocument()
 
     window.removeEventListener(UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT, listener)
   })

--- a/apps/studymesh/tests/unit/components/knowledge/KnowledgeLinkWidget.test.tsx
+++ b/apps/studymesh/tests/unit/components/knowledge/KnowledgeLinkWidget.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { KnowledgeLinkWidget } from '../../../../src/components/knowledge/KnowledgeLinkWidget'
+import {
+  OPEN_KNOWLEDGE_REFERENCE_EVENT,
+  UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT,
+} from '../../../../src/knowledgeReferences'
+
+describe('KnowledgeLinkWidget', () => {
+  it('renders references and dispatches open events', () => {
+    const listener = vi.fn()
+    window.addEventListener(OPEN_KNOWLEDGE_REFERENCE_EVENT, listener)
+
+    render(
+      <KnowledgeLinkWidget
+        cardSize="detailed"
+        references={[
+          {
+            id: 'ref-1',
+            target: {
+              type: 'studyPath',
+              id: 'path-1',
+              title: 'Machine Learning',
+              subtitle: '4 sections',
+            },
+            description: 'Main tutorial path',
+            createdAt: '2026-05-28T10:00:00.000Z',
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('Machine Learning')).toBeInTheDocument()
+    expect(screen.getByText('Study Path')).toBeInTheDocument()
+    expect(screen.getByText('Main tutorial path')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Machine Learning'))
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0][0].detail.target).toEqual({
+      type: 'studyPath',
+      id: 'path-1',
+      title: 'Machine Learning',
+      subtitle: '4 sections',
+    })
+
+    window.removeEventListener(OPEN_KNOWLEDGE_REFERENCE_EVENT, listener)
+  })
+
+  it('dispatches settings updates for card size and empty-dashboard panels', () => {
+    const listener = vi.fn()
+    window.addEventListener(UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT, listener)
+
+    render(<KnowledgeLinkWidget references={[]} editMode />)
+
+    fireEvent.click(screen.getByRole('button', { name: /compact cards/i }))
+    expect(listener.mock.calls[0][0].detail.options).toEqual({
+      cardSize: 'compact',
+    })
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /creation/i }))
+    expect(listener.mock.calls[1][0].detail.options).toEqual({
+      showCreationActions: true,
+    })
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /open material/i }))
+    expect(listener.mock.calls[2][0].detail.options).toEqual({
+      showOpenStudyMaterial: true,
+    })
+
+    window.removeEventListener(UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT, listener)
+  })
+
+  it('hides configuration controls in view mode', () => {
+    render(<KnowledgeLinkWidget references={[]} />)
+
+    expect(
+      screen.queryByRole('button', { name: /compact cards/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('checkbox', { name: /creation/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /use for new dashboards/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('reorders study link cards in edit mode', () => {
+    const listener = vi.fn()
+    window.addEventListener(UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT, listener)
+
+    render(
+      <KnowledgeLinkWidget
+        editMode
+        references={[
+          {
+            id: 'ref-1',
+            target: {
+              type: 'studyPath',
+              id: 'path-1',
+              title: 'Biology',
+            },
+            createdAt: '2026-05-28T10:00:00.000Z',
+          },
+          {
+            id: 'ref-2',
+            target: {
+              type: 'dashboard',
+              id: 'dashboard-1',
+              title: 'Exam dashboard',
+            },
+            createdAt: '2026-05-28T10:01:00.000Z',
+          },
+        ]}
+      />,
+    )
+
+    fireEvent.dragStart(screen.getByRole('button', { name: /exam dashboard/i }))
+    fireEvent.drop(screen.getByRole('button', { name: /biology/i }))
+
+    expect(listener).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({
+          options: expect.objectContaining({
+            references: expect.arrayContaining([
+              expect.objectContaining({ id: 'ref-2' }),
+              expect.objectContaining({ id: 'ref-1' }),
+            ]),
+          }),
+        }),
+      }),
+    )
+    expect(
+      listener.mock.calls.at(-1)?.[0].detail.options.references[0].id,
+    ).toBe('ref-2')
+
+    window.removeEventListener(UPDATE_KNOWLEDGE_LINK_WIDGET_EVENT, listener)
+  })
+})

--- a/apps/studymesh/tests/unit/components/knowledge/KnowledgeLinkWidget.test.tsx
+++ b/apps/studymesh/tests/unit/components/knowledge/KnowledgeLinkWidget.test.tsx
@@ -55,6 +55,10 @@ describe('KnowledgeLinkWidget', () => {
 
     render(<KnowledgeLinkWidget references={[]} editMode />)
 
+    expect(
+      screen.queryByRole('button', { name: /use for new dashboards/i }),
+    ).not.toBeInTheDocument()
+
     fireEvent.click(screen.getByRole('button', { name: /compact cards/i }))
     expect(listener.mock.calls[0][0].detail.options).toEqual({
       cardSize: 'compact',

--- a/apps/studymesh/tests/unit/components/knowledge/StudyLinkPicker.test.tsx
+++ b/apps/studymesh/tests/unit/components/knowledge/StudyLinkPicker.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  StudyLinkPicker,
+  StudyLinkPickerOption,
+} from '../../../../src/components/knowledge/StudyLinkPicker'
+
+const options: StudyLinkPickerOption[] = [
+  {
+    id: 'studyPath||path-1',
+    target: {
+      type: 'studyPath',
+      id: 'path-1',
+      title: 'Biology Path',
+      subtitle: '2 sections',
+    },
+  },
+  {
+    id: 'studyPathSection|path-1|section-1',
+    target: {
+      type: 'studyPathSection',
+      id: 'section-1',
+      parentId: 'path-1',
+      title: 'Cell division',
+      subtitle: 'Biology Path',
+    },
+    parentTitle: 'Biology Path',
+  },
+  {
+    id: 'dashboard||dashboard-2',
+    target: {
+      type: 'dashboard',
+      id: 'dashboard-2',
+      title: 'Exam Index',
+    },
+  },
+]
+
+describe('StudyLinkPicker', () => {
+  it('keeps Study Paths, sections, and dashboards in separate tabs', () => {
+    render(
+      <StudyLinkPicker
+        options={options}
+        selectedOptionIds={['studyPath||path-1']}
+        onSelectedOptionIdsChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Biology Path')).toBeInTheDocument()
+    expect(screen.queryByText('Cell division')).not.toBeInTheDocument()
+    expect(screen.queryByText('Exam Index')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('tab', { name: /sections/i }))
+    expect(screen.getByText('Cell division')).toBeInTheDocument()
+    expect(screen.getAllByText('Biology Path')).toHaveLength(2)
+    expect(screen.queryByText('Exam Index')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('tab', { name: /dashboards/i }))
+    expect(screen.getByText('Exam Index')).toBeInTheDocument()
+    expect(screen.queryByText('Cell division')).not.toBeInTheDocument()
+  })
+
+  it('selects multiple requested options', () => {
+    const onSelectedOptionIdsChange = vi.fn()
+    render(
+      <StudyLinkPicker
+        options={options}
+        selectedOptionIds={['studyPath||path-1']}
+        onSelectedOptionIdsChange={onSelectedOptionIdsChange}
+        initialTab="dashboards"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /exam index/i }))
+
+    expect(onSelectedOptionIdsChange).toHaveBeenCalledWith([
+      'studyPath||path-1',
+      'dashboard||dashboard-2',
+    ])
+  })
+})

--- a/apps/studymesh/tests/unit/dashboard/studyPathUx.test.tsx
+++ b/apps/studymesh/tests/unit/dashboard/studyPathUx.test.tsx
@@ -125,6 +125,7 @@ const StateProbe = () => {
   const {
     openDashboards,
     selectedDashboard,
+    addDashboard,
     addStudyPathContainer,
     updateStudyPathContainer,
   } = useDashboards()
@@ -135,6 +136,7 @@ const StateProbe = () => {
       <button onClick={() => addStudyPathContainer(createStudyPath())}>
         open-study-path
       </button>
+      <button onClick={() => addDashboard()}>open-empty-dashboard</button>
       <button
         onClick={() => {
           const studyPathDashboard = openDashboards.find(
@@ -159,6 +161,9 @@ const StateProbe = () => {
       </output>
       <output data-testid="dashboard-names">
         {openDashboards.map((dashboard) => dashboard.name).join('|')}
+      </output>
+      <output data-testid="selected-component">
+        {selected?.layout?.children?.[0]?.children?.[0]?.component || 'none'}
       </output>
     </div>
   )
@@ -199,6 +204,54 @@ describe('Interactive Study Path UX', () => {
     expect(screen.getByTestId('selected-lesson')).toHaveTextContent('3')
   })
 
+  it('uses the saved custom empty dashboard when opening a new empty dashboard', () => {
+    const storage = createMemoryStorage()
+    storage.set(
+      'customDashboards',
+      JSON.stringify([
+        {
+          id: 'default-start-dashboard',
+          name: 'Study links start',
+          folder: 'Custom empty dashboards',
+          layout: {
+            type: 'row',
+            children: [
+              {
+                type: 'tabset',
+                children: [
+                  {
+                    type: 'tab',
+                    name: 'Study links',
+                    component: 'KnowledgeLinkWidget',
+                  },
+                ],
+              },
+            ],
+          },
+          createdAt: '2026-05-28T10:00:00.000Z',
+          updatedAt: '2026-05-28T10:00:00.000Z',
+        },
+      ]),
+    )
+    storage.set(
+      'studymesh-default-empty-dashboard-id',
+      'default-start-dashboard',
+    )
+
+    renderWithDashboardProvider(<StateProbe />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'open-empty-dashboard' }),
+    )
+
+    expect(screen.getByTestId('dashboard-names')).toHaveTextContent(
+      'Existing dashboard|Study links start',
+    )
+    expect(screen.getByTestId('selected-component')).toHaveTextContent(
+      'KnowledgeLinkWidget',
+    )
+  })
+
   it('uses a subtle floating navigator that overlays the dashboard and can be collapsed', () => {
     const onStudyPathChange = vi.fn()
 
@@ -236,8 +289,12 @@ describe('Interactive Study Path UX', () => {
     expect(screen.getByText('Course helper')).toBeInTheDocument()
     expect(screen.getByText('0/5 completed')).toBeInTheDocument()
     expect(screen.getByText('Lesson 1/5')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /dock left/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /dock right/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /dock left/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /dock right/i }),
+    ).toBeInTheDocument()
     expect(
       screen.getByTestId('mock-selected-widget-border'),
     ).toBeInTheDocument()
@@ -250,6 +307,26 @@ describe('Interactive Study Path UX', () => {
       screen.queryByTestId('study-path-navigator-panel'),
     ).not.toBeInTheDocument()
     expect(screen.getByTestId('study-path-navigator-pill')).toBeInTheDocument()
+  })
+
+  it('keeps Study Links out of the Course helper navigator', () => {
+    render(
+      <StudyPathWorkspaceView
+        studyPath={createStudyPath()}
+        onStudyPathChange={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /open course navigator/i }),
+    )
+
+    expect(
+      screen.queryByRole('button', { name: /add to index dashboard/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /add section to index/i }),
+    ).not.toBeInTheDocument()
   })
 
   it('keeps Study Paths dropdown actions focused and opens lessons as standalone tabs', async () => {

--- a/apps/studymesh/tests/unit/knowledgeReferences.test.ts
+++ b/apps/studymesh/tests/unit/knowledgeReferences.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  addKnowledgeReferencesToLayout,
+  appendKnowledgeLinkWidgetToLayout,
+  createKnowledgeReference,
+  getKnowledgeBacklinks,
+  getKnowledgeReferencesFromLayout,
+} from '../../src/knowledgeReferences'
+import type { StateDashboard } from '../../src/state/store'
+
+describe('knowledge references', () => {
+  it('creates and serializes a Study Path reference', () => {
+    const reference = createKnowledgeReference(
+      {
+        type: 'studyPath',
+        id: 'path-1',
+        title: 'Biology Year 1',
+      },
+      {
+        id: 'ref-1',
+        label: 'Biology index',
+        createdAt: '2026-05-28T10:00:00.000Z',
+      },
+    )
+
+    expect(JSON.parse(JSON.stringify(reference))).toEqual({
+      id: 'ref-1',
+      target: {
+        type: 'studyPath',
+        id: 'path-1',
+        title: 'Biology Year 1',
+      },
+      label: 'Biology index',
+      createdAt: '2026-05-28T10:00:00.000Z',
+    })
+  })
+
+  it('adds link widgets to dashboard layouts and derives backlinks', () => {
+    const sectionReference = createKnowledgeReference(
+      {
+        type: 'studyPathSection',
+        id: 'lesson-2',
+        parentId: 'path-1',
+        title: 'Cell division',
+      },
+      { id: 'section-ref', createdAt: '2026-05-28T10:00:00.000Z' },
+    )
+    const layout = appendKnowledgeLinkWidgetToLayout(
+      { type: 'row', children: [] },
+      [sectionReference],
+      'Cell division',
+    )
+    const dashboards: StateDashboard[] = [
+      {
+        id: 'dashboard-1',
+        name: 'Exam Prep',
+        layout,
+      },
+    ]
+
+    expect(getKnowledgeReferencesFromLayout(layout)).toHaveLength(1)
+    expect(
+      getKnowledgeBacklinks(dashboards, {
+        type: 'studyPathSection',
+        id: 'lesson-2',
+        parentId: 'path-1',
+        title: 'Cell division',
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        dashboardId: 'dashboard-1',
+        dashboardName: 'Exam Prep',
+        widgetName: 'Cell division',
+      }),
+    ])
+  })
+
+  it('appends references to an existing knowledge widget on index dashboards', () => {
+    const firstReference = createKnowledgeReference(
+      {
+        type: 'studyPath',
+        id: 'path-1',
+        title: 'Machine Learning',
+      },
+      { id: 'ref-1', createdAt: '2026-05-28T10:00:00.000Z' },
+    )
+    const secondReference = createKnowledgeReference(
+      {
+        type: 'studyPath',
+        id: 'path-2',
+        title: 'Statistics',
+      },
+      { id: 'ref-2', createdAt: '2026-05-28T10:01:00.000Z' },
+    )
+
+    const layout = addKnowledgeReferencesToLayout(undefined, [firstReference])
+    const updatedLayout = addKnowledgeReferencesToLayout(layout, [
+      secondReference,
+    ])
+
+    expect(
+      getKnowledgeReferencesFromLayout(updatedLayout).map(
+        ({ reference }) => reference.target.title,
+      ),
+    ).toEqual(['Machine Learning', 'Statistics'])
+  })
+})


### PR DESCRIPTION
Add customizable empty dsahboard with study links. 

How it looks right now (a bit ugly):
<img width="1899" height="831" alt="image" src="https://github.com/user-attachments/assets/3fe959f3-82a9-44d3-ad1b-05378fe5c1e6" />

<img width="1908" height="822" alt="image" src="https://github.com/user-attachments/assets/d7a9eb63-47a0-4a2a-9192-cc41987978d2" />
