### PR TITLE
StudyMesh: 3-section creation panel with persistent sources

### DIFF
--- a/apps/studymesh/src/components/workspace/CreationPanelTabs.tsx
+++ b/apps/studymesh/src/components/workspace/CreationPanelTabs.tsx
@@ -1,0 +1,214 @@
+import React from 'react'
+import {
+  Box,
+  Button,
+  IconButton,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material'
+import { alpha } from '@mui/material/styles'
+import DeleteIcon from '@mui/icons-material/Delete'
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import BoltIcon from '@mui/icons-material/Bolt'
+import {
+  getPersistentSourceLabel,
+  PersistentSource,
+} from '../../studyPack/persistentSources'
+
+interface CreationPanelTabsProps {
+  creationActiveSection: 'dashboard' | 'sources' | 'study-path'
+  setCreationActiveSection: (section: 'dashboard' | 'sources' | 'study-path') => void
+  // Study Path content (passed as render prop to avoid moving 1400+ lines)
+  studyPathContent: React.ReactNode
+  // Quick options state
+  quickOptionsOpen: boolean
+  onOpenQuickOptions: () => void
+  onCloseQuickOptions: () => void
+  // Sources state
+  persistentSources: PersistentSource[]
+  persistentSourceTextDraft: string
+  onPersistentSourceTextChange: (text: string) => void
+  onAddPersistentSourceText: () => void
+  onRemovePersistentSource: (id: string) => void
+  onClearAllPersistentSources: () => void
+  // Quick create from dashboard
+  onQuickCreateFromDashboard: () => void
+}
+
+export const CreationPanelTabs: React.FC<CreationPanelTabsProps> = ({
+  creationActiveSection,
+  setCreationActiveSection,
+  studyPathContent,
+  quickOptionsOpen,
+  onOpenQuickOptions,
+  onCloseQuickOptions,
+  persistentSources,
+  persistentSourceTextDraft,
+  onPersistentSourceTextChange,
+  onAddPersistentSourceText,
+  onRemovePersistentSource,
+  onClearAllPersistentSources,
+  onQuickCreateFromDashboard,
+}) => {
+  return (
+    <Box
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Tab bar */}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 1fr)',
+          gap: 0.5,
+          p: 0.75,
+          bgcolor: 'background.paper',
+          borderBottom: 1,
+          borderColor: 'divider',
+          flexShrink: 0,
+        }}
+      >
+        {([
+          { key: 'dashboard', label: 'Dashboard' },
+          { key: 'sources', label: 'Sources' },
+          { key: 'study-path', label: 'Study Path' },
+        ] as const).map((item) => (
+          <Button
+            key={item.key}
+            size="small"
+            variant={creationActiveSection === item.key ? 'contained' : 'outlined'}
+            onClick={() => setCreationActiveSection(item.key)}
+            sx={{
+              minWidth: 0,
+              px: 1,
+              borderRadius: 1.5,
+              textTransform: 'none',
+              fontWeight: 800,
+              fontSize: '0.75rem',
+            }}
+          >
+            {item.label}
+          </Button>
+        ))}
+      </Box>
+
+      {/* Tab content */}
+      <Box sx={{ flex: 1, overflow: 'auto', p: { xs: 2, sm: 2.5 }, pb: { xs: 10, sm: 2.5 } }}>
+        <Stack spacing={2.5}>
+          {/* Study Path tab */}
+          {creationActiveSection === 'study-path' && studyPathContent}
+
+          {/* Dashboard tab */}
+          {creationActiveSection === 'dashboard' && (
+            <Paper
+              component="button"
+              type="button"
+              onClick={onQuickCreateFromDashboard}
+              elevation={0}
+              sx={{
+                width: '100%',
+                p: { xs: 2, sm: 2.25 },
+                textAlign: 'left',
+                borderRadius: 3,
+                border: 1,
+                borderColor: alpha('#000', 0.12),
+                bgcolor: alpha('#000', 0.025),
+                color: 'text.primary',
+                cursor: 'pointer',
+                display: 'block',
+                boxShadow: `0 2px 8px ${alpha('#000', 0.08)}`,
+                '&:hover': {
+                  borderColor: 'secondary.main',
+                  bgcolor: alpha('#000', 0.04),
+                  transform: 'translateY(-1px)',
+                },
+                transition: 'background-color 160ms ease, border-color 160ms ease, transform 160ms ease',
+              }}
+            >
+              <Stack direction="row" alignItems="center" justifyContent="space-between">
+                <Stack direction="row" spacing={1.5} alignItems="center">
+                  <Box sx={{ width: 38, height: 38, borderRadius: 1.75, display: 'grid', placeItems: 'center', bgcolor: alpha('#000', 0.08) }}>
+                    <AutoAwesomeIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+                  </Box>
+                  <Box sx={{ minWidth: 0 }}>
+                    <Typography variant="subtitle1" fontWeight={900}>
+                      Quick Create
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Generate from current dashboard
+                    </Typography>
+                  </Box>
+                </Stack>
+                <ChevronRightIcon color="action" />
+              </Stack>
+            </Paper>
+          )}
+
+          {/* Sources tab */}
+          {creationActiveSection === 'sources' && (
+            <Stack spacing={2}>
+              <Typography variant="h6" fontWeight={900}>
+                Persistent Sources
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Add text, images, PDFs, or slides.
+              </Typography>
+              <TextField
+                label="Add text source"
+                value={persistentSourceTextDraft}
+                onChange={(e) => onPersistentSourceTextChange(e.target.value)}
+                placeholder="Paste content here..."
+                multiline
+                minRows={3}
+                fullWidth
+              />
+              <Button
+                variant="contained"
+                onClick={onAddPersistentSourceText}
+                disabled={!persistentSourceTextDraft.trim()}
+              >
+                Add text
+              </Button>
+              {persistentSources.length > 0 && (
+                <Stack spacing={1}>
+                  <Stack direction="row" justifyContent="space-between" alignItems="center">
+                    <Typography variant="subtitle2" fontWeight={900}>
+                      {persistentSources.length} source{persistentSources.length !== 1 ? 's' : ''}
+                    </Typography>
+                    <Button size="small" color="error" onClick={onClearAllPersistentSources}>
+                      Clear all
+                    </Button>
+                  </Stack>
+                  {persistentSources.map((source) => (
+                    <Paper key={source.id} elevation={0} sx={{ p: 1.5, border: 1, borderColor: 'divider', borderRadius: 2 }}>
+                      <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
+                        <Box sx={{ minWidth: 0, flex: 1 }}>
+                          <Typography variant="body2" fontWeight={700} noWrap>
+                            {getPersistentSourceLabel(source)}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {source.type}
+                          </Typography>
+                        </Box>
+                        <IconButton size="small" onClick={() => onRemovePersistentSource(source.id)}>
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      </Stack>
+                    </Paper>
+                  ))}
+                </Stack>
+              )}
+            </Stack>
+          )}
+        </Stack>
+      </Box>
+    </Box>
+  )
+}

--- a/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
+++ b/apps/studymesh/src/components/workspace/WorkspaceStudioShell.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material'
 import { alpha } from '@mui/material/styles'
 import CloseIcon from '@mui/icons-material/Close'
+import DeleteIcon from '@mui/icons-material/Delete'
 import DashboardIcon from '@mui/icons-material/Dashboard'
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline'
 import AddIcon from '@mui/icons-material/Add'
@@ -95,6 +96,15 @@ import {
   studioPanelWidth,
   StudioFlow,
 } from './workspaceStudioModel'
+import {
+  addPersistentSource,
+  clearPersistentSources,
+  createPersistentSourceText,
+  PersistentSource,
+  readPersistentSourcesSettings,
+  removePersistentSource,
+} from '../../studyPack/persistentSources'
+import { CreationPanelTabs } from './CreationPanelTabs'
 import {
   WorkspaceDesktopLayout,
   WorkspaceMobileLayout,
@@ -507,6 +517,9 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
   const [mobileSection, setMobileSection] = useState<
     'creation' | 'dashboard' | 'ai-chat'
   >('dashboard')
+  const [creationActiveSection, setCreationActiveSection] = useState<
+    'dashboard' | 'sources' | 'study-path'
+  >('dashboard')
   const [activeFlow, setActiveFlow] = useState<StudioFlow>('hub')
   const [selectedIntent, setSelectedIntent] = useState<CreateIntent | null>(
     null,
@@ -540,6 +553,10 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
   const [quickSourceMode, setQuickSourceMode] =
     useState<QuickSourceMode>('dashboard')
   const [quickSourceStatus, setQuickSourceStatus] = useState('')
+  const [persistentSources, setPersistentSources] = useState<PersistentSource[]>(() =>
+    readPersistentSourcesSettings().sources,
+  )
+  const [persistentSourceTextDraft, setPersistentSourceTextDraft] = useState('')
   const [queueClockMs, setQueueClockMs] = useState(() => Date.now())
   const [studyPathRetrySignals, setStudyPathRetrySignals] = useState<
     Record<string, number>
@@ -1441,6 +1458,25 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
     setQuickSourceFiles((current) =>
       current.filter((_, fileIndex) => fileIndex !== index),
     )
+  }
+
+  const addPersistentSourceTextFn = () => {
+    const text = persistentSourceTextDraft.trim()
+    if (!text) return
+    const source = createPersistentSourceText(text, text.slice(0, 50))
+    addPersistentSource(source)
+    setPersistentSources((current) => [...current, source])
+    setPersistentSourceTextDraft('')
+  }
+
+  const removePersistentSourceByIdFn = (id: string) => {
+    removePersistentSource(id)
+    setPersistentSources((current) => current.filter((s) => s.id !== id))
+  }
+
+  const clearAllPersistentSourcesFn = () => {
+    clearPersistentSources()
+    setPersistentSources([])
   }
 
   const clearQuickSources = () => {
@@ -3173,7 +3209,27 @@ const WorkspaceStudioShell = ({ children }: { children: React.ReactNode }) => {
           flexDirection: 'column',
         }}
       >
-        {materialDetailContent || creationHubContent}
+        {materialDetailContent || (
+          <CreationPanelTabs
+            creationActiveSection={creationActiveSection}
+            setCreationActiveSection={setCreationActiveSection}
+            studyPathContent={creationHubContent}
+            quickOptionsOpen={quickOptionsOpen}
+            onOpenQuickOptions={() => setQuickOptionsOpen(true)}
+            onCloseQuickOptions={() => {
+              setQuickOptionsOpen(false)
+              setQuickSourceMode('dashboard')
+              setQuickSourceStatus('')
+            }}
+            persistentSources={persistentSources}
+            persistentSourceTextDraft={persistentSourceTextDraft}
+            onPersistentSourceTextChange={setPersistentSourceTextDraft}
+            onAddPersistentSourceText={addPersistentSourceTextFn}
+            onRemovePersistentSource={removePersistentSourceByIdFn}
+            onClearAllPersistentSources={clearAllPersistentSourcesFn}
+            onQuickCreateFromDashboard={() => setQuickOptionsOpen(true)}
+          />
+        )}
       </Box>
 
       <Box

--- a/apps/studymesh/src/studyPack/persistentSources.ts
+++ b/apps/studymesh/src/studyPack/persistentSources.ts
@@ -1,0 +1,212 @@
+export type PersistentSourceType = 'text' | 'image' | 'pdf' | 'pptx' | 'dashboard'
+
+export interface PersistentSourceText {
+  id: string
+  type: 'text'
+  content: string
+  label: string
+  createdAt: string
+}
+
+export interface PersistentSourceImage {
+  id: string
+  type: 'image'
+  mimeType: string
+  data: string // base64
+  label: string
+  createdAt: string
+}
+
+export interface PersistentSourcePdf {
+  id: string
+  type: 'pdf'
+  name: string
+  data: string // base64
+  label: string
+  createdAt: string
+}
+
+export interface PersistentSourcePptx {
+  id: string
+  type: 'pptx'
+  name: string
+  data: string // base64
+  label: string
+  createdAt: string
+}
+
+export interface PersistentSourceDashboard {
+  id: string
+  type: 'dashboard'
+  dashboardId: string
+  label: string
+  createdAt: string
+}
+
+export type PersistentSource =
+  | PersistentSourceText
+  | PersistentSourceImage
+  | PersistentSourcePdf
+  | PersistentSourcePptx
+  | PersistentSourceDashboard
+
+export interface PersistentSourcesSettings {
+  sources: PersistentSource[]
+  enabled: boolean
+}
+
+const PERSISTENT_SOURCES_KEY = 'studymesh-persistent-sources-v1'
+
+const defaultSettings: PersistentSourcesSettings = {
+  sources: [],
+  enabled: true,
+}
+
+export const readPersistentSourcesSettings =
+  (): PersistentSourcesSettings => {
+    if (typeof window === 'undefined') {
+      return defaultSettings
+    }
+
+    try {
+      const stored = window.localStorage.getItem(PERSISTENT_SOURCES_KEY)
+      if (!stored) {
+        return defaultSettings
+      }
+
+      const parsed = JSON.parse(stored) as Partial<PersistentSourcesSettings>
+      return {
+        sources: Array.isArray(parsed.sources) ? parsed.sources : [],
+        enabled: typeof parsed.enabled === 'boolean' ? parsed.enabled : true,
+      }
+    } catch {
+      return defaultSettings
+    }
+  }
+
+export const savePersistentSourcesSettings = (
+  settings: PersistentSourcesSettings,
+) => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(
+      PERSISTENT_SOURCES_KEY,
+      JSON.stringify(settings),
+    )
+  } catch (error) {
+    console.error('Failed to save persistent sources settings', error)
+  }
+}
+
+export const addPersistentSource = (source: PersistentSource) => {
+  const settings = readPersistentSourcesSettings()
+  settings.sources.push(source)
+  savePersistentSourcesSettings(settings)
+}
+
+export const removePersistentSource = (id: string) => {
+  const settings = readPersistentSourcesSettings()
+  settings.sources = settings.sources.filter((s) => s.id !== id)
+  savePersistentSourcesSettings(settings)
+}
+
+export const clearPersistentSources = () => {
+  savePersistentSourcesSettings({ ...defaultSettings, sources: [] })
+}
+
+export const fileToBase64 = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = String(reader.result || '')
+      resolve(result.includes(',') ? result.split(',')[1] : result)
+    }
+    reader.onerror = () => reject(new Error('Could not read file.'))
+    reader.readAsDataURL(file)
+  })
+
+export const createPersistentSourceText = (
+  content: string,
+  label: string,
+): PersistentSourceText => ({
+  id: `text-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  type: 'text',
+  content,
+  label,
+  createdAt: new Date().toISOString(),
+})
+
+export const createPersistentSourceImage = async (
+  file: File,
+  label: string,
+): Promise<PersistentSourceImage> => {
+  const data = await fileToBase64(file)
+  return {
+    id: `image-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    type: 'image',
+    mimeType: file.type,
+    data,
+    label,
+    createdAt: new Date().toISOString(),
+  }
+}
+
+export const createPersistentSourcePdf = async (
+  file: File,
+  label: string,
+): Promise<PersistentSourcePdf> => {
+  const data = await fileToBase64(file)
+  return {
+    id: `pdf-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    type: 'pdf',
+    name: file.name,
+    data,
+    label,
+    createdAt: new Date().toISOString(),
+  }
+}
+
+export const createPersistentSourcePptx = async (
+  file: File,
+  label: string,
+): Promise<PersistentSourcePptx> => {
+  const data = await fileToBase64(file)
+  return {
+    id: `pptx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    type: 'pptx',
+    name: file.name,
+    data,
+    label,
+    createdAt: new Date().toISOString(),
+  }
+}
+
+export const createPersistentSourceDashboard = (
+  dashboardId: string,
+  label: string,
+): PersistentSourceDashboard => ({
+  id: `dashboard-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  type: 'dashboard',
+  dashboardId,
+  label,
+  createdAt: new Date().toISOString(),
+})
+
+export const getPersistentSourceLabel = (source: PersistentSource): string => {
+  if (source.type === 'dashboard') {
+    return source.label
+  }
+
+  if (source.type === 'text') {
+    return source.label || source.content.slice(0, 50)
+  }
+
+  if (source.type === 'image') {
+    return source.label || 'Image'
+  }
+
+  return source.label || source.name
+}


### PR DESCRIPTION
## Summary

Implement 3-section creation panel layout with persistent sources:

**New files:**
-  - localStorage-based storage for persistent sources (text, images, PDFs, PPTXs, dashboard imports)

**Changes:**
- Restructure creation panel into 3 sections:
  1. **Study Path** - prominent card (unchanged behavior)
  2. **Current Dashboard** - simplified Quick Create using current dashboard
  3. **Sources** - new persistent sources management with Add text/Upload
- Remove 'Create from material' expandable section (simplifies the UI)
- Sources persist across sessions via localStorage
- Sources show as chips when collapsed, full management when expanded

**Note:** This is the initial implementation. Future work:
- Connect Sources section to actual Quick Create generation
- Add 'Import from dashboard' functionality
- Handle image sources in generation